### PR TITLE
feat: add net9.0 support using multi target framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+</Project>
+

--- a/Facet.sln
+++ b/Facet.sln
@@ -8,6 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
+		Directory.Packages.props = Directory.Packages.props
+		NuGet.Config = NuGet.Config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Facet.Mapping", "src\Facet.Mapping\Facet.Mapping.csproj", "{CEF12992-4DB3-4770-B291-FF5FD67FDB01}"

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+    <packageSourceMapping>
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+        </packageSource>
+    </packageSourceMapping>
+</configuration>

--- a/src/Facet.Extensions.EFCore/Facet.Extensions.EFCore.csproj
+++ b/src/Facet.Extensions.EFCore/Facet.Extensions.EFCore.csproj
@@ -1,36 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<PackageId>Facet.Extensions.EFCore</PackageId>
-		<Version>2.0.1</Version>
-		<Authors>Tim Maes</Authors>
-		<Description>EF Core async extension methods for Facet.</Description>
-		<RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Title>Facet.Extensions.EFCore</Title>
-		<PackageProjectUrl>https://www.github.com/Tim-Maes/Facet</PackageProjectUrl>
-	</PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Facet.Extensions.EFCore</PackageId>
+        <Version>2.0.1</Version>
+        <Authors>Tim Maes</Authors>
+        <Description>EF Core async extension methods for Facet.</Description>
+        <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Title>Facet.Extensions.EFCore</Title>
+        <PackageProjectUrl>https://www.github.com/Tim-Maes/Facet</PackageProjectUrl>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-		<ProjectReference Include="..\Facet.Extensions\Facet.Extensions.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <ProjectReference Include="..\Facet.Extensions\Facet.Extensions.csproj" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<None Include="FacetEfCoreExtensions.cs" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="FacetEfCoreExtensions.cs" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<None Update="README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
+    </ItemGroup>
 
 </Project>

--- a/src/Facet.Extensions/Facet.Extensions.csproj
+++ b/src/Facet.Extensions/Facet.Extensions.csproj
@@ -1,31 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-	  <LangVersion>latest</LangVersion>
-	  <Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Facet.Extensions</PackageId>
+        <Version>2.0.1</Version>
+        <Authors>Tim Maes</Authors>
+        <Description>Provider-agnostic extension methods for Facet.</Description>
+        <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-	  <IsPackable>true</IsPackable>
-	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <PackageId>Facet.Extensions</PackageId>
-	  <Version>2.0.1</Version>
-	  <Authors>Tim Maes</Authors>
-	  <Description>Provider-agnostic extension methods for Facet.</Description>
-	  <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
-	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" />
+        <None Include="FacetExtensions.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <None Include="FacetExtensions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Facet\Facet.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Facet\Facet.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/Facet.Mapping/Facet.Mapping.csproj
+++ b/src/Facet.Mapping/Facet.Mapping.csproj
@@ -1,40 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Facet.Mapping</PackageId>
+        <Version>2.0.1</Version>
+        <Authors>Tim Maes</Authors>
+        <Description>Advanced static mapping configuration support for the Facet source generator with async capabilities.</Description>
+        <PackageTags>facet mapping source-generator dto compile-time async</PackageTags>
+        <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Title>Facet.Mapping</Title>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReleaseNotes>
+            Version 2.0.0:
+            - Added async mapping support with IFacetMapConfigurationAsync interface
+            - Added hybrid sync/async mapping with IFacetMapConfigurationHybrid interface
+            - Added comprehensive async extension methods
+            - Added parallel collection mapping capabilities
+            - Full cancellation token support throughout
+        </PackageReleaseNotes>
+    </PropertyGroup>
 
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<PackageId>Facet.Mapping</PackageId>
-		<Version>2.0.1</Version>
-		<Authors>Tim Maes</Authors>
-		<Description>Advanced static mapping configuration support for the Facet source generator with async capabilities.</Description>
-		<PackageTags>facet mapping source-generator dto compile-time async</PackageTags>
-		<RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Title>Facet.Mapping</Title>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageReleaseNotes>
-			Version 2.0.0:
-			- Added async mapping support with IFacetMapConfigurationAsync interface
-			- Added hybrid sync/async mapping with IFacetMapConfigurationHybrid interface
-			- Added comprehensive async extension methods
-			- Added parallel collection mapping capabilities
-			- Full cancellation token support throughout
-		</PackageReleaseNotes>
-	</PropertyGroup>
-
-	<ItemGroup>
-	  <None Update="README.md">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
-	  <None Update="Examples.cs">
-	    <Pack>True</Pack>
-	    <PackagePath>content\</PackagePath>
-	  </None>
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
+        <None Update="Examples.cs">
+            <Pack>True</Pack>
+            <PackagePath>content\</PackagePath>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/src/Facet/Facet.csproj
+++ b/src/Facet/Facet.csproj
@@ -1,38 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Facet</PackageId>
+        <Version>2.0.1</Version>
+        <Authors>Tim Maes</Authors>
+        <Description>A Roslyn source generator for lean DTOs.</Description>
+        <PackageTags>source-generator dto projection redaction facet</PackageTags>
+        <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <Title>Facet</Title>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<PackageId>Facet</PackageId>
-		<Version>2.0.1</Version>
-		<Authors>Tim Maes</Authors>
-		<Description>A Roslyn source generator for lean DTOs.</Description>
-		<PackageTags>source-generator dto projection redaction facet</PackageTags>
-		<RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-		<Title>Facet</Title>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Remove="bin\Debug\netstandard2.0\\Facet.dll" />
+    </ItemGroup>
 
-	<ItemGroup>
-	  <None Remove="bin\Debug\netstandard2.0\\Facet.dll" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-		<None Include="..\..\README.md">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
-		</None>
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
Added multi-target framework support for **.NET 9.0** in `Facet.Extensions`, `Facet.Extensions.EFCore`, and `Facet.Mapping`.

Changes:
- Allows projects targeting **.NET 9.0** to use the package without downgrading EF Core. 
- Adds Central Package Management through the `Directory.Packages.props` file.
- Adds `NuGet.Config` file to avoid **NU1507** warnings
- Adds `Directory.Packages.props` and `NuGet.Config` to the *Solution Items* virtual directory in the `Facet.sln` file.

