### PR TITLE
Handle classes in global namespace

### DIFF
--- a/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
@@ -321,7 +321,14 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
 
     private static string GetSimpleTypeName(string fullyQualifiedName)
     {
-        var parts = fullyQualifiedName.Split('.');
+        // remove global:: prefix if present (for types in global namespace)
+        var name = fullyQualifiedName;
+        if (name.StartsWith("global::"))
+        {
+            name = name.Substring(8);
+        }
+
+        var parts = name.Split('.');
         return parts[parts.Length - 1];
     }
 

--- a/test/Facet.Tests/TestModels/GlobalNamespaceTestEntities.cs
+++ b/test/Facet.Tests/TestModels/GlobalNamespaceTestEntities.cs
@@ -1,0 +1,22 @@
+using Facet;
+
+[GenerateDtos(Types = DtoTypes.All, OutputType = OutputType.Record)]
+public class TestGlobalNamespaceEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime LastUpdatedAt { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+}
+
+[GenerateAuditableDtos(Types = DtoTypes.All, OutputType = OutputType.Class)]
+public class TestGlobalAuditableEntity
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+}


### PR DESCRIPTION
fixes #140 

The `GetSimpleTypeName` method in `GenerateDtosGenerator` wasn't handling the `global:: prefix` that appears in fully qualified type names for classses without a namespace

Updated the generator strip that prefix before the split happens.

Added some test classes in the unit test project, since all test models were in inside a namespace so this bug was never caught.

