### PR TITLE
Add bi-directional mapping support for EF

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,12 +2,31 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />

--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ var userDtos = await users.ToFacetsParallelAsync(mapper);
 // Async projection directly in EF Core queries
 var userDtos = await dbContext.Users
     .Where(u => u.IsActive)
-    .ToFacetsAsync<User, UserDto>();
+    .ToFacetsAsync<UserDto>();
 
 // LINQ projection for complex queries
 var results = await dbContext.Products
     .Where(p => p.IsAvailable)
-    .SelectFacet<Product, ProductDto>()
+    .SelectFacet<ProductDto>()
     .OrderBy(dto => dto.Name)
     .ToListAsync();
 ```

--- a/README.md
+++ b/README.md
@@ -112,21 +112,7 @@ public partial struct PointDto;
 
 // Generate as record struct (immutable value type)
 [Facet(typeof(Coordinates))]
-public partial record struct CoordinatesDto;
-```
-
-### Smart Defaults for Records
-```csharp
-public record ModernUser
-{
-    public required string Id { get; init; }
-    public required string Name { get; init; }
-    public string? Email { get; set; }
-}
-
-// Records automatically preserve init-only and required modifiers
-[Facet(typeof(ModernUser))]
-public partial record ModernUserDto;  // Preserves required/init-only automaticall
+public partial record struct CoordinatesDto; // Preserves required/init-only
 ```
 
 ### Custom Sync Mapping
@@ -213,18 +199,16 @@ var results = await dbContext.Products
 
 #### Reverse Mapping (facet -> Entity)
 ```csharp
-// Define update DTO (excludes sensitive/immutable properties)
-[Facet(typeof(User), "Password", "CreatedAt")]
+[Facet(typeof(User)]
 public partial class UpdateUserDto { }
 
-// API Controller with selective updates
 [HttpPut("{id}")]
 public async Task<IActionResult> UpdateUser(int id, UpdateUserDto dto)
 {
     var user = await context.Users.FindAsync(id);
     if (user == null) return NotFound();
     
-    // Only updates properties that actually changed
+    // Only updates properties that mutated
     user.UpdateFromFacet(dto, context);
     
     await context.SaveChangesAsync();

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ var results = await dbContext.Products
     .ToListAsync();
 ```
 
-#### Reverse Mapping (facet -> Entity)
+#### Reverse Mapping (Facet -> Entity)
 ```csharp
 [Facet(typeof(User)]
 public partial class UpdateUserDto { }
@@ -223,4 +223,3 @@ if (result.HasChanges)
         user.Id, string.Join(", ", result.ChangedProperties));
 }
 ```
-

--- a/docs/05_Extensions.md
+++ b/docs/05_Extensions.md
@@ -18,10 +18,13 @@ For async EF Core support, see the separate Facet.Extensions.EFCore package.
 
 | Method                              | Description                                                      |
 |------------------------------------- |------------------------------------------------------------------|
-| `ToFacetsAsync<TSource, TTarget>()`  | Async projection to `List<TTarget>` (EF Core).                    |
-| `FirstFacetAsync<TSource, TTarget>()`| Async projection to first or default (EF Core).                   |
-| `SingleFacetAsync<TSource, TTarget>()`| Async projection to single (EF Core).                            |
-| `UpdateFromFacet<TEntity, TFacet>()`| Update entity with changed properties from facet DTO.            |
+| `ToFacetsAsync<TSource, TTarget>()`  | Async projection to `List<TTarget>` with explicit source type.    |
+| `ToFacetsAsync<TTarget>()`           | Async projection to `List<TTarget>` with inferred source type.    |
+| `FirstFacetAsync<TSource, TTarget>()`| Async projection to first/default with explicit source type.      |
+| `FirstFacetAsync<TTarget>()`         | Async projection to first/default with inferred source type.      |
+| `SingleFacetAsync<TSource, TTarget>()`| Async projection to single with explicit source type.            |
+| `SingleFacetAsync<TTarget>()`        | Async projection to single with inferred source type.            |
+| `UpdateFromFacet<TEntity, TFacet>()` | Update entity with changed properties from facet DTO.            |
 | `UpdateFromFacetAsync<TEntity, TFacet>()`| Async update entity with changed properties from facet DTO.  |
 | `UpdateFromFacetWithChanges<TEntity, TFacet>()`| Update entity and return information about changed properties. |
 
@@ -55,12 +58,18 @@ dotnet add package Facet.Extensions.EFCore
 
 using Facet.Extensions.EFCore; 
 
+var query = dbContext.People.SelectFacet<PersonDto>();
 var query = dbContext.People.SelectFacet<Person, PersonDto>();
 
-// Async (EF Core)
+// Async (EF Core) 
 var dtosAsync = await dbContext.People.ToFacetsAsync<Person, PersonDto>();
+var dtosInferred = await dbContext.People.ToFacetsAsync<PersonDto>();
+
 var firstDto = await dbContext.People.FirstFacetAsync<Person, PersonDto>();
+var firstInferred = await dbContext.People.FirstFacetAsync<PersonDto>();
+
 var singleDto = await dbContext.People.SingleFacetAsync<Person, PersonDto>();
+var singleInferred = await dbContext.People.SingleFacetAsync<PersonDto>();
 ```
 
 ### EF Core Reverse Mapping (UpdateFromFacet)

--- a/docs/05_Extensions.md
+++ b/docs/05_Extensions.md
@@ -3,7 +3,7 @@
 Facet.Extensions provides a set of provider-agnostic extension methods for mapping and projecting between your domain entities and generated facet types.
 For async EF Core support, see the separate Facet.Extensions.EFCore package.
 
-## Key Methods (Facet.Extensions)
+## Methods (Facet.Extensions)
 
 | Method                              | Description                                                      |
 |------------------------------------- |------------------------------------------------------------------|
@@ -14,13 +14,16 @@ For async EF Core support, see the separate Facet.Extensions.EFCore package.
 | `SelectFacet<TTarget>()`    | Project an `IQueryable<TSource>` to `IQueryable<TTarget>`.        |
 | `SelectFacet<TSource, TTarget>()`    | Project an `IQueryable<TSource>` to `IQueryable<TTarget>`.        |
 
-## Key Methods (Facet.Extensions.EFCore)
+## Methods (Facet.Extensions.EFCore)
 
 | Method                              | Description                                                      |
 |------------------------------------- |------------------------------------------------------------------|
 | `ToFacetsAsync<TSource, TTarget>()`  | Async projection to `List<TTarget>` (EF Core).                    |
 | `FirstFacetAsync<TSource, TTarget>()`| Async projection to first or default (EF Core).                   |
 | `SingleFacetAsync<TSource, TTarget>()`| Async projection to single (EF Core).                            |
+| `UpdateFromFacet<TEntity, TFacet>()`| Update entity with changed properties from facet DTO.            |
+| `UpdateFromFacetAsync<TEntity, TFacet>()`| Async update entity with changed properties from facet DTO.  |
+| `UpdateFromFacetWithChanges<TEntity, TFacet>()`| Update entity and return information about changed properties. |
 
 ## Usage Examples
 
@@ -58,6 +61,83 @@ var query = dbContext.People.SelectFacet<Person, PersonDto>();
 var dtosAsync = await dbContext.People.ToFacetsAsync<Person, PersonDto>();
 var firstDto = await dbContext.People.FirstFacetAsync<Person, PersonDto>();
 var singleDto = await dbContext.People.SingleFacetAsync<Person, PersonDto>();
+```
+
+### EF Core Reverse Mapping (UpdateFromFacet)
+
+```csharp
+using Facet.Extensions.EFCore;
+
+[HttpPut("{id}")]
+public async Task<IActionResult> UpdateUser(int id, [FromBody] UpdateUserDto dto)
+{
+    var user = await context.Users.FindAsync(id);
+    if (user == null) return NotFound();
+    
+    // Only updates properties that actually changed - selective update
+    user.UpdateFromFacet(dto, context);
+    
+    await context.SaveChangesAsync();
+    return Ok();
+}
+
+// With change tracking for auditing
+var result = user.UpdateFromFacetWithChanges(dto, context);
+if (result.HasChanges)
+{
+    logger.LogInformation("User {UserId} updated. Changed: {Properties}", 
+        user.Id, string.Join(", ", result.ChangedProperties));
+}
+
+// Async version
+await user.UpdateFromFacetAsync(dto, context);
+```
+
+### Complete API Example
+
+```csharp
+// Domain model
+public class User
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Email { get; set; }
+    public string Password { get; set; }  // Sensitive
+    public DateTime CreatedAt { get; set; }  // Immutable
+}
+
+// Update DTO - excludes sensitive/immutable properties
+[Facet(typeof(User), "Password", "CreatedAt")]
+public partial class UpdateUserDto { }
+
+// API Controller
+[ApiController]
+public class UsersController : ControllerBase
+{
+    // GET: Entity -> Facet
+    [HttpGet("{id}")]
+    public async Task<ActionResult<UserDto>> GetUser(int id)
+    {
+        var user = await context.Users.FindAsync(id);
+        if (user == null) return NotFound();
+        
+        return user.ToFacet<UserDto>();  // Forward mapping
+    }
+    
+    // PUT: Facet -> Entity (selective update)
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateUser(int id, UpdateUserDto dto)
+    {
+        var user = await context.Users.FindAsync(id);
+        if (user == null) return NotFound();
+        
+        user.UpdateFromFacet(dto, context);  // Reverse mapping
+        await context.SaveChangesAsync();
+        
+        return NoContent();
+    }
+}
 ```
 
 ---

--- a/docs/07_WhatIsBeingGenerated.md
+++ b/docs/07_WhatIsBeingGenerated.md
@@ -135,6 +135,8 @@ public partial class UserDto
 ```csharp
 public partial class UserDto
 {
+    public string FullName { get; set; }
+    public string RegisteredText { get; set; }
     public UserDto(Project.Namespace.User source)
     {
         Project.Namespace.UserMapper.Map(source, this);
@@ -146,7 +148,220 @@ public partial class UserDto
 
 ---
 
-## 5. Readonly / Init-Only Example
+## 5. Smart Defaults
+
+Facet automatically chooses sensible defaults based on the target type:
+
+**Input:**
+```csharp
+public record ModernUser
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public string? Email { get; set; }
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+}
+
+// 1. RECORD: Automatically preserves init-only and required modifiers
+[Facet(typeof(ModernUser))]
+public partial record UserRecord;
+
+// 2. CLASS: Defaults to mutable (backward compatibility)
+[Facet(typeof(ModernUser))]
+public partial class UserClass;
+```
+
+**Generated for Record:**
+```csharp
+public partial record UserRecord
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public string? Email { get; set; }
+    public DateTime CreatedAt { get; init; }
+    public UserRecord(Project.Namespace.ModernUser source)
+    {
+        this.Id = source.Id;
+        this.Name = source.Name;
+        this.Email = source.Email;
+        this.CreatedAt = source.CreatedAt;
+    }
+    public static Expression<Func<Project.Namespace.ModernUser, UserRecord>> Projection =>
+        source => new UserRecord(source);
+}
+```
+
+**Generated for Class:**
+```csharp
+public partial class UserClass
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public string? Email { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public UserClass(Project.Namespace.ModernUser source)
+    {
+        this.Id = source.Id;
+        this.Name = source.Name;
+        this.Email = source.Email;
+        this.CreatedAt = source.CreatedAt;
+    }
+    public static Expression<Func<Project.Namespace.ModernUser, UserClass>> Projection =>
+        source => new UserClass(source);
+}
+```
+
+---
+
+## 6. Explicit Control Over Init-Only and Required Properties
+
+You can override smart defaults with explicit control:
+
+**Input:**
+```csharp
+// Force a class to preserve init-only and required (modern class pattern)
+[Facet(typeof(ModernUser),
+       PreserveInitOnlyProperties = true,
+       PreserveRequiredProperties = true)]
+public partial class ImmutableUserClass;
+
+// Force a record to use mutable properties (unusual but possible)
+[Facet(typeof(ModernUser), 
+       PreserveInitOnlyProperties = false,
+       PreserveRequiredProperties = false)]
+public partial record MutableUserRecord;
+```
+
+**Generated for Immutable Class:**
+```csharp
+public partial class ImmutableUserClass
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public string? Email { get; set; }
+    public DateTime CreatedAt { get; init; }
+    public ImmutableUserClass(Project.Namespace.ModernUser source)
+    {
+        this.Id = source.Id;
+        this.Name = source.Name;
+        this.Email = source.Email;
+        this.CreatedAt = source.CreatedAt;
+    }
+    public static Expression<Func<Project.Namespace.ModernUser, ImmutableUserClass>> Projection =>
+        source => new ImmutableUserClass(source);
+}
+```
+
+**Generated for Mutable Record:**
+```csharp
+public partial record MutableUserRecord
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public string? Email { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public MutableUserRecord(Project.Namespace.ModernUser source)
+    {
+        this.Id = source.Id;
+        this.Name = source.Name;
+        this.Email = source.Email;
+        this.CreatedAt = source.CreatedAt;
+    }
+    public static Expression<Func<Project.Namespace.ModernUser, MutableUserRecord>> Projection =>
+        source => new MutableUserRecord(source);
+}
+```
+
+---
+
+## 7. Init-Only Properties with Custom Mapping
+
+When using custom mapping with init-only properties, Facet generates a `FromSource` factory method:
+
+**Input:**
+```csharp
+public record ImmutableUser
+{
+    public required string Id { get; init; }
+    public required string FullName { get; init; }
+    public DateTime CreatedAt { get; init; }
+}
+
+public class ImmutableUserMapper : IFacetMapConfiguration<ModernUser, ImmutableUserDto>
+{
+    public static void Map(ModernUser source, ImmutableUserDto target)
+    {
+        // Custom logic here
+        target.FullName = $"{source.FirstName} {source.LastName}";
+        target.DisplayName = target.FullName.ToUpper();
+    }
+}
+
+[Facet(typeof(ModernUser), "Email", 
+       Configuration = typeof(ImmutableUserMapper),
+       PreserveInitOnlyProperties = true,
+       PreserveRequiredProperties = true)]
+public partial record ImmutableUserDto
+{
+    public required string FullName { get; init; }
+    public string DisplayName { get; set; }
+}
+```
+
+**Generated:**
+```csharp
+public partial record ImmutableUserDto
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public required string FullName { get; init; }
+    public string DisplayName { get; set; }
+    
+    public ImmutableUserDto(Project.Namespace.ModernUser source)
+    {
+        // This constructor should not be used for types with init-only properties and custom mapping
+        // Use FromSource factory method instead
+        throw new InvalidOperationException("Use ImmutableUserDto.FromSource(source) for types with init-only properties");
+    }
+    
+    public static ImmutableUserDto FromSource(Project.Namespace.ModernUser source)
+    {
+        // Custom mapper creates and returns the instance with init-only properties set
+        return Project.Namespace.ImmutableUserMapper.Map(source, null);
+    }
+    
+    public static Expression<Func<Project.Namespace.ModernUser, ImmutableUserDto>> Projection =>
+        source => new ImmutableUserDto(source);
+}
+```
+
+---
+
+## 8. Positional Record Facets
+
+**Input:**
+```csharp
+public record struct DataRecordStruct(int Code, string Label);
+
+[Facet(typeof(DataRecordStruct), Kind = FacetKind.RecordStruct)]
+public partial record struct DataRecordStructDto { }
+```
+
+**Generated:**
+```csharp
+public partial record struct DataRecordStructDto(int Code, string Label);
+public partial record struct DataRecordStructDto
+{
+    public DataRecordStructDto(Project.Namespace.DataRecordStruct source) : this(source.Code, source.Label) { }
+    public static Expression<Func<Project.Namespace.DataRecordStruct, DataRecordStructDto>> Projection =>
+        source => new DataRecordStructDto(source);
+}
+```
+
+---
+
+## 9. Legacy Readonly / Init-Only Example
 
 **Input:**
 ```csharp
@@ -186,7 +401,7 @@ public partial class ReadonlySourceModelFacet
 
 ---
 
-## 6. Record Facet Example
+## 10. Record Facet with Custom Mapping
 
 **Input:**
 ```csharp
@@ -214,6 +429,8 @@ public partial record UserRecordDto
 public partial record UserRecordDto();
 public partial record UserRecordDto
 {
+    public string FullName { get; set; }
+    public string RegisteredText { get; set; }
     public UserRecordDto(Project.Namespace.UserRecord source) : this()
     {
         Project.Namespace.UserRecordMapper.Map(source, this);
@@ -225,30 +442,7 @@ public partial record UserRecordDto
 
 ---
 
-## 7. Record Struct Facet Example
-
-**Input:**
-```csharp
-public record struct DataRecordStruct(int Code, string Label);
-
-[Facet(typeof(DataRecordStruct), Kind = FacetKind.RecordStruct)]
-public partial record struct DataRecordStructDto { }
-```
-
-**Generated:**
-```csharp
-public partial record struct DataRecordStructDto(int Code, string Label);
-public partial record struct DataRecordStructDto
-{
-    public DataRecordStructDto(Project.Namespace.DataRecordStruct source) : this(source.Code, source.Label) { }
-    public static Expression<Func<Project.Namespace.DataRecordStruct, DataRecordStructDto>> Projection =>
-        source => new DataRecordStructDto(source);
-}
-```
-
----
-
-## 8. Plain Struct Facet Example
+## 11. Plain Struct Facet Example
 
 **Input:**
 ```csharp

--- a/docs/07_WhatIsBeingGenerated.md
+++ b/docs/07_WhatIsBeingGenerated.md
@@ -166,7 +166,7 @@ public record ModernUser
 [Facet(typeof(ModernUser))]
 public partial record UserRecord;
 
-// 2. CLASS: Defaults to mutable (backward compatibility)
+// 2. CLASS: Defaults to mutable
 [Facet(typeof(ModernUser))]
 public partial class UserClass;
 ```

--- a/src/Facet.Extensions.EFCore/Facet.Extensions.EFCore.csproj
+++ b/src/Facet.Extensions.EFCore/Facet.Extensions.EFCore.csproj
@@ -7,7 +7,7 @@
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Facet.Extensions.EFCore</PackageId>
-		<Version>2.2.0</Version>
+		<Version>2.3.0</Version>
         <Authors>Tim Maes</Authors>
         <Description>EF Core async extension methods for Facet.</Description>
         <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>

--- a/src/Facet.Extensions.EFCore/FacetEfCoreExtensions.cs
+++ b/src/Facet.Extensions.EFCore/FacetEfCoreExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,4 +54,190 @@ public static class FacetEfCoreExtensions
         return Facet.Extensions.FacetExtensions.SelectFacet<TSource, TTarget>(source)
                      .SingleAsync(cancellationToken);
     }
+
+    /// <summary>
+    /// Updates an entity with changed properties from a Facet DTO, using EF Core change tracking 
+    /// to selectively update only properties that have different values.
+    /// Only maps properties that exist in both the facet and the entity.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type being updated</typeparam>
+    /// <typeparam name="TFacet">The facet DTO type containing the new values</typeparam>
+    /// <param name="entity">The entity instance to update</param>
+    /// <param name="facet">The facet DTO containing the new property values</param>
+    /// <param name="context">The EF Core DbContext for change tracking</param>
+    /// <returns>The updated entity instance (for fluent chaining)</returns>
+    /// <exception cref="ArgumentNullException">Thrown when entity, facet, or context is null</exception>
+    /// <example>
+    /// <code>
+    /// [HttpPut("{id}")]
+    /// public async Task&lt;IActionResult&gt; UpdateUser(int id, UpdateUserDto dto)
+    /// {
+    ///     var user = await context.Users.FindAsync(id);
+    ///     if (user == null) return NotFound();
+    ///     
+    ///     user.UpdateFromFacet(dto, context);
+    ///     await context.SaveChangesAsync();
+    ///     
+    ///     return Ok();
+    /// }
+    /// </code>
+    /// </example>
+    public static TEntity UpdateFromFacet<TEntity, TFacet>(
+        this TEntity entity,
+        TFacet facet,
+        DbContext context)
+        where TEntity : class
+    {
+        if (entity is null) throw new ArgumentNullException(nameof(entity));
+        if (facet is null) throw new ArgumentNullException(nameof(facet));
+        if (context is null) throw new ArgumentNullException(nameof(context));
+
+        var entry = context.Entry(entity);
+        var changedProperties = new List<string>();
+
+        // Get properties that exist in both Facet and Entity
+        var facetProperties = typeof(TFacet).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead)
+            .ToDictionary(p => p.Name, p => p);
+
+        // Iterate through entity properties that can be modified
+        foreach (var entityProperty in entry.Properties)
+        {
+            var propertyName = entityProperty.Metadata.Name;
+            
+            if (facetProperties.TryGetValue(propertyName, out var facetProperty))
+            {
+                var facetValue = facetProperty.GetValue(facet);
+                var entityValue = entityProperty.CurrentValue;
+
+                // Only update if values are different
+                if (!Equals(facetValue, entityValue))
+                {
+                    entityProperty.CurrentValue = facetValue;
+                    entityProperty.IsModified = true;
+                    changedProperties.Add(propertyName);
+                }
+            }
+        }
+
+        return entity;
+    }
+
+    /// <summary>
+    /// Asynchronously updates an entity with changed properties from a Facet DTO, using EF Core change tracking 
+    /// to selectively update only properties that have different values.
+    /// This method is useful when you need to perform additional async operations during the update process.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type being updated</typeparam>
+    /// <typeparam name="TFacet">The facet DTO type containing the new values</typeparam>
+    /// <param name="entity">The entity instance to update</param>
+    /// <param name="facet">The facet DTO containing the new property values</param>
+    /// <param name="context">The EF Core DbContext for change tracking</param>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete</param>
+    /// <returns>A task that represents the asynchronous update operation. The task result contains the updated entity instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when entity, facet, or context is null</exception>
+    /// <example>
+    /// <code>
+    /// [HttpPut("{id}")]
+    /// public async Task&lt;IActionResult&gt; UpdateUser(int id, UpdateUserDto dto)
+    /// {
+    ///     var user = await context.Users.FindAsync(id);
+    ///     if (user == null) return NotFound();
+    ///     
+    ///     await user.UpdateFromFacetAsync(dto, context);
+    ///     await context.SaveChangesAsync();
+    ///     
+    ///     return Ok();
+    /// }
+    /// </code>
+    /// </example>
+    public static Task<TEntity> UpdateFromFacetAsync<TEntity, TFacet>(
+        this TEntity entity,
+        TFacet facet,
+        DbContext context,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        // For now, this is just a synchronous operation wrapped in a completed task
+        // In the future, this could be enhanced to support async validation, logging, etc.
+        var result = entity.UpdateFromFacet(facet, context);
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Updates an entity from a facet DTO and returns information about which properties were changed.
+    /// This is useful for auditing, logging, or conditional logic based on what actually changed.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type being updated</typeparam>
+    /// <typeparam name="TFacet">The facet DTO type containing the new values</typeparam>
+    /// <param name="entity">The entity instance to update</param>
+    /// <param name="facet">The facet DTO containing the new property values</param>
+    /// <param name="context">The EF Core DbContext for change tracking</param>
+    /// <returns>A result containing the updated entity and a list of property names that were changed</returns>
+    /// <exception cref="ArgumentNullException">Thrown when entity, facet, or context is null</exception>
+    /// <example>
+    /// <code>
+    /// var result = user.UpdateFromFacetWithChanges(dto, context);
+    /// if (result.ChangedProperties.Any())
+    /// {
+    ///     logger.LogInformation("User {UserId} updated. Changed: {Properties}", 
+    ///         user.Id, string.Join(", ", result.ChangedProperties));
+    /// }
+    /// </code>
+    /// </example>
+    public static FacetUpdateResult<TEntity> UpdateFromFacetWithChanges<TEntity, TFacet>(
+        this TEntity entity,
+        TFacet facet,
+        DbContext context)
+        where TEntity : class
+    {
+        if (entity is null) throw new ArgumentNullException(nameof(entity));
+        if (facet is null) throw new ArgumentNullException(nameof(facet));
+        if (context is null) throw new ArgumentNullException(nameof(context));
+
+        var entry = context.Entry(entity);
+        var changedProperties = new List<string>();
+
+        // Get properties that exist in both Facet and Entity
+        var facetProperties = typeof(TFacet).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead)
+            .ToDictionary(p => p.Name, p => p);
+
+        // Iterate through entity properties that can be modified
+        foreach (var entityProperty in entry.Properties)
+        {
+            var propertyName = entityProperty.Metadata.Name;
+            
+            if (facetProperties.TryGetValue(propertyName, out var facetProperty))
+            {
+                var facetValue = facetProperty.GetValue(facet);
+                var entityValue = entityProperty.CurrentValue;
+
+                // Only update if values are different
+                if (!Equals(facetValue, entityValue))
+                {
+                    entityProperty.CurrentValue = facetValue;
+                    entityProperty.IsModified = true;
+                    changedProperties.Add(propertyName);
+                }
+            }
+        }
+
+        return new FacetUpdateResult<TEntity>(entity, changedProperties);
+    }
+}
+
+/// <summary>
+/// Represents the result of a facet update operation, containing the updated entity and information about what changed.
+/// </summary>
+/// <typeparam name="TEntity">The type of entity that was updated</typeparam>
+public readonly record struct FacetUpdateResult<TEntity>(
+    TEntity Entity,
+    IReadOnlyList<string> ChangedProperties)
+    where TEntity : class
+{
+    /// <summary>
+    /// Gets a value indicating whether any properties were changed during the update.
+    /// </summary>
+    public bool HasChanges => ChangedProperties.Count > 0;
 }

--- a/src/Facet.Extensions.EFCore/FacetEfCoreExtensions.cs
+++ b/src/Facet.Extensions.EFCore/FacetEfCoreExtensions.cs
@@ -14,7 +14,7 @@ namespace Facet.Extensions.EFCore;
 public static class FacetEfCoreExtensions
 {
     /// <summary>
-    /// Asynchronously projects an IQueryable<TSource> to a List<TTarget>
+    /// Asynchronously projects an IQueryable&lt;TSource&gt; to a List&lt;TTarget&gt;
     /// using the generated Projection expression and Entity Framework Core's ToListAsync.
     /// </summary>
     public static Task<List<TTarget>> ToFacetsAsync<TSource, TTarget>(
@@ -28,7 +28,22 @@ public static class FacetEfCoreExtensions
     }
 
     /// <summary>
-    /// Asynchronously projects the first element of an IQueryable<TSource>
+    /// Asynchronously projects an IQueryable&lt;TSource&gt; to a List&lt;TTarget&gt;
+    /// using the generated Projection expression and Entity Framework Core's ToListAsync.
+    /// The source type is inferred from the query.
+    /// </summary>
+    public static Task<List<TTarget>> ToFacetsAsync<TTarget>(
+        this IQueryable source,
+        CancellationToken cancellationToken = default)
+        where TTarget : class
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        return Facet.Extensions.FacetExtensions.SelectFacet<TTarget>(source)
+                     .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously projects the first element of an IQueryable&lt;TSource&gt;
     /// to a facet, or returns null if none found, using Entity Framework Core's FirstOrDefaultAsync.
     /// </summary>
     public static Task<TTarget?> FirstFacetAsync<TSource, TTarget>(
@@ -42,7 +57,22 @@ public static class FacetEfCoreExtensions
     }
 
     /// <summary>
-    /// Asynchronously projects a single element of an IQueryable<TSource>
+    /// Asynchronously projects the first element of an IQueryable&lt;TSource&gt;
+    /// to a facet, or returns null if none found, using Entity Framework Core's FirstOrDefaultAsync.
+    /// The source type is inferred from the query.
+    /// </summary>
+    public static Task<TTarget?> FirstFacetAsync<TTarget>(
+        this IQueryable source,
+        CancellationToken cancellationToken = default)
+        where TTarget : class
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        return Facet.Extensions.FacetExtensions.SelectFacet<TTarget>(source)
+                     .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously projects a single element of an IQueryable&lt;TSource&gt;
     /// to a facet, throwing if not exactly one element exists, using Entity Framework Core's SingleAsync.
     /// </summary>
     public static Task<TTarget> SingleFacetAsync<TSource, TTarget>(
@@ -52,6 +82,21 @@ public static class FacetEfCoreExtensions
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
         return Facet.Extensions.FacetExtensions.SelectFacet<TSource, TTarget>(source)
+                     .SingleAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously projects a single element of an IQueryable&lt;TSource&gt;
+    /// to a facet, throwing if not exactly one element exists, using Entity Framework Core's SingleAsync.
+    /// The source type is inferred from the query.
+    /// </summary>
+    public static Task<TTarget> SingleFacetAsync<TTarget>(
+        this IQueryable source,
+        CancellationToken cancellationToken = default)
+        where TTarget : class
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        return Facet.Extensions.FacetExtensions.SelectFacet<TTarget>(source)
                      .SingleAsync(cancellationToken);
     }
 

--- a/src/Facet.Extensions.EFCore/README.md
+++ b/src/Facet.Extensions.EFCore/README.md
@@ -4,9 +4,15 @@ EF Core async extension methods for the Facet library, enabling one-line async m
 
 ## Key Features
 
-- Async projection to `List<TTarget>`: `ToFacetsAsync<TSource,TTarget>()`
-- Async projection to first or default: `FirstFacetAsync<TSource,TTarget>()`
-- Async projection to single: `SingleFacetAsync<TSource,TTarget>()`
+- **Forward Mapping**: Entity ? Facet DTO
+  - Async projection to `List<TTarget>`: `ToFacetsAsync<TSource,TTarget>()`
+  - Async projection to first or default: `FirstFacetAsync<TSource,TTarget>()`
+  - Async projection to single: `SingleFacetAsync<TSource,TTarget>()`
+
+- **Reverse Mapping**: Facet DTO ? Entity (NEW!)
+  - Selective entity updates: `UpdateFromFacet<TEntity,TFacet>()`
+  - Async entity updates: `UpdateFromFacetAsync<TEntity,TFacet>()`
+  - Update with change tracking: `UpdateFromFacetWithChanges<TEntity,TFacet>()`
 
 All methods leverage your already generated ctor or Projection property and require EF Core 6+.
 
@@ -24,6 +30,8 @@ dotnet add package Facet.Extensions.EFCore
 using Facet.Extensions.EFCore; // for async EF Core extension methods
 ```
 
+## Forward Mapping (Entity ? DTO)
+
 ### 3. Use async mapping in EF Core
 
 ```csharp
@@ -36,6 +44,158 @@ var firstDto = await dbContext.People.FirstFacetAsync<Person, PersonDto>();
 // Async projection to single
 var singleDto = await dbContext.People.SingleFacetAsync<Person, PersonDto>();
 ```
+
+## Reverse Mapping (DTO ? Entity)
+
+### 4. Use selective entity updates
+
+```csharp
+// Define update DTO (excludes sensitive/immutable properties)
+[Facet(typeof(User), "Password", "CreatedAt")]
+public partial class UpdateUserDto { }
+
+// API Controller
+[HttpPut("{id}")]
+public async Task<IActionResult> UpdateUser(int id, UpdateUserDto dto)
+{
+    var user = await context.Users.FindAsync(id);
+    if (user == null) return NotFound();
+    
+    // Only updates properties that actually changed
+    user.UpdateFromFacet(dto, context);
+    
+    await context.SaveChangesAsync();
+    return NoContent();
+}
+```
+
+### 5. Advanced scenarios
+
+```csharp
+// With change tracking for auditing
+var result = user.UpdateFromFacetWithChanges(dto, context);
+if (result.HasChanges)
+{
+    logger.LogInformation("User {UserId} updated. Changed: {Properties}", 
+        user.Id, string.Join(", ", result.ChangedProperties));
+}
+
+// Async version (for future extensibility)
+await user.UpdateFromFacetAsync(dto, context);
+```
+
+## Complete Example
+
+```csharp
+// Domain entity
+public class Product
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public decimal Price { get; set; }
+    public DateTime CreatedAt { get; set; }  // Immutable
+    public string InternalNotes { get; set; }  // Sensitive
+}
+
+// Read DTO (for GET operations)
+[Facet(typeof(Product), "InternalNotes")]
+public partial class ProductDto { }
+
+// Update DTO (for PUT operations - excludes immutable/sensitive fields)
+[Facet(typeof(Product), "Id", "CreatedAt", "InternalNotes")]
+public partial class UpdateProductDto { }
+
+// API Controller
+[ApiController]
+[Route("api/[controller]")]
+public class ProductsController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+    
+    public ProductsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+    
+    // GET: Forward mapping (Entity ? DTO)
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ProductDto>>> GetProducts()
+    {
+        return await _context.Products
+            .Where(p => p.IsActive)
+            .ToFacetsAsync<Product, ProductDto>();
+    }
+    
+    [HttpGet("{id}")]
+    public async Task<ActionResult<ProductDto>> GetProduct(int id)
+    {
+        var product = await _context.Products
+            .FirstFacetAsync<Product, ProductDto>(p => p.Id == id);
+            
+        return product == null ? NotFound() : product;
+    }
+    
+    // PUT: Reverse mapping (DTO ? Entity)
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateProduct(int id, UpdateProductDto dto)
+    {
+        var product = await _context.Products.FindAsync(id);
+        if (product == null) return NotFound();
+        
+        // Selective update - only changed properties
+        var result = product.UpdateFromFacetWithChanges(dto, _context);
+        
+        if (result.HasChanges)
+        {
+            await _context.SaveChangesAsync();
+            
+            // Optional: Log what changed
+            logger.LogInformation("Product {ProductId} updated. Changed: {Properties}", 
+                id, string.Join(", ", result.ChangedProperties));
+        }
+        
+        return NoContent();
+    }
+}
+```
+
+## Performance Benefits
+
+### Selective Updates
+- **Efficient SQL**: Only updates columns that actually changed
+- **Reduced Conflicts**: Minimizes optimistic concurrency conflicts
+- **Better Performance**: Smaller UPDATE statements
+- **Cleaner Logs**: Audit trails only show actual changes
+
+### Generated SQL Comparison
+
+**Traditional approach** (updates all properties):
+```sql
+UPDATE Products SET 
+    Name = @p0,         -- Even if unchanged
+    Description = @p1,  -- Even if unchanged
+    Price = @p2         -- Even if unchanged
+WHERE Id = @p3
+```
+
+**UpdateFromFacet** (selective updates):
+```sql
+UPDATE Products SET 
+    Price = @p0         -- Only changed property
+WHERE Id = @p1
+```
+
+## API Reference
+
+| Method | Description | Use Case |
+|--------|-------------|----------|
+| `ToFacetsAsync<TSource, TTarget>()` | Project query to DTO list | GET endpoints |
+| `FirstFacetAsync<TSource, TTarget>()` | Project first result to DTO | GET single item |
+| `SingleFacetAsync<TSource, TTarget>()` | Project single result to DTO | GET single item (strict) |
+| `UpdateFromFacet<TEntity, TFacet>()` | Update entity from DTO | PUT/PATCH endpoints |
+| `UpdateFromFacetAsync<TEntity, TFacet>()` | Async update entity from DTO | PUT/PATCH with async logic |
+| `UpdateFromFacetWithChanges<TEntity, TFacet>()` | Update with change tracking | Auditing/logging scenarios |
 
 ## Requirements
 

--- a/src/Facet.Extensions/Facet.Extensions.csproj
+++ b/src/Facet.Extensions/Facet.Extensions.csproj
@@ -7,7 +7,7 @@
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Facet.Extensions</PackageId>
-		<Version>2.2.0</Version>
+		<Version>2.3.0</Version>
         <Authors>Tim Maes</Authors>
         <Description>Provider-agnostic extension methods for Facet.</Description>
         <RepositoryUrl>https://github.com/Tim-Maes/Facet</RepositoryUrl>

--- a/src/Facet.Mapping/Facet.Mapping.csproj
+++ b/src/Facet.Mapping/Facet.Mapping.csproj
@@ -7,7 +7,7 @@
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Facet.Mapping</PackageId>
-		<Version>2.2.0</Version>
+		<Version>2.3.0</Version>
         <Authors>Tim Maes</Authors>
         <Description>Advanced static mapping configuration support for the Facet source generator with async capabilities.</Description>
         <PackageTags>facet mapping source-generator dto compile-time async</PackageTags>

--- a/src/Facet/Facet.csproj
+++ b/src/Facet/Facet.csproj
@@ -7,7 +7,7 @@
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Facet</PackageId>
-        <Version>2.2.0</Version>
+        <Version>2.3.0</Version>
         <Authors>Tim Maes</Authors>
         <Description>A Roslyn source generator for lean DTOs.</Description>
         <PackageTags>source-generator dto projection redaction facet</PackageTags>

--- a/test/Facet.TestConsole/DTOs/FacetDTOs.cs
+++ b/test/Facet.TestConsole/DTOs/FacetDTOs.cs
@@ -1,0 +1,40 @@
+namespace Facet.TestConsole.DTOs;
+
+[Facet(typeof(Data.User), "Password")]
+public partial class DbUserDto { }
+
+[Facet(typeof(Data.User), "Password", "CreatedAt")]
+public partial class UpdateDbUserDto { }
+
+[Facet(typeof(Data.User), "Password")]
+public partial class PublicDbUserDto { }
+
+[Facet(typeof(Data.User), "Id", "CreatedAt", "LastLoginAt")]
+public partial class CreateDbUserDto { }
+
+[Facet(typeof(Data.Product), "InternalNotes")]
+public partial class DbProductDto { }
+
+[Facet(typeof(Data.Product), "Id", "CreatedAt", "InternalNotes")]  
+public partial class UpdateDbProductDto { }
+
+[Facet(typeof(Data.Product), "InternalNotes", "CategoryId")]
+public partial class PublicDbProductDto { }
+
+[Facet(typeof(Data.Product), "Id", "CreatedAt")]
+public partial class CreateDbProductDto { }
+
+[Facet(typeof(Data.Category))]
+public partial class DbCategoryDto { }
+
+[Facet(typeof(Data.Category), "Id", "CreatedAt")]
+public partial class UpdateDbCategoryDto { }
+
+[Facet(typeof(Data.User), "Password", Kind = FacetKind.Record)]
+public partial record DbUserRecord;
+
+[Facet(typeof(Data.Product), "InternalNotes", "Description", Kind = FacetKind.RecordStruct)]  
+public partial record struct DbProductSummary;
+
+[Facet(typeof(Data.User), "Password", "Bio", "ProfilePictureUrl", "LastLoginAt", Kind = FacetKind.Struct)]
+public partial struct DbUserSummary;

--- a/test/Facet.TestConsole/Data/FacetTestDbContext.cs
+++ b/test/Facet.TestConsole/Data/FacetTestDbContext.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Facet.TestConsole.Data;
+
+// Entity classes that will be stored in the database
+public class User
+{
+    public int Id { get; set; }
+    
+    [Required]
+    [MaxLength(100)]
+    public string FirstName { get; set; } = string.Empty;
+    
+    [Required]
+    [MaxLength(100)]
+    public string LastName { get; set; } = string.Empty;
+    
+    [Required]
+    [MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+    
+    [Required]
+    [MaxLength(255)]
+    public string Password { get; set; } = string.Empty; // This will be excluded in DTOs
+    
+    public bool IsActive { get; set; } = true;
+    
+    public DateTime DateOfBirth { get; set; }
+    
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    
+    public DateTime? LastLoginAt { get; set; }
+    
+    [MaxLength(500)]
+    public string? ProfilePictureUrl { get; set; }
+    
+    [MaxLength(1000)]
+    public string? Bio { get; set; }
+}
+
+public class Product
+{
+    public int Id { get; set; }
+    
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+    
+    [MaxLength(2000)]
+    public string Description { get; set; } = string.Empty;
+    
+    [Required]
+    public decimal Price { get; set; }
+    
+    public int CategoryId { get; set; }
+    
+    public bool IsAvailable { get; set; } = true;
+    
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    
+    [MaxLength(1000)]
+    public string InternalNotes { get; set; } = string.Empty; // This will be excluded in DTOs
+}
+
+public class Category
+{
+    public int Id { get; set; }
+    
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+    
+    [MaxLength(500)]
+    public string Description { get; set; } = string.Empty;
+    
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    
+    // Navigation property
+    public virtual ICollection<Product> Products { get; set; } = new List<Product>();
+}
+
+// DbContext for the test application
+public class FacetTestDbContext : DbContext
+{
+    public FacetTestDbContext(DbContextOptions<FacetTestDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users { get; set; } = null!;
+    public DbSet<Product> Products { get; set; } = null!;
+    public DbSet<Category> Categories { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Configure User entity
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => e.Email).IsUnique();
+        });
+
+        // Configure Product entity
+        modelBuilder.Entity<Product>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Price).HasColumnType("decimal(18,2)");
+            
+            // Configure relationship with Category
+            entity.HasOne<Category>()
+                  .WithMany(c => c.Products)
+                  .HasForeignKey(p => p.CategoryId)
+                  .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        // Configure Category entity
+        modelBuilder.Entity<Category>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+        });
+
+        // Seed data
+        SeedData(modelBuilder);
+    }
+
+    private static void SeedData(ModelBuilder modelBuilder)
+    {
+        // Seed Categories
+        modelBuilder.Entity<Category>().HasData(
+            new Category { Id = 1, Name = "Electronics", Description = "Electronic devices and gadgets", CreatedAt = DateTime.UtcNow.AddDays(-30) },
+            new Category { Id = 2, Name = "Books", Description = "Books and educational materials", CreatedAt = DateTime.UtcNow.AddDays(-25) },
+            new Category { Id = 3, Name = "Clothing", Description = "Apparel and accessories", CreatedAt = DateTime.UtcNow.AddDays(-20) }
+        );
+
+        // Seed Users
+        modelBuilder.Entity<User>().HasData(
+            new User
+            {
+                Id = 1,
+                FirstName = "John",
+                LastName = "Doe",
+                Email = "john.doe@example.com",
+                Password = "hashedpassword123",
+                IsActive = true,
+                DateOfBirth = new DateTime(1990, 5, 15),
+                CreatedAt = DateTime.UtcNow.AddDays(-100),
+                LastLoginAt = DateTime.UtcNow.AddHours(-2),
+                Bio = "Software developer passionate about clean code"
+            },
+            new User
+            {
+                Id = 2,
+                FirstName = "Jane",
+                LastName = "Smith",
+                Email = "jane.smith@example.com",
+                Password = "hashedpassword456",
+                IsActive = true,
+                DateOfBirth = new DateTime(1985, 12, 3),
+                CreatedAt = DateTime.UtcNow.AddDays(-90),
+                LastLoginAt = DateTime.UtcNow.AddDays(-1),
+                Bio = "UX designer with 10+ years experience"
+            },
+            new User
+            {
+                Id = 3,
+                FirstName = "Bob",
+                LastName = "Johnson",
+                Email = "bob.johnson@example.com",
+                Password = "hashedpassword789",
+                IsActive = false,
+                DateOfBirth = new DateTime(1992, 8, 22),
+                CreatedAt = DateTime.UtcNow.AddDays(-80),
+                LastLoginAt = null,
+                Bio = "Data analyst and machine learning enthusiast"
+            }
+        );
+
+        // Seed Products
+        modelBuilder.Entity<Product>().HasData(
+            new Product
+            {
+                Id = 1,
+                Name = "MacBook Pro",
+                Description = "High-performance laptop for professionals",
+                Price = 1299.99m,
+                CategoryId = 1,
+                IsAvailable = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-50),
+                InternalNotes = "Supplier: Apple Inc. - Margin: 25% - Volume discount available"
+            },
+            new Product
+            {
+                Id = 2,
+                Name = "iPhone 15",
+                Description = "Latest smartphone with advanced features",
+                Price = 899.99m,
+                CategoryId = 1,
+                IsAvailable = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-40),
+                InternalNotes = "Supplier: Apple Inc. - Margin: 30% - High demand item"
+            },
+            new Product
+            {
+                Id = 3,
+                Name = "Clean Code",
+                Description = "A Handbook of Agile Software Craftsmanship by Robert C. Martin",
+                Price = 49.99m,
+                CategoryId = 2,
+                IsAvailable = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                InternalNotes = "Publisher: Prentice Hall - Margin: 40% - Educational discount available"
+            },
+            new Product
+            {
+                Id = 4,
+                Name = "Winter Jacket",
+                Description = "Warm and comfortable winter jacket",
+                Price = 159.99m,
+                CategoryId = 3,
+                IsAvailable = false,
+                CreatedAt = DateTime.UtcNow.AddDays(-20),
+                InternalNotes = "Supplier: OutdoorGear Co. - Margin: 50% - Seasonal item"
+            }
+        );
+    }
+}

--- a/test/Facet.TestConsole/Facet.TestConsole.csproj
+++ b/test/Facet.TestConsole/Facet.TestConsole.csproj
@@ -11,6 +11,24 @@
     <ProjectReference Include="..\..\src\Facet\Facet.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\Facet.Extensions\Facet.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Facet.Mapping\Facet.Mapping.csproj" />
+    <ProjectReference Include="..\..\src\Facet.Extensions.EFCore\Facet.Extensions.EFCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/Facet.TestConsole/Services/UserService.cs
+++ b/test/Facet.TestConsole/Services/UserService.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Facet.TestConsole.Data;
+using Facet.TestConsole.DTOs;
+using Facet.Extensions.EFCore;
+using Facet.Extensions;
+
+namespace Facet.TestConsole.Services;
+
+public interface IUserService
+{
+    Task<IEnumerable<DbUserDto>> GetAllUsersAsync();
+    Task<DbUserDto?> GetUserByIdAsync(int id);
+    Task<DbUserDto> CreateUserAsync(CreateDbUserDto createUserDto);
+    Task<DbUserDto?> UpdateUserAsync(int id, UpdateDbUserDto updateUserDto);
+    Task<bool> DeleteUserAsync(int id);
+    Task<(DbUserDto?, IReadOnlyList<string> changedProperties)> UpdateUserWithChangeTrackingAsync(int id, UpdateDbUserDto updateUserDto);
+}
+
+public class UserService : IUserService
+{
+    private readonly FacetTestDbContext _context;
+    private readonly ILogger<UserService> _logger;
+
+    public UserService(FacetTestDbContext context, ILogger<UserService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<DbUserDto>> GetAllUsersAsync()
+    {
+        _logger.LogInformation("Getting all users");
+        
+        return await _context.Users
+            .Where(u => u.IsActive)
+            .ToFacetsAsync<DbUserDto>();
+    }
+
+    public async Task<DbUserDto?> GetUserByIdAsync(int id)
+    {
+        _logger.LogInformation("Getting user with ID: {UserId}", id);
+        
+        return await _context.Users
+            .Where(u => u.Id == id)
+            .FirstFacetAsync<DbUserDto>();
+    }
+
+    public async Task<DbUserDto> CreateUserAsync(CreateDbUserDto createUserDto)
+    {
+        _logger.LogInformation("Creating new user: {Email}", createUserDto.Email);
+
+        var user = new Data.User
+        {
+            FirstName = createUserDto.FirstName,
+            LastName = createUserDto.LastName,
+            Email = createUserDto.Email,
+            Password = createUserDto.Password,
+            IsActive = createUserDto.IsActive,
+            DateOfBirth = createUserDto.DateOfBirth,
+            ProfilePictureUrl = createUserDto.ProfilePictureUrl,
+            Bio = createUserDto.Bio,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation("User created with ID: {UserId}", user.Id);
+        
+        return user.ToFacet<DbUserDto>();
+    }
+
+    public async Task<DbUserDto?> UpdateUserAsync(int id, UpdateDbUserDto updateUserDto)
+    {
+        _logger.LogInformation("Updating user with ID: {UserId}", id);
+
+        var user = await _context.Users.FindAsync(id);
+        if (user == null)
+        {
+            _logger.LogWarning("User with ID {UserId} not found", id);
+            return null;
+        }
+
+        user.UpdateFromFacet(updateUserDto, _context);
+
+        await _context.SaveChangesAsync();
+        
+        _logger.LogInformation("User {UserId} updated successfully", id);
+
+        return user.ToFacet<DbUserDto>();
+    }
+
+    public async Task<(DbUserDto?, IReadOnlyList<string> changedProperties)> UpdateUserWithChangeTrackingAsync(int id, UpdateDbUserDto updateUserDto)
+    {
+        _logger.LogInformation("Updating user with change tracking for ID: {UserId}", id);
+
+        var user = await _context.Users.FindAsync(id);
+        if (user == null)
+        {
+            _logger.LogWarning("User with ID {UserId} not found", id);
+            return (null, new List<string>());
+        }
+
+        var result = user.UpdateFromFacetWithChanges(updateUserDto, _context);
+
+        if (result.HasChanges)
+        {
+            await _context.SaveChangesAsync();
+            
+            _logger.LogInformation("User {UserId} updated. Changed properties: {Properties}", 
+                id, string.Join(", ", result.ChangedProperties));
+        }
+        else
+        {
+            _logger.LogInformation("No changes detected for user {UserId}", id);
+        }
+
+        return (user.ToFacet<DbUserDto>(), result.ChangedProperties);
+    }
+
+    public async Task<bool> DeleteUserAsync(int id)
+    {
+        _logger.LogInformation("Deleting user with ID: {UserId}", id);
+
+        var user = await _context.Users.FindAsync(id);
+        if (user == null)
+        {
+            _logger.LogWarning("User with ID {UserId} not found", id);
+            return false;
+        }
+
+        _context.Users.Remove(user);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation("User {UserId} deleted successfully", id);
+        return true;
+    }
+}
+
+public interface IProductService
+{
+    Task<IEnumerable<DbProductDto>> GetAllProductsAsync();
+    Task<DbProductDto?> GetProductByIdAsync(int id);
+    Task<DbProductDto?> UpdateProductAsync(int id, UpdateDbProductDto updateProductDto);
+    Task<(DbProductDto?, IReadOnlyList<string> changedProperties)> UpdateProductWithChangeTrackingAsync(int id, UpdateDbProductDto updateProductDto);
+}
+
+public class ProductService : IProductService
+{
+    private readonly FacetTestDbContext _context;
+    private readonly ILogger<ProductService> _logger;
+
+    public ProductService(FacetTestDbContext context, ILogger<ProductService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<DbProductDto>> GetAllProductsAsync()
+    {
+        _logger.LogInformation("Getting all products");
+        
+        return await _context.Products
+            .Where(p => p.IsAvailable)
+            .ToFacetsAsync<DbProductDto>();
+    }
+
+    public async Task<DbProductDto?> GetProductByIdAsync(int id)
+    {
+        _logger.LogInformation("Getting product with ID: {ProductId}", id);
+        
+        return await _context.Products
+            .Where(p => p.Id == id)
+            .FirstFacetAsync<DbProductDto>();
+    }
+
+    public async Task<DbProductDto?> UpdateProductAsync(int id, UpdateDbProductDto updateProductDto)
+    {
+        _logger.LogInformation("Updating product with ID: {ProductId}", id);
+
+        var product = await _context.Products.FindAsync(id);
+        if (product == null)
+        {
+            _logger.LogWarning("Product with ID {ProductId} not found", id);
+            return null;
+        }
+
+        product.UpdateFromFacet(updateProductDto, _context);
+
+        await _context.SaveChangesAsync();
+        
+        _logger.LogInformation("Product {ProductId} updated successfully", id);
+
+        return product.ToFacet<DbProductDto>();
+    }
+
+    public async Task<(DbProductDto?, IReadOnlyList<string> changedProperties)> UpdateProductWithChangeTrackingAsync(int id, UpdateDbProductDto updateProductDto)
+    {
+        _logger.LogInformation("Updating product with change tracking for ID: {ProductId}", id);
+
+        var product = await _context.Products.FindAsync(id);
+        if (product == null)
+        {
+            _logger.LogWarning("Product with ID {ProductId} not found", id);
+            return (null, new List<string>());
+        }
+
+        var result = product.UpdateFromFacetWithChanges(updateProductDto, _context);
+
+        if (result.HasChanges)
+        {
+            await _context.SaveChangesAsync();
+            
+            _logger.LogInformation("Product {ProductId} updated. Changed properties: {Properties}", 
+                id, string.Join(", ", result.ChangedProperties));
+        }
+        else
+        {
+            _logger.LogInformation("No changes detected for product {ProductId}", id);
+        }
+
+        return (product.ToFacet<DbProductDto>(), result.ChangedProperties);
+    }
+}

--- a/test/Facet.TestConsole/Tests/EfCoreIntegrationTests.cs
+++ b/test/Facet.TestConsole/Tests/EfCoreIntegrationTests.cs
@@ -1,0 +1,239 @@
+using Facet.Extensions;
+using Facet.Extensions.EFCore;
+using Facet.TestConsole.Data;
+using Facet.TestConsole.DTOs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Facet.TestConsole.Tests;
+
+public class EfCoreIntegrationTests
+{
+    private readonly FacetTestDbContext _context;
+    private readonly ILogger<EfCoreIntegrationTests> _logger;
+
+    public EfCoreIntegrationTests(FacetTestDbContext context, ILogger<EfCoreIntegrationTests> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task RunAllTestsAsync()
+    {
+        Console.WriteLine("=== EF Core Integration Tests ===\n");
+
+        await TestAsyncProjections();
+        await TestLinqToEntitiesQueries();
+        await TestEntityTrackingIntegration();
+        await TestComplexQueryProjections();
+        await TestPerformanceComparisons();
+
+        Console.WriteLine("\n=== All EF Core integration tests completed! ===");
+    }
+
+    private async Task TestAsyncProjections()
+    {
+        Console.WriteLine("1. Testing Async Projections:");
+        Console.WriteLine("==============================");
+
+        Console.WriteLine("  Testing ToFacetsAsync:");
+        var userDtos = await _context.Users
+            .Where(u => u.IsActive)
+            .ToFacetsAsync<DbUserDto>();
+        
+        Console.WriteLine($"    Retrieved {userDtos.Count} user DTOs");
+        foreach (var dto in userDtos)
+        {
+            Console.WriteLine($"      - {dto.FirstName} {dto.LastName} ({dto.Email})");
+        }
+
+        Console.WriteLine("\n  Testing FirstFacetAsync:");
+        var firstUserDto = await _context.Users
+            .Where(u => u.Email.Contains("john"))
+            .FirstFacetAsync<DbUserDto>();
+        
+        if (firstUserDto != null)
+        {
+            Console.WriteLine($"    Found first user: {firstUserDto.FirstName} {firstUserDto.LastName}");
+        }
+
+        Console.WriteLine("\n  Testing SingleFacetAsync:");
+        try
+        {
+            var singleUserDto = await _context.Users
+                .Where(u => u.Email == "john.doe@example.com")
+                .SingleFacetAsync<DbUserDto>();
+            
+            if (singleUserDto != null)
+            {
+                Console.WriteLine($"    Found unique user: {singleUserDto.FirstName} {singleUserDto.LastName}");
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.WriteLine($"    Expected exception for non-unique query: {ex.Message}");
+        }
+
+        Console.WriteLine();
+    }
+
+    private async Task TestLinqToEntitiesQueries()
+    {
+        Console.WriteLine("2. Testing LINQ to Entities Queries:");
+        Console.WriteLine("====================================");
+
+        Console.WriteLine("  Testing complex LINQ query with projections:");
+        var productDtos = await _context.Products
+            .Where(p => p.IsAvailable && p.Price > 100)
+            .OrderBy(p => p.Price)
+            .ToFacetsAsync<DbProductDto>();
+
+        Console.WriteLine($"    Retrieved {productDtos.Count} available products over $100:");
+        foreach (var dto in productDtos)
+        {
+            Console.WriteLine($"      - {dto.Name}: ${dto.Price}");
+        }
+
+        Console.WriteLine("\n  Testing pagination with projections:");
+        var pagedUsers = await _context.Users
+            .OrderBy(u => u.LastName)
+            .ThenBy(u => u.FirstName)
+            .Skip(0)
+            .Take(2)
+            .ToFacetsAsync<DbUserDto>();
+
+        Console.WriteLine($"    Retrieved page 1 ({pagedUsers.Count} users):");
+        foreach (var dto in pagedUsers)
+        {
+            Console.WriteLine($"      - {dto.FirstName} {dto.LastName}");
+        }
+
+        Console.WriteLine();
+    }
+
+    private async Task TestEntityTrackingIntegration()
+    {
+        Console.WriteLine("3. Testing Entity Tracking Integration:");
+        Console.WriteLine("======================================");
+
+        Console.WriteLine("  Testing DTO creation from tracked entities:");
+        
+        var trackedUsers = await _context.Users.Take(2).ToListAsync();
+        Console.WriteLine($"    Loaded {trackedUsers.Count} tracked entities");
+
+        foreach (var user in trackedUsers)
+        {
+            var dto = user.ToFacet<DbUserDto>();
+            Console.WriteLine($"      Tracked entity -> DTO: {dto.FirstName} {dto.LastName}");
+            
+            var entry = _context.Entry(user);
+            Console.WriteLine($"        Entity state: {entry.State}");
+        }
+
+        Console.WriteLine("\n  Testing update -> DTO conversion:");
+        var userToUpdate = trackedUsers.First();
+        var originalBio = userToUpdate.Bio;
+        
+        userToUpdate.Bio = "Updated bio for tracking test";
+        var updatedDto = userToUpdate.ToFacet<DbUserDto>();
+        
+        Console.WriteLine($"    Updated entity bio: {updatedDto.Bio}");
+        Console.WriteLine($"    Entity state after update: {_context.Entry(userToUpdate).State}");
+        
+        userToUpdate.Bio = originalBio;
+
+        Console.WriteLine();
+    }
+
+    private async Task TestComplexQueryProjections()
+    {
+        Console.WriteLine("4. Testing Complex Query Projections:");
+        Console.WriteLine("=====================================");
+
+        Console.WriteLine("  Testing aggregation queries:");
+        
+        var usersByActivity = await _context.Users
+            .GroupBy(u => u.IsActive)
+            .Select(g => new { IsActive = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        foreach (var group in usersByActivity)
+        {
+            Console.WriteLine($"    {(group.IsActive ? "Active" : "Inactive")} users: {group.Count}");
+        }
+
+        Console.WriteLine("\n  Testing date-based filtering with projections:");
+        var recentUsers = await _context.Users
+            .Where(u => u.CreatedAt > DateTime.UtcNow.AddDays(-120))
+            .ToFacetsAsync<DbUserDto>();
+
+        Console.WriteLine($"    Users created in last 120 days: {recentUsers.Count}");
+
+        Console.WriteLine("\n  Testing null-safe projections:");
+        var usersWithLastLogin = await _context.Users
+            .Where(u => u.LastLoginAt != null)
+            .ToFacetsAsync<DbUserDto>();
+
+        Console.WriteLine($"    Users who have logged in: {usersWithLastLogin.Count}");
+        foreach (var dto in usersWithLastLogin)
+        {
+            Console.WriteLine($"      - {dto.FirstName} {dto.LastName}: {dto.LastLoginAt:yyyy-MM-dd HH:mm}");
+        }
+
+        Console.WriteLine();
+    }
+
+    private async Task TestPerformanceComparisons()
+    {
+        Console.WriteLine("5. Testing Performance Comparisons:");
+        Console.WriteLine("===================================");
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        stopwatch.Restart();
+        var facetProjection = await _context.Users
+            .ToFacetsAsync<DbUserDto>();
+        stopwatch.Stop();
+        var facetTime = stopwatch.ElapsedMilliseconds;
+
+        Console.WriteLine($"  Facet projection: {facetProjection.Count} records in {facetTime}ms");
+
+        stopwatch.Restart();
+        var loadedUsers = await _context.Users.ToListAsync();
+        var convertedDtos = loadedUsers.SelectFacets<DbUserDto>().ToList();
+        stopwatch.Stop();
+        var loadConvertTime = stopwatch.ElapsedMilliseconds;
+
+        Console.WriteLine($"  Load+Convert: {convertedDtos.Count} records in {loadConvertTime}ms");
+
+        // Test 3: Manual projection (for comparison)
+        stopwatch.Restart();
+        var manualProjection = await _context.Users
+            .Select(u => new 
+            {
+                Id = u.Id,
+                FirstName = u.FirstName,
+                LastName = u.LastName,
+                Email = u.Email,
+                IsActive = u.IsActive,
+                DateOfBirth = u.DateOfBirth,
+                LastLoginAt = u.LastLoginAt,
+                ProfilePictureUrl = u.ProfilePictureUrl,
+                Bio = u.Bio
+            })
+            .ToListAsync();
+        stopwatch.Stop();
+        var manualTime = stopwatch.ElapsedMilliseconds;
+
+        Console.WriteLine($"  Manual projection: {manualProjection.Count} records in {manualTime}ms");
+
+        Console.WriteLine("\n  Performance Analysis:");
+        Console.WriteLine($"    Facet vs Load+Convert: {(loadConvertTime > facetTime ? "Facet is faster" : "Load+Convert is faster")} by {Math.Abs(facetTime - loadConvertTime)}ms");
+        Console.WriteLine($"    Facet vs Manual: {(manualTime > facetTime ? "Facet is faster" : "Manual is faster")} by {Math.Abs(facetTime - manualTime)}ms");
+
+        Console.WriteLine();
+    }
+}

--- a/test/Facet.TestConsole/Tests/UpdateFromFacetTests.cs
+++ b/test/Facet.TestConsole/Tests/UpdateFromFacetTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
+using Facet.TestConsole.DTOs;
+using Facet.TestConsole.Data;
+using Facet.Extensions.EFCore;
+using Facet.Extensions;
+
+namespace Facet.TestConsole.Tests;
+
+public class UpdateFromFacetTests
+{
+    private readonly FacetTestDbContext _context;
+    private readonly ILogger<UpdateFromFacetTests> _logger;
+
+    public UpdateFromFacetTests(FacetTestDbContext context, ILogger<UpdateFromFacetTests> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task RunAllTestsAsync()
+    {
+        Console.WriteLine("=== UpdateFromFacet Feature Tests (Entity -> DTO -> Mutate -> Entity) ===\n");
+
+        // Temporarily reduce EF logging noise for clearer test output
+        var originalLogLevel = _logger.IsEnabled(LogLevel.Information);
+
+        await TestBasicMutationWorkflow();
+        await TestSelectivePropertyMutation();
+        await TestChangeTrackingMutation();
+        await TestNoChangesMutation();
+        await TestMultiplePropertyMutation();
+        await TestNullValueMutation();
+        await TestDifferentFacetKindMutations();
+        await TestBulkMutationOperations();
+
+        Console.WriteLine("\n=== All UpdateFromFacet mutation tests completed! ===");
+    }
+
+    private async Task TestBasicMutationWorkflow()
+    {
+        Console.WriteLine("1. Testing Basic Mutation Workflow (Entity ? DTO ? Mutate ? Entity):");
+        Console.WriteLine("=====================================================================");
+
+        var user = await _context.Users.FindAsync(1);
+        if (user == null)
+        {
+            Console.WriteLine("User not found");
+            return;
+        }
+
+        Console.WriteLine($"BEFORE: User {user.FirstName} {user.LastName}");
+        Console.WriteLine($"  Email: {user.Email}");
+        Console.WriteLine($"  Bio: {user.Bio ?? "NULL"}");
+        Console.WriteLine($"  Profile Picture: {user.ProfilePictureUrl ?? "NULL"}");
+
+        var userDto = user.ToFacet<UpdateDbUserDto>();
+        Console.WriteLine($"\nDTO created from entity: {userDto.FirstName} {userDto.LastName}");
+
+        userDto.LastName = "MutatedLastName";
+        userDto.Bio = "This bio was mutated through DTO modification";
+        userDto.ProfilePictureUrl = "https://example.com/mutated-avatar.jpg";
+        userDto.LastLoginAt = DateTime.UtcNow;
+
+        Console.WriteLine($"\nDTO after mutation: {userDto.FirstName} {userDto.LastName}");
+        Console.WriteLine($"  Bio: {userDto.Bio}");
+        Console.WriteLine($"  Profile Picture: {userDto.ProfilePictureUrl}");
+
+        var result = user.UpdateFromFacetWithChanges(userDto, _context);
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine($"\nAFTER applying mutated DTO: User {user.FirstName} {user.LastName}");
+        Console.WriteLine($"  Email: {user.Email} (should be unchanged)");
+        Console.WriteLine($"  Bio: {user.Bio}");
+        Console.WriteLine($"  Profile Picture: {user.ProfilePictureUrl}");
+        Console.WriteLine($"  Changed properties: {string.Join(", ", result.ChangedProperties)}");
+
+        var refreshedUser = await _context.Users.FindAsync(1);
+        Console.WriteLine($"\nVERIFICATION (fresh from DB): {refreshedUser!.FirstName} {refreshedUser.LastName}");
+        Console.WriteLine($"  Bio: {refreshedUser.Bio}");
+        Console.WriteLine($"  Profile Picture: {refreshedUser.ProfilePictureUrl}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestSelectivePropertyMutation()
+    {
+        Console.WriteLine("2. Testing Selective Property Mutation:");
+        Console.WriteLine("======================================");
+
+        var user = await _context.Users.FindAsync(2);
+        if (user == null) return;
+
+        Console.WriteLine($"BEFORE: {user.FirstName} {user.LastName} ({user.Email})");
+
+        var userDto = user.ToFacet<UpdateDbUserDto>();
+
+        var originalEmail = userDto.Email;
+        userDto.Email = "mutated.email@example.com";  // Only change email
+
+        Console.WriteLine($"Mutating only Email: {originalEmail} -> {userDto.Email}");
+
+        var result = user.UpdateFromFacetWithChanges(userDto, _context);
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine($"AFTER: {user.FirstName} {user.LastName} ({user.Email})");
+        Console.WriteLine($"Changed properties: {string.Join(", ", result.ChangedProperties)}");
+        Console.WriteLine($"Expected: Only 'Email' should be changed");
+
+        var dbUser = await _context.Users.AsNoTracking().FirstAsync(u => u.Id == 2);
+        Console.WriteLine($"DB Verification: Email = {dbUser.Email}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestChangeTrackingMutation()
+    {
+        Console.WriteLine("3. Testing Change Tracking with Multiple Mutations:");
+        Console.WriteLine("==================================================");
+
+        var user = await _context.Users.FindAsync(3);
+        if (user == null) return;
+
+        Console.WriteLine($"BEFORE: {user.FirstName} {user.LastName}");
+        Console.WriteLine($"  IsActive: {user.IsActive}");
+        Console.WriteLine($"  LastLoginAt: {user.LastLoginAt?.ToString("yyyy-MM-dd HH:mm") ?? "NULL"}");
+        Console.WriteLine($"  Bio: {user.Bio ?? "NULL"}");
+
+        var userDto = user.ToFacet<UpdateDbUserDto>();
+        
+        userDto.IsActive = true;
+        userDto.LastLoginAt = DateTime.UtcNow;
+        userDto.Bio = "Reactivated user with new bio";
+
+        Console.WriteLine($"\nApplying mutations...");
+
+        var result = user.UpdateFromFacetWithChanges(userDto, _context);
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine($"AFTER: {user.FirstName} {user.LastName}");
+        Console.WriteLine($"  IsActive: {user.IsActive}");
+        Console.WriteLine($"  LastLoginAt: {user.LastLoginAt:yyyy-MM-dd HH:mm}");
+        Console.WriteLine($"  Bio: {user.Bio}");
+        Console.WriteLine($"Changed properties: {string.Join(", ", result.ChangedProperties)}");
+        Console.WriteLine($"Number of changes: {result.ChangedProperties.Count}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestNoChangesMutation()
+    {
+        Console.WriteLine("4. Testing No-Changes Mutation (DTO not modified):");
+        Console.WriteLine("==================================================");
+
+        var user = await _context.Users.FindAsync(1);
+        if (user == null) return;
+
+        var userDto = user.ToFacet<UpdateDbUserDto>();
+        
+        Console.WriteLine($"Created DTO from user {user.FirstName} {user.LastName}");
+        Console.WriteLine("Applying DTO back without any mutations...");
+
+        var result = user.UpdateFromFacetWithChanges(userDto, _context);
+
+        Console.WriteLine($"Changed properties: {(result.ChangedProperties.Any() ? string.Join(", ", result.ChangedProperties) : "NONE")}");
+        Console.WriteLine($"HasChanges: {result.HasChanges}");
+        Console.WriteLine("Expected: No properties should be changed");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestMultiplePropertyMutation()
+    {
+        Console.WriteLine("5. Testing Multiple Property Mutation on Products:");
+        Console.WriteLine("=================================================");
+
+        var product = await _context.Products.FindAsync(1);
+        if (product == null) return;
+
+        Console.WriteLine($"BEFORE: {product.Name} - ${product.Price}");
+        Console.WriteLine($"  Description: {product.Description}");
+        Console.WriteLine($"  Available: {product.IsAvailable}");
+        Console.WriteLine($"  Category: {product.CategoryId}");
+
+        var productDto = product.ToFacet<UpdateDbProductDto>();
+        
+        productDto.Name = "Mutated MacBook Pro M3 Max";
+        productDto.Price = 2499.99m;
+        productDto.Description = "Mutated description: Even more powerful laptop";
+        productDto.IsAvailable = false;
+
+        Console.WriteLine($"\nApplying multiple mutations...");
+
+        var result = product.UpdateFromFacetWithChanges(productDto, _context);
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine($"AFTER: {product.Name} - ${product.Price}");
+        Console.WriteLine($"  Description: {product.Description}");
+        Console.WriteLine($"  Available: {product.IsAvailable}");
+        Console.WriteLine($"  Category: {product.CategoryId} (should be unchanged)");
+        Console.WriteLine($"Changed properties: {string.Join(", ", result.ChangedProperties)}");
+
+        var dbProduct = await _context.Products.AsNoTracking().FirstAsync(p => p.Id == 1);
+        Console.WriteLine($"DB Verification: {dbProduct.Name} - ${dbProduct.Price} - Available: {dbProduct.IsAvailable}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestNullValueMutation()
+    {
+        Console.WriteLine("6. Testing Null Value Mutation:");
+        Console.WriteLine("===============================");
+
+        var user = await _context.Users.FindAsync(2);
+        if (user == null) return;
+
+        Console.WriteLine($"BEFORE: {user.FirstName} {user.LastName}");
+        Console.WriteLine($"  Bio: {user.Bio ?? "NULL"}");
+        Console.WriteLine($"  ProfilePictureUrl: {user.ProfilePictureUrl ?? "NULL"}");
+
+        var userDto = user.ToFacet<UpdateDbUserDto>();
+        
+        userDto.Bio = null;
+        userDto.ProfilePictureUrl = null;
+
+        Console.WriteLine($"Setting Bio and ProfilePictureUrl to NULL...");
+
+        var result = user.UpdateFromFacetWithChanges(userDto, _context);
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine($"AFTER: {user.FirstName} {user.LastName}");
+        Console.WriteLine($"  Bio: {user.Bio ?? "NULL"}");
+        Console.WriteLine($"  ProfilePictureUrl: {user.ProfilePictureUrl ?? "NULL"}");
+        Console.WriteLine($"Changed properties: {string.Join(", ", result.ChangedProperties)}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestDifferentFacetKindMutations()
+    {
+        Console.WriteLine("7. Testing Different Facet Kind Mutations:");
+        Console.WriteLine("==========================================");
+
+        var user = await _context.Users.FindAsync(1);
+        if (user == null) return;
+
+        Console.WriteLine($"Testing with user: {user.FirstName} {user.LastName}");
+
+        Console.WriteLine("\n  Testing Record DTO mutation:");
+        var userRecord = user.ToFacet<DbUserRecord>();
+        Console.WriteLine($"    Original Record: {userRecord.FirstName} {userRecord.LastName}");
+        
+        var mutatedRecord = userRecord with { 
+            FirstName = "MutatedFirst", 
+            LastName = "MutatedLast" 
+        };
+        Console.WriteLine($"    Mutated Record: {mutatedRecord.FirstName} {mutatedRecord.LastName}");
+
+        var recordResult = user.UpdateFromFacetWithChanges(mutatedRecord, _context);
+        Console.WriteLine($"    Record mutation applied, changed: {string.Join(", ", recordResult.ChangedProperties)}");
+
+        Console.WriteLine("\n  Testing Struct DTO:");
+        var userSummary = new DbUserSummary(user);
+        Console.WriteLine($"    Struct DTO: {userSummary.FirstName} {userSummary.LastName} - Active: {userSummary.IsActive}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestBulkMutationOperations()
+    {
+        Console.WriteLine("8. Testing Bulk Mutation Operations:");
+        Console.WriteLine("====================================");
+
+        var users = await _context.Users.Take(3).ToListAsync();
+        Console.WriteLine($"Processing {users.Count} users for bulk mutation...");
+
+        foreach (var user in users)
+        {
+            Console.WriteLine($"\n  Processing: {user.FirstName} {user.LastName}");
+            
+            var userDto = user.ToFacet<UpdateDbUserDto>();
+            
+            userDto.Bio = $"Bulk updated at {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}";
+            
+            var result = user.UpdateFromFacetWithChanges(userDto, _context);
+            Console.WriteLine($"    Changed: {string.Join(", ", result.ChangedProperties)}");
+        }
+
+        await _context.SaveChangesAsync();
+        Console.WriteLine($"\nBulk mutation completed for {users.Count} users");
+
+        var updatedUsers = await _context.Users.AsNoTracking().Take(3).ToListAsync();
+        foreach (var user in updatedUsers)
+        {
+            Console.WriteLine($"  Verified: {user.FirstName} {user.LastName} - Bio: {user.Bio}");
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/test/Facet.TestConsole/Tests/ValidationAndErrorTests.cs
+++ b/test/Facet.TestConsole/Tests/ValidationAndErrorTests.cs
@@ -1,0 +1,275 @@
+using Facet.Extensions.EFCore;
+using Facet.TestConsole.Data;
+using Facet.TestConsole.DTOs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Facet.TestConsole.Tests;
+
+public class ValidationAndErrorTests
+{
+    private readonly FacetTestDbContext _context;
+    private readonly ILogger<ValidationAndErrorTests> _logger;
+
+    public ValidationAndErrorTests(FacetTestDbContext context, ILogger<ValidationAndErrorTests> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task RunAllTestsAsync()
+    {
+        Console.WriteLine("=== Validation and Error Handling Tests ===\n");
+
+        await TestEntityValidation();
+        await TestDtoValidation();
+        await TestConcurrencyConflicts();
+        await TestConstraintViolations();
+        await TestErrorRecovery();
+
+        Console.WriteLine("\n=== All validation and error tests completed! ===");
+    }
+
+    private async Task TestEntityValidation()
+    {
+        Console.WriteLine("1. Testing Entity Validation:");
+        Console.WriteLine("=============================");
+
+        Console.WriteLine("  Testing required field validation:");
+        try
+        {
+            var invalidUser = new Data.User
+            {
+                IsActive = true,
+                DateOfBirth = DateTime.Now.AddYears(-25),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _context.Users.Add(invalidUser);
+            await _context.SaveChangesAsync();
+            Console.WriteLine("    ERROR: Should have failed validation!");
+        }
+        catch (DbUpdateException ex)
+        {
+            Console.WriteLine($"    ? Correctly caught validation error: {ex.InnerException?.Message ?? ex.Message}");
+            _context.ChangeTracker.Clear();
+        }
+
+        Console.WriteLine("\n  Testing email uniqueness constraint:");
+        try
+        {
+            var duplicateEmailUser = new Data.User
+            {
+                FirstName = "Duplicate",
+                LastName = "User",
+                Email = "john.doe@example.com", // This email already exists
+                Password = "password123",
+                IsActive = true,
+                DateOfBirth = DateTime.Now.AddYears(-30),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _context.Users.Add(duplicateEmailUser);
+            await _context.SaveChangesAsync();
+            Console.WriteLine("    ERROR: Should have failed uniqueness constraint!");
+        }
+        catch (DbUpdateException ex)
+        {
+            Console.WriteLine($"    ? Correctly caught uniqueness constraint violation: {ex.InnerException?.Message ?? ex.Message}");
+            _context.ChangeTracker.Clear();
+        }
+
+        Console.WriteLine();
+    }
+
+    private async Task TestDtoValidation()
+    {
+        Console.WriteLine("2. Testing DTO Validation:");
+        Console.WriteLine("==========================");
+
+        var user = await _context.Users.FirstAsync();
+        
+        Console.WriteLine("  Testing DTO property constraints:");
+        
+        var updateDto = new UpdateDbUserDto(user)
+        {
+            Email = "invalid-email-format",
+            FirstName = "",
+            DateOfBirth = DateTime.Now.AddYears(10)
+        };
+
+        try
+        {
+            user.UpdateFromFacet(updateDto, _context);
+            await _context.SaveChangesAsync();
+            Console.WriteLine("    ERROR: Should have failed validation!");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"    ? Correctly caught DTO validation error: {ex.Message}");
+            _context.ChangeTracker.Clear();
+            await _context.Entry(user).ReloadAsync();
+        }
+
+        Console.WriteLine("\n  Testing valid DTO update:");
+        var validUpdateDto = new UpdateDbUserDto(user)
+        {
+            Bio = "Updated bio through validation test"
+        };
+
+        user.UpdateFromFacet(validUpdateDto, _context);
+        await _context.SaveChangesAsync();
+        Console.WriteLine($"    ? Successfully updated user bio: {user.Bio}");
+
+        Console.WriteLine();
+    }
+
+    private async Task TestConcurrencyConflicts()
+    {
+        Console.WriteLine("3. Testing Concurrency Conflicts:");
+        Console.WriteLine("=================================");
+
+        Console.WriteLine("  Simulating concurrent update scenario:");
+
+        var user1 = await _context.Users.FirstAsync();
+        var originalBio = user1.Bio;
+
+        var updateDto1 = new UpdateDbUserDto(user1)
+        {
+            Bio = "Updated by first operation"
+        };
+        user1.UpdateFromFacet(updateDto1, _context);
+        await _context.SaveChangesAsync();
+        Console.WriteLine($"    First update completed: {user1.Bio}");
+
+        var updateDto2 = new UpdateDbUserDto(user1)
+        {
+            Bio = "Updated by second operation"
+        };
+        user1.UpdateFromFacet(updateDto2, _context);
+        await _context.SaveChangesAsync();
+        Console.WriteLine($"    Second update completed: {user1.Bio}");
+
+        user1.Bio = originalBio;
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine();
+    }
+
+    private async Task TestConstraintViolations()
+    {
+        Console.WriteLine("4. Testing Database Constraint Violations:");
+        Console.WriteLine("==========================================");
+
+        // Test foreign key constraint (if we had one)
+        Console.WriteLine("  Testing foreign key constraints:");
+        
+        var product = await _context.Products.FirstAsync();
+        var originalCategoryId = product.CategoryId;
+
+        try
+        {
+            var updateDto = new UpdateDbProductDto(product)
+            {
+                CategoryId = 999 // Non-existent category
+            };
+
+            product.UpdateFromFacet(updateDto, _context);
+            await _context.SaveChangesAsync();
+            Console.WriteLine("    ERROR: Should have failed foreign key constraint!");
+        }
+        catch (DbUpdateException ex)
+        {
+            Console.WriteLine($"    ? Correctly caught foreign key constraint violation: {ex.InnerException?.Message ?? ex.Message}");
+            _context.ChangeTracker.Clear();
+            await _context.Entry(product).ReloadAsync();
+        }
+
+        Console.WriteLine("\n  Testing string length constraints:");
+        var user = await _context.Users.FirstAsync();
+        var originalFirstName = user.FirstName;
+
+        try
+        {
+            var updateDto = new UpdateDbUserDto(user)
+            {
+                FirstName = new string('A', 150) // Exceeds MaxLength(100)
+            };
+
+            user.UpdateFromFacet(updateDto, _context);
+            await _context.SaveChangesAsync();
+            Console.WriteLine("    ERROR: Should have failed string length constraint!");
+        }
+        catch (DbUpdateException ex)
+        {
+            Console.WriteLine($"    ? Correctly caught string length constraint violation: {ex.InnerException?.Message ?? ex.Message}");
+            _context.ChangeTracker.Clear();
+            await _context.Entry(user).ReloadAsync();
+        }
+
+        Console.WriteLine();
+    }
+
+    private async Task TestErrorRecovery()
+    {
+        Console.WriteLine("5. Testing Error Recovery:");
+        Console.WriteLine("==========================");
+
+        Console.WriteLine("  Testing graceful error recovery:");
+        
+        var user = await _context.Users.FirstAsync();
+        var originalEmail = user.Email;
+        var originalBio = user.Bio;
+
+        var operations = new List<(string description, Func<Task> operation)>
+        {
+            ("Valid bio update", async () => {
+                var dto = new UpdateDbUserDto(user) { Bio = "Recovery test bio" };
+                user.UpdateFromFacet(dto, _context);
+                await _context.SaveChangesAsync();
+            }),
+            
+            ("Invalid email update", async () => {
+                var dto = new UpdateDbUserDto(user) { Email = "jane.smith@example.com" }; // Duplicate email
+                user.UpdateFromFacet(dto, _context);
+                await _context.SaveChangesAsync();
+            }),
+            
+            ("Valid profile picture update", async () => {
+                var dto = new UpdateDbUserDto(user) { ProfilePictureUrl = "https://example.com/recovery-test.jpg" };
+                user.UpdateFromFacet(dto, _context);
+                await _context.SaveChangesAsync();
+            })
+        };
+
+        foreach (var (description, operation) in operations)
+        {
+            try
+            {
+                await operation();
+                Console.WriteLine($"    ? {description}: Success");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"    ? {description}: Failed - {ex.Message}");
+                _context.ChangeTracker.Clear();
+                await _context.Entry(user).ReloadAsync();
+            }
+        }
+
+        Console.WriteLine($"\n  Final user state:");
+        Console.WriteLine($"    Email: {user.Email} (should be original: {originalEmail})");
+        Console.WriteLine($"    Bio: {user.Bio}");
+        Console.WriteLine($"    Profile Picture: {user.ProfilePictureUrl}");
+
+        user.Bio = originalBio;
+        user.Email = originalEmail;
+        user.ProfilePictureUrl = null;
+        await _context.SaveChangesAsync();
+
+        Console.WriteLine();
+    }
+}

--- a/test/Facet.TestConsole/appsettings.json
+++ b/test/Facet.TestConsole/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=FacetTestDb;Trusted_Connection=true;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.EntityFrameworkCore": "Information"
+    }
+  }
+}

--- a/test/FacetTest.sln
+++ b/test/FacetTest.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Facet.Mapping", "..\src\Fac
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Facet.TestConsole", "Facet.TestConsole\Facet.TestConsole.csproj", "{E5B5B3C1-8F4A-4C8B-9D1E-F2C3A4B5D6E7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Facet.Extensions.EFCore", "..\src\Facet.Extensions.EFCore\Facet.Extensions.EFCore.csproj", "{E2786633-C705-DC6C-05A1-CF19DDE62B32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,5 +34,12 @@ Global
 		{E5B5B3C1-8F4A-4C8B-9D1E-F2C3A4B5D6E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5B5B3C1-8F4A-4C8B-9D1E-F2C3A4B5D6E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5B5B3C1-8F4A-4C8B-9D1E-F2C3A4B5D6E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2786633-C705-DC6C-05A1-CF19DDE62B32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2786633-C705-DC6C-05A1-CF19DDE62B32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2786633-C705-DC6C-05A1-CF19DDE62B32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2786633-C705-DC6C-05A1-CF19DDE62B32}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fixes #30 

Provides these basic methods for mapping mutated facet data to entities

| Method                              | Description                                                      |
|------------------------------------- |------------------------------------------------------------------|
| `ToFacetsAsync<TSource, TTarget>()`  | Async projection to `List<TTarget>` with explicit source type.    |
| `ToFacetsAsync<TTarget>()`           | Async projection to `List<TTarget>` with inferred source type.    |
| `FirstFacetAsync<TSource, TTarget>()`| Async projection to first/default with explicit source type.      |
| `FirstFacetAsync<TTarget>()`         | Async projection to first/default with inferred source type.      |
| `SingleFacetAsync<TSource, TTarget>()`| Async projection to single with explicit source type.            |
| `SingleFacetAsync<TTarget>()`        | Async projection to single with inferred source type.            |
| `UpdateFromFacet<TEntity, TFacet>()` | Update entity with changed properties from facet DTO.            |
| `UpdateFromFacetAsync<TEntity, TFacet>()`| Async update entity with changed properties from facet DTO.  |
| `UpdateFromFacetWithChanges<TEntity, TFacet>()`| Update entity and return information about changed properties. |