### PR TITLE
FIx facets sourced from static class

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -18,6 +18,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public bool GenerateExpressionProjection { get; }
     public bool GenerateBackTo { get; }
     public string SourceTypeName { get; }
+    public ImmutableArray<string> SourceContainingTypes { get; }
     public string? ConfigurationTypeName { get; }
     public ImmutableArray<FacetMember> Members { get; }
     public bool HasExistingPrimaryConstructor { get; }
@@ -42,6 +43,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         bool generateExpressionProjection,
         bool generateBackTo,
         string sourceTypeName,
+        ImmutableArray<string> sourceContainingTypes,
         string? configurationTypeName,
         ImmutableArray<FacetMember> members,
         bool hasExistingPrimaryConstructor = false,
@@ -65,6 +67,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         GenerateExpressionProjection = generateExpressionProjection;
         GenerateBackTo = generateBackTo;
         SourceTypeName = sourceTypeName;
+        SourceContainingTypes = sourceContainingTypes.IsDefault ? ImmutableArray<string>.Empty : sourceContainingTypes;
         ConfigurationTypeName = configurationTypeName;
         Members = members;
         HasExistingPrimaryConstructor = hasExistingPrimaryConstructor;
@@ -93,6 +96,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && GenerateParameterlessConstructor == other.GenerateParameterlessConstructor
             && GenerateExpressionProjection == other.GenerateExpressionProjection
             && SourceTypeName == other.SourceTypeName
+            && SourceContainingTypes.SequenceEqual(other.SourceContainingTypes)
             && ConfigurationTypeName == other.ConfigurationTypeName
             && HasExistingPrimaryConstructor == other.HasExistingPrimaryConstructor
             && SourceHasPositionalConstructor == other.SourceHasPositionalConstructor
@@ -139,6 +143,9 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
 
             foreach (var containingType in ContainingTypes)
                 hash = hash * 31 + (containingType?.GetHashCode() ?? 0);
+
+            foreach (var sourceContainingType in SourceContainingTypes)
+                hash = hash * 31 + (sourceContainingType?.GetHashCode() ?? 0);
 
             foreach (var excludedMember in ExcludedRequiredMembers)
                 hash = hash * 31 + excludedMember.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -22,11 +22,21 @@ internal static class CodeBuilder
         // Collect all namespaces from referenced types
         var namespacesToImport = CodeGenerationHelpers.CollectNamespaces(model);
 
+        // Collect types that need 'using static' directives
+        var staticUsingTypes = CodeGenerationHelpers.CollectStaticUsingTypes(model);
+
         // Generate using statements for all required namespaces
         foreach (var ns in namespacesToImport.OrderBy(x => x))
         {
             sb.AppendLine($"using {ns};");
         }
+
+        // Generate using static statements for types nested in other types
+        foreach (var type in staticUsingTypes.OrderBy(x => x))
+        {
+            sb.AppendLine($"using static {type};");
+        }
+
         sb.AppendLine();
 
         // Nullable must be enabled in generated code with a directive

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -86,6 +86,9 @@ internal static class ModelBuilder
         // Get containing types for nested classes
         var containingTypes = TypeAnalyzer.GetContainingTypes(targetSymbol);
 
+        // Get containing types for the source type (to detect nesting in static classes)
+        var sourceContainingTypes = TypeAnalyzer.GetContainingTypes(sourceType);
+
         // Check if the target type already has a primary constructor
         var hasExistingPrimaryConstructor = TypeAnalyzer.HasExistingPrimaryConstructor(targetSymbol);
 
@@ -103,6 +106,7 @@ internal static class ModelBuilder
             generateProjection,
             generateBackTo,
             sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            sourceContainingTypes,
             configurationTypeName,
             members,
             hasExistingPrimaryConstructor,

--- a/test/Facet.Tests/TestModels/StaticClassTestModels.cs
+++ b/test/Facet.Tests/TestModels/StaticClassTestModels.cs
@@ -1,0 +1,17 @@
+namespace Application.Example1
+{
+    public static class Foo
+    {
+        public sealed record Bar
+        {
+            public string Name { get; set; } = string.Empty;
+            public int Value { get; set; }
+        }
+    }
+}
+
+namespace Facet.Tests.TestModels.StaticClassTest
+{
+    [Facet.Facet(typeof(Application.Example1.Foo.Bar))]
+    public sealed partial record BarDto;
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/StaticClassNestedTypeTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/StaticClassNestedTypeTests.cs
@@ -1,0 +1,47 @@
+using Facet.Tests.TestModels.StaticClassTest;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// Tests for issue #145: Generator fails to create static imports
+/// </summary>
+public class StaticClassNestedTypeTests
+{
+    [Fact]
+    public void Facet_ShouldGenerateCorrectly_WhenSourceTypeIsNestedInStaticClass()
+    {
+        // Arrange
+        var bar = new Application.Example1.Foo.Bar
+        {
+            Name = "Test",
+            Value = 42
+        };
+
+        // Act
+        var dto = new BarDto(bar);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Name.Should().Be("Test");
+        dto.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Facet_ShouldMap_WhenSourceTypeIsNestedInStaticClass()
+    {
+        // Arrange
+        var bar = new Application.Example1.Foo.Bar
+        {
+            Name = "Test",
+            Value = 42
+        };
+
+        // Act
+        var dto = bar.ToFacet<Application.Example1.Foo.Bar, BarDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Name.Should().Be("Test");
+        dto.Value.Should().Be(42);
+    }
+}


### PR DESCRIPTION
Fixes #145 

When a facet source type was nested within a static class the generator was creating incorrect usings.

Fixed this issue + added unit tests