### PR TITLE
feat: Facet overload with include option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can think of it like **carving out a specific facet** of a gem:
 ## :star: Key Features
 
 - :white_check_mark: Generate classes, records, structs, or record structs from existing types
-- :white_check_mark: Exclude fields/properties you don't want (create a Facetted view of your model)
+- :white_check_mark: Define what to include, or exclude fields/properties you don't want (create a Facetted view of your model)
 - :white_check_mark: Include/redact public fields
 - :white_check_mark: Auto-generate constructors for fast mapping
 - :white_check_mark: LINQ projection expressions
@@ -124,9 +124,17 @@ string[] excludeFields = { "Password", "Email" };
 [Facet(typeof(User), exclude: excludeFields)]
 public partial class UserWithoutEmail { }
 
+// Include only specific properties
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email" })]
+public partial class UserContactDto { }
+
 // Include public fields
 [Facet(typeof(Entity), IncludeFields = true)]
 public partial class EntityDto { }
+
+// Include specific fields and properties 
+[Facet(typeof(Entity), Include = new[] { "Name", "Status" }, IncludeFields = true)]
+public partial class EntitySummaryDto { }
 ```
 
 ### Custom Sync Mapping

--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -4,30 +4,110 @@ The `[Facet]` attribute is used to declare a new projection (facet) type based o
 
 ## Usage
 
+### Exclude Mode (Default)
 ```csharp
 [Facet(typeof(SourceType), exclude: "Property1", "Property2")]
 public partial class MyFacet { }
 ```
 
+### Include Mode (New)
+```csharp
+[Facet(typeof(SourceType), Include = new[] { "Property1", "Property2" })]
+public partial class MyFacet { }
+```
+
 ## Parameters
 
-| Parameter            | Type      | Description                                                                 |
-|----------------------|-----------|-----------------------------------------------------------------------------|
-| `sourceType`         | `Type`    | The type to project from (required).                                        |
-| `exclude`            | `string[]`| Names of properties/fields to exclude from the generated type (optional).   |
-| `IncludeFields`      | `bool`    | Include public fields from the source type (default: false).                |
-| `GenerateConstructor`| `bool`    | Generate a constructor that copies values from the source (default: true).   |
-| `Configuration`      | `Type?`   | Custom mapping config type (see [Custom Mapping](04_CustomMapping.md)).      |
-| `GenerateProjection` | `bool`    | Generate a static LINQ projection (default: true).                          |
-| `Kind`               | `FacetKind`| Output type: Class, Record, Struct, RecordStruct (default: Class).          |
-| `UseFullName`        | `bool`    | Use full type name in generated file names to avoid collisions (default: false). |
+| Parameter                      | Type      | Description                                                                 |
+|--------------------------------|-----------|-----------------------------------------------------------------------------|
+| `sourceType`                   | `Type`    | The type to project from (required).                                        |
+| `exclude`                      | `string[]`| Names of properties/fields to exclude from the generated type (optional).   |
+| `Include`                      | `string[]`| Names of properties/fields to include in the generated type (optional). Mutually exclusive with `exclude`. |
+| `IncludeFields`                | `bool`    | Include public fields from the source type (default: false for include mode, false for exclude mode). |
+| `GenerateConstructor`          | `bool`    | Generate a constructor that copies values from the source (default: true).   |
+| `GenerateParameterlessConstructor` | `bool` | Generate a parameterless constructor for testing and initialization (default: true). |
+| `Configuration`                | `Type?`   | Custom mapping config type (see [Custom Mapping](04_CustomMapping.md)).      |
+| `GenerateProjection`           | `bool`    | Generate a static LINQ projection (default: true).                          |
+| `GenerateBackTo`               | `bool`    | Generate a method to map back from facet to source type (default: true).    |
+| `Kind`                         | `FacetKind`| Output type: Class, Record, Struct, RecordStruct, Auto (default: Auto).     |
+| `PreserveInitOnlyProperties`   | `bool`    | Preserve init-only modifiers from source properties (default: true for records). |
+| `PreserveRequiredProperties`   | `bool`    | Preserve required modifiers from source properties (default: true for records). |
+| `UseFullName`                  | `bool`    | Use full type name in generated file names to avoid collisions (default: false). |
 
-## Example
+## Include vs Exclude
 
+The `Include` and `Exclude` parameters are mutually exclusive:
+
+- **Exclude Mode**: Include all properties except those listed in `exclude` (default behavior)
+- **Include Mode**: Only include properties listed in `Include` array
+
+### Include Mode Behavior
+
+When using `Include` mode:
+- Only the properties specified in the `Include` array are copied to the facet
+- `IncludeFields` defaults to `false` (disabled by default for include mode)
+- All other properties from the source type are excluded
+- Works with inheritance - you can include properties from base classes
+
+## Examples
+
+### Basic Include Usage
 ```csharp
+// Only include FirstName, LastName, and Email
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email" })]
+public partial class UserContactDto;
+```
+
+### Single Property Include
+```csharp
+// Only include the Name property
+[Facet(typeof(Product), Include = new[] { "Name" })]
+public partial class ProductNameDto;
+```
+
+### Include with Custom Properties
+```csharp
+// Include specific properties and add custom ones
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName" })]
+public partial class UserSummaryDto
+{
+    public string FullName { get; set; } = string.Empty; // Custom property
+}
+```
+
+### Include with Fields
+```csharp
+// Include fields as well as properties
+[Facet(typeof(EntityWithFields), Include = new[] { "Name", "Age" }, IncludeFields = true)]
+public partial class EntityDto;
+```
+
+### Include with Records
+```csharp
+// Generate a record type with only specific properties
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName" }, Kind = FacetKind.Record)]
+public partial record UserNameRecord;
+```
+
+### Traditional Exclude Usage
+```csharp
+// Exclude sensitive properties (original behavior)
 [Facet(typeof(User), exclude: nameof(User.Password), Kind = FacetKind.Record)]
 public partial record UserDto;
 ```
+
+## When to Use Include vs Exclude
+
+### Use **Include** when:
+- You want a facet with only a few specific properties from a large source type
+- Creating focused DTOs (e.g., summary views, contact info only)
+- Building API response models that should only expose certain fields
+- Creating search result DTOs with minimal data
+
+### Use **Exclude** when:
+- You want most properties but need to hide a few sensitive ones
+- The majority of the source type should be included in the facet
+- Following the original Facet pattern for backward compatibility
 
 ---
 

--- a/docs/06_AdvancedScenarios.md
+++ b/docs/06_AdvancedScenarios.md
@@ -1,58 +1,311 @@
-# Advanced Usage Scenarios
+# Advanced Scenarios
 
-Facet supports a variety of advanced scenarios to help you tailor projections to your needs.
+This section covers advanced use cases and configuration options for Facet.
 
-## 1. Generating Records, Structs, and Record Structs
+## Multiple Facets from One Source
 
-```csharp
-[Facet(typeof(Person), Kind = FacetKind.Record)]
-public partial record PersonRecord;
-
-[Facet(typeof(MyStruct), Kind = FacetKind.Struct, IncludeFields = true)]
-public partial struct MyStructDto;
-
-[Facet(typeof(MyRecordStruct), Kind = FacetKind.RecordStruct)]
-public partial record struct MyRecordStructDto;
-```
-
-## 2. Including Public Fields
+You can create multiple facets from the same source type:
 
 ```csharp
-[Facet(typeof(Entity), IncludeFields = true)]
-public partial class EntityDto { }
-```
-
-## 3. Excluding Properties/Fields
-
-```csharp
-[Facet(typeof(User), exclude: nameof(User.Password))]
-public partial class UserDto { }
-```
-
-## 4. Custom Mapping with Additional Properties
-
-```csharp
-public class UserMapConfig : IFacetMapConfiguration<User, UserDto>
+public class User
 {
-    public static void Map(User source, UserDto target)
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Email { get; set; }
+    public DateTime DateOfBirth { get; set; }
+    public string Password { get; set; }
+    public decimal Salary { get; set; }
+    public string Department { get; set; }
+}
+
+// Public profile (exclude sensitive data)
+[Facet(typeof(User), nameof(User.Password), nameof(User.Salary))]
+public partial class UserPublicDto { }
+
+// Contact information only (include specific fields)
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email" })]
+public partial class UserContactDto { }
+
+// Summary for lists (include minimal data)
+[Facet(typeof(User), Include = new[] { "Id", "FirstName", "LastName" })]
+public partial class UserSummaryDto { }
+
+// HR view (exclude password but include salary)
+[Facet(typeof(User), nameof(User.Password))]
+public partial class UserHRDto { }
+```
+
+## Include vs Exclude Patterns
+
+### Include Pattern - Building Focused DTOs
+
+Use the `Include` pattern when you want facets with only specific properties:
+
+```csharp
+public class Product
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public decimal Price { get; set; }
+    public int CategoryId { get; set; }
+    public bool IsAvailable { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string InternalNotes { get; set; }
+    public decimal Cost { get; set; }
+    public string SKU { get; set; }
+}
+
+// API response with only customer-facing data
+[Facet(typeof(Product), Include = new[] { "Id", "Name", "Description", "Price", "IsAvailable" })]
+public partial record ProductApiDto;
+
+// Search results with minimal data
+[Facet(typeof(Product), Include = new[] { "Id", "Name", "Price" })]
+public partial record ProductSearchDto;
+
+// Internal admin view with cost data
+[Facet(typeof(Product), Include = new[] { "Id", "Name", "Price", "Cost", "SKU", "InternalNotes" })]
+public partial class ProductAdminDto;
+```
+
+### Exclude Pattern - Hiding Sensitive Data
+
+Use the `Exclude` pattern when you want most properties but need to hide specific ones:
+
+```csharp
+// Exclude only sensitive information
+[Facet(typeof(User), nameof(User.Password))]
+public partial class UserDto { }
+
+// Exclude multiple sensitive fields
+[Facet(typeof(Employee), nameof(Employee.Salary), nameof(Employee.SSN))]
+public partial class EmployeePublicDto { }
+```
+
+## Working with Fields
+
+### Include Fields Example
+
+```csharp
+public class LegacyEntity
+{
+    public int Id;
+    public string Name;
+    public DateTime CreatedDate;
+    public string Status { get; set; }
+    public string Notes { get; set; }
+}
+
+// Include specific fields and properties
+[Facet(typeof(LegacyEntity), Include = new[] { "Name", "Status" }, IncludeFields = true)]
+public partial class LegacyEntityDto;
+
+// Only include properties (fields ignored even if listed)
+[Facet(typeof(LegacyEntity), Include = new[] { "Status", "Notes", "Name" }, IncludeFields = false)]
+public partial class LegacyEntityPropsOnlyDto;
+```
+
+## Nested Types and Inheritance
+
+### Including Properties from Base Classes
+
+Include mode works seamlessly with inheritance:
+
+```csharp
+public class BaseEntity
+{
+    public int Id { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string CreatedBy { get; set; }
+}
+
+public class Product : BaseEntity
+{
+    public string Name { get; set; }
+    public decimal Price { get; set; }
+    public string Category { get; set; }
+}
+
+// Include properties from both base and derived class
+[Facet(typeof(Product), Include = new[] { "Id", "Name", "Price" })]
+public partial class ProductSummaryDto;
+
+// Include only derived class properties
+[Facet(typeof(Product), Include = new[] { "Name", "Category" })]
+public partial class ProductInfoDto;
+```
+
+### Nested Classes
+
+Both include and exclude work with nested classes:
+
+```csharp
+public class OuterClass
+{
+    [Facet(typeof(User), Include = new[] { "FirstName", "LastName" })]
+    public partial class NestedUserDto { }
+}
+```
+
+## Custom Mapping with Include
+
+You can combine Include mode with custom mapping:
+
+```csharp
+public class UserIncludeMapper : IFacetMapConfiguration<User, UserFormattedDto>
+{
+    public static void Map(User source, UserFormattedDto target)
     {
-        target.FullName = $"{source.FirstName} {source.LastName}";
+        target.DisplayName = $"{source.FirstName} {source.LastName}".ToUpper();
     }
 }
 
-[Facet(typeof(User), Configuration = typeof(UserMapConfig))]
-public partial class UserDto { public string FullName { get; set; } }
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName" }, Configuration = typeof(UserIncludeMapper))]
+public partial class UserFormattedDto
+{
+    public string DisplayName { get; set; } = string.Empty;
+}
 ```
 
-## 5. LINQ/EF Core Projections
+## Mixed Usage Patterns
+
+### API Layer Pattern
 
 ```csharp
-using Facet.Extensions; // provider-agnostic
-var query = dbContext.People.SelectFacet<PersonDto>();
+// Controller uses different facets for different endpoints
+[ApiController]
+public class UsersController : ControllerBase
+{
+    [HttpGet]
+    public List<UserSummaryDto> GetUsers()
+    {
+        return users.SelectFacets<User, UserSummaryDto>().ToList();
+    }
+    
+    [HttpGet("{id}")]
+    public UserDetailDto GetUser(int id)
+    {
+        return user.ToFacet<User, UserDetailDto>();
+    }
+    
+    [HttpPost]
+    public IActionResult CreateUser(UserCreateDto dto)
+    {
+        var user = dto.BackTo();
+        // Save user...
+    }
+}
 
-using Facet.Extensions.EFCore; // for async EF Core support
-var dtosAsync = await dbContext.People.ToFacetsAsync<PersonDto>();
+// Different DTOs for different use cases
+[Facet(typeof(User), Include = new[] { "Id", "FirstName", "LastName" })]
+public partial record UserSummaryDto;
+
+[Facet(typeof(User), nameof(User.Password))] // Exclude password but include everything else
+public partial class UserDetailDto;
+
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email", "Department" })]
+public partial class UserCreateDto;
 ```
+
+## Record Types with Include
+
+Include mode works perfectly with modern C# records:
+
+```csharp
+public record ModernUser
+{
+    public required string Id { get; init; }
+    public required string FirstName { get; init; }
+    public required string LastName { get; init; }
+    public string? Email { get; set; }
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+    public string? Bio { get; set; }
+}
+
+// Generate record with only specific properties
+[Facet(typeof(ModernUser), Include = new[] { "FirstName", "LastName", "Email" }, Kind = FacetKind.Record)]
+public partial record ModernUserContactRecord;
+
+// Include with init-only preservation
+[Facet(typeof(ModernUser), 
+       Include = new[] { "Id", "FirstName", "LastName" }, 
+       Kind = FacetKind.Record,
+       PreserveInitOnlyProperties = true)]
+public partial record ModernUserImmutableRecord;
+```
+
+## Performance Considerations
+
+### Include vs Exclude Performance
+
+- **Include mode**: Generates smaller facets, which can improve serialization performance and reduce memory usage
+- **Exclude mode**: Better when you need most properties from the source type
+
+### Generated Code Comparison
+
+```csharp
+// Include mode - generates minimal code
+[Facet(typeof(User), Include = new[] { "FirstName", "Email" })]
+public partial class UserMinimalDto;
+// Generated: only FirstName and Email properties
+
+// Exclude mode - generates more code
+[Facet(typeof(User), nameof(User.Password))]  
+public partial class UserFullDto;
+// Generated: all properties except Password
+```
+
+## BackTo Method Behavior with Include
+
+When using Include mode, the `BackTo()` method generates source objects with default values for non-included properties:
+
+```csharp
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email" })]
+public partial class UserContactDto;
+
+var dto = new UserContactDto();
+var backToUser = dto.BackTo(); 
+
+// backToUser.FirstName = dto.FirstName (copied)
+// backToUser.LastName = dto.LastName (copied)  
+// backToUser.Email = dto.Email (copied)
+// backToUser.Id = 0 (default for int)
+// backToUser.Password = string.Empty (default for string)
+// backToUser.IsActive = false (default for bool)
+```
+
+## Best Practices
+
+### When to Use Include
+
+1. **API Responses**: Create focused DTOs for API endpoints
+2. **Search Results**: Include only essential data for search listings
+3. **Mobile Apps**: Minimize data transfer with targeted DTOs
+4. **Microservices**: Create service-specific views of shared models
+
+### When to Use Exclude
+
+1. **Security**: Hide sensitive fields while keeping everything else
+2. **Legacy Code**: Maintain existing patterns and behavior
+3. **Large Models**: When you need most properties from complex entities
+
+### Naming Conventions
+
+```csharp
+// Descriptive names for include-based DTOs
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName" })]
+public partial class UserNameOnlyDto; // Clear about what's included
+
+[Facet(typeof(Product), Include = new[] { "Id", "Name", "Price" })]
+public partial class ProductListItemDto; // Indicates usage context
+
+// Traditional names for exclude-based DTOs  
+[Facet(typeof(User), nameof(User.Password))]
+public partial class UserDto; // General DTO name when excluding few fields
+```
+
 ---
 
-See [Attribute Reference](03_AttributeReference.md), [Custom Mapping](04_CustomMapping.md), and [Extension Methods](05_Extensions.md) for more details.
+See [Expression Mapping](10_ExpressionMapping.md) for advanced query scenarios and [Custom Mapping](04_CustomMapping.md) for complex transformation logic.

--- a/src/Facet/FacetAttribute.cs
+++ b/src/Facet/FacetAttribute.cs
@@ -15,8 +15,16 @@ public sealed class FacetAttribute : Attribute
 
     /// <summary>
     /// An array of property or field names to exclude from the generated class.
+    /// This property is mutually exclusive with <see cref="Include"/>.
     /// </summary>
     public string[] Exclude { get; }
+
+    /// <summary>
+    /// An array of property or field names to include in the generated class.
+    /// When specified, only these properties will be included in the facet.
+    /// This property is mutually exclusive with <see cref="Exclude"/>.
+    /// </summary>
+    public string[]? Include { get; set; }
 
     /// <summary>
     /// Whether to include public fields from the source type (default: true).
@@ -95,5 +103,6 @@ public sealed class FacetAttribute : Attribute
     {
         SourceType = sourceType;
         Exclude = exclude ?? Array.Empty<string>();
+        Include = null;
     }
 }

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -41,6 +41,34 @@ public partial struct ProductSummary;
 [Facet(typeof(EventLog), "Source")]
 public partial class EventLogDto;
 
+// Include functionality test DTOs
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email" })]
+public partial class UserIncludeDto;
+
+[Facet(typeof(User), Include = new[] { "FirstName" })]
+public partial class UserSingleIncludeDto;
+
+[Facet(typeof(Product), Include = new[] { "Name", "Price" })]
+public partial class ProductIncludeDto;
+
+[Facet(typeof(Employee), Include = new[] { "FirstName", "LastName", "Department" })]
+public partial class EmployeeIncludeDto;
+
+[Facet(typeof(User), Include = new[] { "FirstName", "LastName" })]
+public partial class UserIncludeWithCustomDto
+{
+    public string FullName { get; set; } = string.Empty;
+}
+
+[Facet(typeof(ModernUser), Include = new[] { "FirstName", "LastName" }, Kind = FacetKind.Record)]
+public partial record ModernUserIncludeDto;
+
+[Facet(typeof(EntityWithFields), Include = new[] { "Name", "Age" }, IncludeFields = true)]
+public partial class EntityWithFieldsIncludeDto;
+
+[Facet(typeof(EntityWithFields), Include = new[] { "Email", "Name", "Age" }, IncludeFields = false)]
+public partial class EntityWithFieldsIncludeNoFieldsDto;
+
 public class UserDtoWithMappingMapper : IFacetMapConfiguration<User, UserDtoWithMapping>
 {
     public static void Map(User source, UserDtoWithMapping target)

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -86,3 +86,12 @@ public sealed class NullableTestEntity
     public string Test3 { get; set; } = string.Empty;
     public string? Test4 { get; set; } = null;
 }
+
+// Test entity with fields for include functionality testing
+public class EntityWithFields
+{
+    public int Id;
+    public string Name = string.Empty;
+    public int Age;
+    public string Email { get; set; } = string.Empty;
+}

--- a/test/Facet.Tests/UnitTests/IncludePropertyTests.cs
+++ b/test/Facet.Tests/UnitTests/IncludePropertyTests.cs
@@ -1,0 +1,247 @@
+using Facet.Tests.TestModels;
+using Facet.Tests.Utilities;
+
+namespace Facet.Tests.UnitTests;
+
+public class IncludePropertyTests
+{
+    [Fact]
+    public void ToFacet_WithInclude_ShouldOnlyIncludeSpecifiedProperties()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe");
+
+        // Act
+        var dto = user.ToFacet<User, UserIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.FirstName.Should().Be("John");
+        dto.LastName.Should().Be("Doe");
+        dto.Email.Should().Be(user.Email);
+        
+        // Verify that excluded properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+        dtoType.GetProperty("DateOfBirth").Should().BeNull("DateOfBirth should not be included");
+        dtoType.GetProperty("Password").Should().BeNull("Password should not be included");
+        dtoType.GetProperty("IsActive").Should().BeNull("IsActive should not be included");
+        dtoType.GetProperty("CreatedAt").Should().BeNull("CreatedAt should not be included");
+        dtoType.GetProperty("LastLoginAt").Should().BeNull("LastLoginAt should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldWorkWithSingleProperty()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("Jane", "Smith");
+
+        // Act
+        var dto = user.ToFacet<User, UserSingleIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.FirstName.Should().Be("Jane");
+        
+        // Verify that all other properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("LastName").Should().BeNull("LastName should not be included");
+        dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldWorkWithProductEntity()
+    {
+        // Arrange
+        var product = TestDataFactory.CreateProduct("Test Product", 99.99m);
+
+        // Act
+        var dto = product.ToFacet<Product, ProductIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Name.Should().Be("Test Product");
+        dto.Price.Should().Be(99.99m);
+        
+        // Verify that excluded properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+        dtoType.GetProperty("Description").Should().BeNull("Description should not be included");
+        dtoType.GetProperty("CategoryId").Should().BeNull("CategoryId should not be included");
+        dtoType.GetProperty("IsAvailable").Should().BeNull("IsAvailable should not be included");
+        dtoType.GetProperty("CreatedAt").Should().BeNull("CreatedAt should not be included");
+        dtoType.GetProperty("InternalNotes").Should().BeNull("InternalNotes should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldPreservePropertyTypes()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("Type", "Test");
+
+        // Act
+        var dto = user.ToFacet<User, UserIncludeDto>();
+
+        // Assert
+        var dtoType = dto.GetType();
+        var firstNameProp = dtoType.GetProperty("FirstName");
+        var lastNameProp = dtoType.GetProperty("LastName");
+        var emailProp = dtoType.GetProperty("Email");
+        
+        firstNameProp.Should().NotBeNull();
+        firstNameProp!.PropertyType.Should().Be(typeof(string));
+        
+        lastNameProp.Should().NotBeNull();
+        lastNameProp!.PropertyType.Should().Be(typeof(string));
+        
+        emailProp.Should().NotBeNull();
+        emailProp!.PropertyType.Should().Be(typeof(string));
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldWorkWithInheritedProperties()
+    {
+        // Arrange
+        var employee = TestDataFactory.CreateEmployee("Include", "Test", "Engineering");
+
+        // Act
+        var dto = employee.ToFacet<Employee, EmployeeIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.FirstName.Should().Be("Include"); // From User base class
+        dto.LastName.Should().Be("Test"); // From User base class
+        dto.Department.Should().Be("Engineering"); // From Employee class
+        
+        // Verify excluded properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+        dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
+        dtoType.GetProperty("EmployeeId").Should().BeNull("EmployeeId should not be included");
+        dtoType.GetProperty("Salary").Should().BeNull("Salary should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_AndCustomProperties_ShouldWork()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("Custom", "Props");
+
+        // Act  
+        var dto = user.ToFacet<User, UserIncludeWithCustomDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.FirstName.Should().Be("Custom");
+        dto.LastName.Should().Be("Props");
+        
+        // Custom property should exist and have default value
+        dto.FullName.Should().Be(string.Empty);
+        
+        // Verify excluded properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldSupportModernRecordTypes()
+    {
+        // Arrange
+        var modernUser = TestDataFactory.CreateModernUser("Modern", "Include");
+
+        // Act
+        var dto = modernUser.ToFacet<ModernUser, ModernUserIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.FirstName.Should().Be("Modern");
+        dto.LastName.Should().Be("Include");
+        
+        // Verify excluded properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+        dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
+        dtoType.GetProperty("CreatedAt").Should().BeNull("CreatedAt should not be included");
+        dtoType.GetProperty("Bio").Should().BeNull("Bio should not be included");
+        dtoType.GetProperty("PasswordHash").Should().BeNull("PasswordHash should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldWorkWithFields_WhenIncludeFieldsIsTrue()
+    {
+        // Arrange  
+        var fieldEntity = new EntityWithFields
+        {
+            Name = "Field Test",
+            Age = 25,
+            Email = "test@test.com",
+            Id = 1
+        };
+
+        // Act
+        var dto = fieldEntity.ToFacet<EntityWithFields, EntityWithFieldsIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Name.Should().Be("Field Test");
+        dto.Age.Should().Be(25);
+        
+        // Verify excluded field is not present
+        var dtoType = dto.GetType();
+        dtoType.GetField("Id").Should().BeNull("Id field should not be included");
+        dtoType.GetProperty("Email").Should().BeNull("Email property should not be included");
+    }
+
+    [Fact] 
+    public void ToFacet_WithInclude_ShouldNotIncludeFields_WhenIncludeFieldsIsFalse()
+    {
+        // This test verifies that IncludeFields defaults to false for include mode
+        // Arrange  
+        var fieldEntity = new EntityWithFields
+        {
+            Name = "Field Test",
+            Age = 25,
+            Email = "test@test.com",
+            Id = 1
+        };
+
+        // Act
+        var dto = fieldEntity.ToFacet<EntityWithFields, EntityWithFieldsIncludeNoFieldsDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Email.Should().Be("test@test.com"); // Property should be included
+        
+        // Verify fields are not included even if specified in include array
+        var dtoType = dto.GetType();
+        dtoType.GetField("Name").Should().BeNull("Name field should not be included when IncludeFields = false");
+        dtoType.GetField("Age").Should().BeNull("Age field should not be included when IncludeFields = false");
+    }
+
+    [Fact]
+    public void BackTo_WithInclude_ShouldCreateSourceWithDefaultValues()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("Back", "To");
+        var dto = user.ToFacet<User, UserIncludeDto>();
+
+        // Act
+        var backToSource = dto.BackTo();
+
+        // Assert
+        backToSource.Should().NotBeNull();
+        backToSource.FirstName.Should().Be("Back");
+        backToSource.LastName.Should().Be("To");
+        backToSource.Email.Should().Be(user.Email);
+        
+        // Properties not included in facet should have default values
+        backToSource.Id.Should().Be(0); // Default for int
+        backToSource.DateOfBirth.Should().Be(default(DateTime));
+        backToSource.Password.Should().Be(string.Empty); // Default for string
+        backToSource.IsActive.Should().BeFalse(); // Default for bool
+        backToSource.CreatedAt.Should().Be(default(DateTime));
+        backToSource.LastLoginAt.Should().BeNull(); // Nullable property
+    }
+}

--- a/test/Facet.Tests/Utilities/TestDataFactory.cs
+++ b/test/Facet.Tests/Utilities/TestDataFactory.cs
@@ -137,4 +137,17 @@ public static class TestDataFactory
             Email = $"{name.Replace(" ", ".").ToLower()}@example.com"
         };
     }
+
+    public static EntityWithFields CreateEntityWithFields(
+        string name = "Test Entity",
+        int age = 25)
+    {
+        return new EntityWithFields
+        {
+            Id = Random.Shared.Next(1, 1000),
+            Name = name,
+            Age = age,
+            Email = $"{name.Replace(" ", ".").ToLower()}@fields.com"
+        };
+    }
 }


### PR DESCRIPTION
Suggested fix for #60 

This adds a constructor for Facet attribute, where the consumer can specify what subset of properties to copy from the source.

So if a Facet is needed where you only grab a few members, you don't need to specify a big `exclude` array, but an `include` array. By default, this overload has `IncludeFields` set to false, whereas for the `exclude` approach we grab all members by default and `IncludeFields` is true.

Usage:

```
// Source type

public class User
{
    public Guid Id { get; set; }

    public string FirstName { get; set ;}

    public string LastName { get; set; }

    public string Email { get; set; }

    public DateTime DateOfBirth { get; set ;}

    public string RandomProperty { get; set; }

    public int NumberOfSomething { get; set; }

    // And so on..
}

// New way of defining your Facet

[Facet(typeof(User), Include = new[] { "FirstName", "LastName", "Email" })]
public partial class UserInfo { }
```  

No breaking changes for existing Facet usages, and Facets generated with the `Include` option are generated correctly. 

Unit tests added to assert new feature works as intended.
