### PR TITLE
Fix: Complex structures hierarchy

### DIFF
--- a/src/Facet/FacetAttribute.cs
+++ b/src/Facet/FacetAttribute.cs
@@ -113,10 +113,10 @@ public sealed class FacetAttribute : Attribute
     /// limit how deep nested facets can be instantiated to prevent stack overflow with circular references.
     /// A value of 0 means unlimited depth (not recommended - can cause stack overflow).
     /// A value of 1 allows one level of nesting, 2 allows two levels, etc.
-    /// Default is 3, which handles most real-world scenarios (e.g., Order -> LineItems -> Product -> Category).
+    /// Default is 10, which handles most real-world scenarios including deep non-circular nesting.
     /// Set to 0 to disable (use with caution), or increase if you need deeper nesting.
     /// </summary>
-    public int MaxDepth { get; set; } = 3;
+    public int MaxDepth { get; set; } = 10;
 
     /// <summary>
     /// When true, the generator will track object references during facet construction to prevent

--- a/src/Facet/Generators/ConstructorGenerator.cs
+++ b/src/Facet/Generators/ConstructorGenerator.cs
@@ -233,13 +233,6 @@ internal static class ConstructorGenerator
         sb.AppendLine($"    {ctorSig}");
         sb.AppendLine("    {");
 
-        // Add source object to processed set if using reference tracking
-        if (model.PreserveReferences)
-        {
-            sb.AppendLine("        __processed?.Add(source);");
-            sb.AppendLine();
-        }
-
         if (!isPositional && !model.HasExistingPrimaryConstructor)
         {
             GenerateDepthAwareConstructorBody(sb, model, hasInitOnlyProperties, hasCustomMapping);

--- a/src/Facet/Generators/FacetConstants.cs
+++ b/src/Facet/Generators/FacetConstants.cs
@@ -34,7 +34,7 @@ internal static class FacetConstants
     /// <summary>
     /// The default maximum depth for nested facet traversal to prevent stack overflow.
     /// </summary>
-    public const int DefaultMaxDepth = 3;
+    public const int DefaultMaxDepth = 10;
 
     /// <summary>
     /// The default setting for preserving object references during mapping to detect circular references.


### PR DESCRIPTION
Fixes #131 and more related bugfixes

The bug was that objects were being added to the `__processed` HashSet AFTER their children were constructed, which mean circular references weren't properly detected and so they interfered with the `MaxDepth` value, which was already low when defaulted.

Also increased the default value to 10, which I believe covers 99.999% of model structures I've seen in my lifetime :) 

The fixe also ensures that `PreserveReferences` now works correctly to prevent infinite recursion while allowing legitimate deep nesting up to the actual `MaxDepth` value.

Thanks [kwpbartecautoid](https://github.com/kwpbartecautoid) for your valuable feedback and issue reports. 