### PR TITLE
Updated cache mapping delegates to remove per-call reflection

### DIFF
--- a/src/Facet.Extensions/FacetCache.cs
+++ b/src/Facet.Extensions/FacetCache.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Facet;
+
+/// <summary>
+/// Provides a cached <see cref="Func{TSource, TTarget}"/> mapping delegate used by
+/// <c>ToFacet&lt;TSource, TTarget&gt;</c> to efficiently construct <typeparamref name="TTarget"/> instances
+/// from <typeparamref name="TSource"/> values.
+/// </summary>
+/// <typeparam name="TSource">The source model type.</typeparam>
+/// <typeparam name="TTarget">
+/// The target DTO or facet type. Must expose either a public static <c>FromSource(<typeparamref name="TSource"/>)</c>
+/// factory method, or a public constructor accepting a <typeparamref name="TSource"/> instance.
+/// </typeparam>
+/// <remarks>
+/// This type performs reflection only once per <typeparamref name="TSource"/> / <typeparamref name="TTarget"/>
+/// combination, precompiling a delegate for reuse in all subsequent mappings.
+/// </remarks>
+/// <exception cref="InvalidOperationException">
+/// Thrown when no usable <c>FromSource</c> factory or compatible constructor is found on <typeparamref name="TTarget"/>.
+/// </exception>
+public static class FacetCache<TSource, TTarget>
+    where TTarget : class
+{
+    public static readonly Func<TSource, TTarget> Mapper = CreateMapper();
+
+    private static Func<TSource, TTarget> CreateMapper()
+    {
+        // Check for static FromSource factory method first (preferred for init-only properties)
+        var fromSource = typeof(TTarget).GetMethod(
+            "FromSource",
+            BindingFlags.Public | BindingFlags.Static,
+            null,
+            new[] { typeof(TSource) },
+            null);
+
+        if (fromSource != null)
+        {
+            // Compile a delegate to the static factory method
+            return (Func<TSource, TTarget>)Delegate.CreateDelegate(
+                typeof(Func<TSource, TTarget>), fromSource);
+        }
+
+        // Fallback to ctor(User)
+        var ctor = typeof(TTarget).GetConstructor(new[] { typeof(TSource) });
+
+        if (ctor != null)
+        {
+            var param = Expression.Parameter(typeof(TSource), "src");
+            var newExpr = Expression.New(ctor, param);
+            return Expression.Lambda<Func<TSource, TTarget>>(newExpr, param).Compile();
+        }
+
+        // If neither works, provide a helpful error message
+        throw new InvalidOperationException(
+            $"Unable to map {typeof(TSource).Name} to {typeof(TTarget).Name}: " +
+            $"no compatible FromSource or ctor found.");
+    }
+}

--- a/src/Facet.Extensions/FacetCache.cs
+++ b/src/Facet.Extensions/FacetCache.cs
@@ -21,7 +21,7 @@ namespace Facet;
 /// <exception cref="InvalidOperationException">
 /// Thrown when no usable <c>FromSource</c> factory or compatible constructor is found on <typeparamref name="TTarget"/>.
 /// </exception>
-public static class FacetCache<TSource, TTarget>
+internal static class FacetCache<TSource, TTarget>
     where TTarget : class
 {
     public static readonly Func<TSource, TTarget> Mapper = CreateMapper();

--- a/src/Facet.Extensions/FacetExtensions.cs
+++ b/src/Facet.Extensions/FacetExtensions.cs
@@ -23,34 +23,8 @@ public static class FacetExtensions
     public static TTarget ToFacet<TSource, TTarget>(this TSource source)
         where TTarget : class
     {
-        if (source is null) throw new ArgumentNullException(nameof(source));
-        
-        // Check for static FromSource factory method first (preferred for init-only properties)
-        var fromSourceMethod = typeof(TTarget).GetMethod(
-            "FromSource",
-            BindingFlags.Public | BindingFlags.Static,
-            null,
-            new[] { typeof(TSource) },
-            null);
-            
-        if (fromSourceMethod != null)
-        {
-            return (TTarget)fromSourceMethod.Invoke(null, new object[] { source })!;
-        }
-        
-        // Fall back to constructor
-        try
-        {
-            return (TTarget)Activator.CreateInstance(typeof(TTarget), source)!;
-        }
-        catch
-        {
-            // If neither works, provide a helpful error message
-            throw new InvalidOperationException(
-                $"Unable to map {typeof(TSource).Name} to {typeof(TTarget).Name}. " +
-                $"Ensure {typeof(TTarget).Name} has either a constructor accepting {typeof(TSource).Name} " +
-                $"or a static FromSource({typeof(TSource).Name}) method.");
-        }
+        if (source is null) throw new ArgumentNullException(nameof(source));    
+        return FacetCache<TSource, TTarget>.Mapper(source);
     }
 
     /// <summary>


### PR DESCRIPTION
Moved activation logic from ToFacet<TSource,TTarget>() into a generic static FacetCache<TSource,TTarget> which compiles and stores a mapping delegate (FromSource factory method or source-based constructor) on first use.

This reduces allocations and removes reflection from the hot path, improving mapping performance

Benchmarked mapping two objects in sequence.

- Before change:

| Method       | Mean     | Error   | StdDev  | Gen0   | Allocated |
|------------- |---------:|--------:|--------:|-------:|----------:|
| MapWithFacet | 354.2 ns | 3.19 ns | 2.98 ns | 0.0701 |    1104 B |
| MapManually  | 229.8 ns | 2.22 ns | 1.97 ns | 0.0570 |     896 B |

- After change:

| Method       | Mean     | Error   | StdDev  | Gen0   | Allocated |
|------------- |---------:|--------:|--------:|-------:|----------:|
| MapWithFacet | 120.2 ns | 1.30 ns | 1.15 ns | 0.0336 |     528 B |
| MapManually  | 229.5 ns | 2.55 ns | 2.13 ns | 0.0570 |     896 B |

The change is backwards-compatible.

The test project ran successfully after this change.