### PR TITLE
Add [SetsRequiredMembers] to GenerateDtos generator. Add #nullable enable directive when applicable

### DIFF
--- a/src/Facet/FacetMember.cs
+++ b/src/Facet/FacetMember.cs
@@ -7,16 +7,18 @@ internal sealed class FacetMember : IEquatable<FacetMember>
     public string Name { get; }
     public string TypeName { get; }
     public FacetMemberKind Kind { get; }
+    public bool IsValueType { get; }
     public bool IsInitOnly { get; }
     public bool IsRequired { get; }
     public bool IsReadOnly { get; }
     public string? XmlDocumentation { get; }
 
-    public FacetMember(string name, string typeName, FacetMemberKind kind, bool isInitOnly = false, bool isRequired = false, bool isReadOnly = false, string? xmlDocumentation = null)
+    public FacetMember(string name, string typeName, FacetMemberKind kind, bool isValueType, bool isInitOnly = false, bool isRequired = false, bool isReadOnly = false, string? xmlDocumentation = null)
     {
         Name = name;
         TypeName = typeName;
         Kind = kind;
+        IsValueType = isValueType;
         IsInitOnly = isInitOnly;
         IsRequired = isRequired;
         IsReadOnly = isReadOnly;

--- a/src/Facet/Generators/FacetGenerator.cs
+++ b/src/Facet/Generators/FacetGenerator.cs
@@ -138,6 +138,7 @@ public sealed class FacetGenerator : IIncrementalGenerator
                             p.Name,
                             GeneratorUtilities.GetTypeNameWithNullability(p.Type),
                             FacetMemberKind.Property,
+                            p.Type.IsValueType,
                             isInitOnly,
                             isRequired,
                             false, // Properties are not readonly
@@ -159,6 +160,7 @@ public sealed class FacetGenerator : IIncrementalGenerator
                     p.Name,
                     typeName,
                     FacetMemberKind.Property,
+                    p.Type.IsValueType,
                     shouldPreserveInitOnly,
                     shouldPreserveRequired,
                     false, // Properties are not readonly
@@ -178,6 +180,7 @@ public sealed class FacetGenerator : IIncrementalGenerator
                             f.Name,
                             GeneratorUtilities.GetTypeNameWithNullability(f.Type),
                             FacetMemberKind.Field,
+                            f.Type.IsValueType,
                             false, // Fields don't have init-only
                             isRequired,
                             f.IsReadOnly, // Fields can be readonly
@@ -198,6 +201,7 @@ public sealed class FacetGenerator : IIncrementalGenerator
                     f.Name,
                     typeName,
                     FacetMemberKind.Field,
+                    f.Type.IsValueType,
                     false, // Fields don't have init-only
                     shouldPreserveRequired,
                     f.IsReadOnly, // Fields can be readonly
@@ -512,8 +516,8 @@ public sealed class FacetGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         // Nullable must be enabled in generated code with a directive
-        var hasNullableProperties = model.Members.Any(m => m.TypeName.EndsWith("?"));
-        if (hasNullableProperties)
+        var hasNullableRefTypeMembers = model.Members.Any(m => !m.IsValueType && m.TypeName.EndsWith("?"));
+        if (hasNullableRefTypeMembers)
         {
             sb.AppendLine("#nullable enable");
             sb.AppendLine();
@@ -743,10 +747,10 @@ public sealed class FacetGenerator : IIncrementalGenerator
             ctorSig += $" : this({args})";
         }
 
-		if (hasRequiredProperties)
-		{
-			sb.AppendLine("    [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
-		}
+        if (hasRequiredProperties)
+        {
+            sb.AppendLine("    [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
+        }
         sb.AppendLine($"    {ctorSig}");
         sb.AppendLine("    {");
 


### PR DESCRIPTION
Adds the [SetsRequiredMembers] attribute to the generate dtos generator constructors (missed this generator in my last PR)

Adds `#nullable enable` to generated files when applicable. Currently if your generated type has nullable reference type members in it, you will get this compiler warning: `warning CS8669: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. Auto-generated code requires an explicit '#nullable' directive in source.`