### PR TITLE
Complete Roslyn analyzers

### DIFF
--- a/docs/13_AnalyzerRules.md
+++ b/docs/13_AnalyzerRules.md
@@ -1,0 +1,662 @@
+# Facet Analyzer Rules
+
+Facet includes comprehensive Roslyn analyzers that provide real-time feedback in your IDE. These analyzers catch common mistakes and configuration issues at design-time, before you even compile your code.
+
+## Quick Reference
+
+| Rule ID | Severity | Category | Description |
+|---------|----------|----------|-------------|
+| [FAC001](#fac001) | Error | Usage | Type must be annotated with [Facet] |
+| [FAC002](#fac002) | Info | Performance | Consider using two-generic variant |
+| [FAC003](#fac003) | Error | Declaration | Missing partial keyword on [Facet] type |
+| [FAC004](#fac004) | Error | Usage | Invalid property name in Exclude/Include |
+| [FAC005](#fac005) | Error | Usage | Invalid source type |
+| [FAC006](#fac006) | Error | Usage | Invalid Configuration type |
+| [FAC007](#fac007) | Warning | Usage | Invalid NestedFacets type |
+| [FAC008](#fac008) | Warning | Performance | Circular reference risk |
+| [FAC009](#fac009) | Error | Usage | Both Include and Exclude specified |
+| [FAC010](#fac010) | Warning | Performance | Unusual MaxDepth value |
+| [FAC011](#fac011) | Error | Usage | [GenerateDtos] on non-class type |
+| [FAC012](#fac012) | Warning | Usage | Invalid ExcludeProperties |
+| [FAC013](#fac013) | Warning | Usage | No DTO types selected |
+| [FAC014](#fac014) | Error | Declaration | Missing partial keyword on [Flatten] type |
+| [FAC015](#fac015) | Error | Usage | Invalid source type in [Flatten] |
+| [FAC016](#fac016) | Warning | Performance | Unusual MaxDepth in [Flatten] |
+| [FAC017](#fac017) | Info | Usage | LeafOnly naming collision risk |
+
+---
+
+## Extension Method Analyzers
+
+### FAC001
+
+**Type must be annotated with [Facet]**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+When using extension methods like `ToFacet<T>()`, `BackTo<T>()`, `SelectFacet<T>()`, etc., the target type must be annotated with the `[Facet]` attribute.
+
+#### Bad Code
+
+```csharp
+// UserDto does NOT have [Facet] attribute
+public class UserDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+
+var dto = user.ToFacet<User, UserDto>(); // ❌ FAC001
+```
+
+#### Good Code
+
+```csharp
+[Facet(typeof(User))]
+public partial class UserDto { }
+
+var dto = user.ToFacet<User, UserDto>(); // ✅ OK
+```
+
+---
+
+### FAC002
+
+**Consider using the two-generic variant for better performance**
+
+- **Severity**: Info
+- **Category**: Performance
+
+#### Description
+
+When using single-generic extension methods like `ToFacet<TTarget>()`, the library uses reflection to discover the source type. For better performance, use the two-generic variant `ToFacet<TSource, TTarget>()`.
+
+#### Code Triggering Warning
+
+```csharp
+var dto = user.ToFacet<UserDto>(); // ℹ️ FAC002: Consider ToFacet<User, UserDto>()
+```
+
+#### Recommended Code
+
+```csharp
+var dto = user.ToFacet<User, UserDto>(); // ✅ Better performance
+```
+
+#### Impact
+
+The performance difference is minimal (a few nanoseconds) but can add up in tight loops or high-throughput scenarios.
+
+---
+
+## [Facet] Attribute Analyzers
+
+### FAC003
+
+**Type with [Facet] attribute must be declared as partial**
+
+- **Severity**: Error
+- **Category**: Declaration
+
+#### Description
+
+Source generators require types to be `partial` so they can add generated members. Any type marked with `[Facet]` must be declared as `partial`.
+
+#### Bad Code
+
+```csharp
+[Facet(typeof(User))]
+public class UserDto { } // ❌ FAC003: Missing 'partial' keyword
+```
+
+#### Good Code
+
+```csharp
+[Facet(typeof(User))]
+public partial class UserDto { } // ✅ OK
+```
+
+---
+
+### FAC004
+
+**Property name does not exist in source type**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+Property names specified in `Exclude` or `Include` parameters must exist in the source type.
+
+#### Bad Code
+
+```csharp
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+
+[Facet(typeof(User), "PasswordHash")] // ❌ FAC004: User doesn't have PasswordHash
+public partial class UserDto { }
+```
+
+#### Good Code
+
+```csharp
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string PasswordHash { get; set; }
+}
+
+[Facet(typeof(User), "PasswordHash")] // ✅ OK
+public partial class UserDto { }
+```
+
+---
+
+### FAC005
+
+**Source type is not accessible or does not exist**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+The source type specified in the `[Facet]` attribute must be a valid, accessible type.
+
+#### Bad Code
+
+```csharp
+[Facet(typeof(NonExistentType))] // ❌ FAC005
+public partial class UserDto { }
+```
+
+#### Good Code
+
+```csharp
+[Facet(typeof(User))] // ✅ OK
+public partial class UserDto { }
+```
+
+---
+
+### FAC006
+
+**Configuration type does not implement required interface**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+Configuration types must implement `IFacetMapConfiguration<TSource, TTarget>`, `IFacetMapConfigurationAsync<TSource, TTarget>`, or provide a static `Map` method.
+
+#### Bad Code
+
+```csharp
+public class UserMapper // ❌ No interface, no Map method
+{
+    public void DoSomething(User source, UserDto target) { }
+}
+
+[Facet(typeof(User), Configuration = typeof(UserMapper))] // ❌ FAC006
+public partial class UserDto { }
+```
+
+#### Good Code
+
+```csharp
+// Option 1: Implement interface
+public class UserMapper : IFacetMapConfiguration<User, UserDto>
+{
+    public static void Map(User source, UserDto target)
+    {
+        target.FullName = $"{source.FirstName} {source.LastName}";
+    }
+}
+
+// Option 2: Provide static Map method
+public class UserMapper
+{
+    public static void Map(User source, UserDto target)
+    {
+        target.FullName = $"{source.FirstName} {source.LastName}";
+    }
+}
+
+[Facet(typeof(User), Configuration = typeof(UserMapper))] // ✅ OK
+public partial class UserDto { }
+```
+
+---
+
+### FAC007
+
+**Nested facet type is not marked with [Facet] attribute**
+
+- **Severity**: Warning
+- **Category**: Usage
+
+#### Description
+
+All types specified in the `NestedFacets` array must be marked with the `[Facet]` attribute.
+
+#### Bad Code
+
+```csharp
+public class AddressDto { } // ❌ Missing [Facet] attribute
+
+[Facet(typeof(User), NestedFacets = [typeof(AddressDto)])] // ⚠️ FAC007
+public partial class UserDto { }
+```
+
+#### Good Code
+
+```csharp
+[Facet(typeof(Address))]
+public partial class AddressDto { }
+
+[Facet(typeof(User), NestedFacets = [typeof(AddressDto)])] // ✅ OK
+public partial class UserDto { }
+```
+
+---
+
+### FAC008
+
+**Potential stack overflow with circular references**
+
+- **Severity**: Warning
+- **Category**: Performance
+
+#### Description
+
+When `MaxDepth` is set to 0 (unlimited) and `PreserveReferences` is `false`, circular references in object graphs can cause stack overflow exceptions.
+
+#### Bad Code
+
+```csharp
+[Facet(typeof(User),
+    MaxDepth = 0,
+    PreserveReferences = false,
+    NestedFacets = [typeof(CompanyDto)])] // ⚠️ FAC008
+public partial class UserDto { }
+```
+
+#### Good Code
+
+```csharp
+// Option 1: Enable PreserveReferences (default)
+[Facet(typeof(User),
+    NestedFacets = [typeof(CompanyDto)])] // ✅ OK (PreserveReferences defaults to true)
+
+// Option 2: Set MaxDepth limit
+[Facet(typeof(User),
+    MaxDepth = 5,
+    NestedFacets = [typeof(CompanyDto)])] // ✅ OK
+
+// Option 3: Both
+[Facet(typeof(User),
+    MaxDepth = 10,
+    PreserveReferences = true,
+    NestedFacets = [typeof(CompanyDto)])] // ✅ OK (safest)
+```
+
+---
+
+### FAC009
+
+**Cannot specify both Include and Exclude**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+The `Include` and `Exclude` parameters are mutually exclusive. Use either `Include` to whitelist properties or `Exclude` to blacklist properties, but not both.
+
+#### Bad Code
+
+```csharp
+[Facet(typeof(User),
+    "PasswordHash",  // Exclude parameter
+    Include = ["Id", "Name"])] // ❌ FAC009: Can't use both
+public partial class UserDto { }
+```
+
+#### Good Code
+
+```csharp
+// Option 1: Exclude approach
+[Facet(typeof(User), "PasswordHash", "SecretKey")] // ✅ OK
+public partial class UserDto { }
+
+// Option 2: Include approach
+[Facet(typeof(User), Include = ["Id", "Name", "Email"])] // ✅ OK
+public partial class UserDto { }
+```
+
+---
+
+### FAC010
+
+**MaxDepth value is unusual**
+
+- **Severity**: Warning
+- **Category**: Performance
+
+#### Description
+
+MaxDepth values should typically be between 1 and 10 for most scenarios. Negative values are invalid, and values above 100 may indicate a configuration error.
+
+#### Code Triggering Warning
+
+```csharp
+[Facet(typeof(User), MaxDepth = -1)] // ⚠️ FAC010: Negative
+[Facet(typeof(User), MaxDepth = 500)] // ⚠️ FAC010: Too large
+```
+
+#### Good Code
+
+```csharp
+[Facet(typeof(User), MaxDepth = 5)] // ✅ OK
+[Facet(typeof(User), MaxDepth = 10)] // ✅ OK (default)
+```
+
+---
+
+## [GenerateDtos] Attribute Analyzers
+
+### FAC011
+
+**[GenerateDtos] can only be applied to classes**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+The `[GenerateDtos]` and `[GenerateAuditableDtos]` attributes are designed for class types and cannot be applied to structs, interfaces, or other type kinds.
+
+#### Bad Code
+
+```csharp
+[GenerateDtos(DtoTypes.All)]
+public struct Product { } // ❌ FAC011: Can't use on struct
+```
+
+#### Good Code
+
+```csharp
+[GenerateDtos(DtoTypes.All)]
+public class Product { } // ✅ OK
+```
+
+---
+
+### FAC012
+
+**Excluded property does not exist**
+
+- **Severity**: Warning
+- **Category**: Usage
+
+#### Description
+
+Properties specified in `ExcludeProperties` should exist in the source type.
+
+#### Bad Code
+
+```csharp
+public class Product
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+
+[GenerateDtos(DtoTypes.All,
+    ExcludeProperties = ["InternalNotes"])] // ⚠️ FAC012: Doesn't exist
+public class Product { }
+```
+
+#### Good Code
+
+```csharp
+public class Product
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string InternalNotes { get; set; }
+}
+
+[GenerateDtos(DtoTypes.All,
+    ExcludeProperties = ["InternalNotes"])] // ✅ OK
+public class Product { }
+```
+
+---
+
+### FAC013
+
+**No DTO types selected for generation**
+
+- **Severity**: Warning
+- **Category**: Usage
+
+#### Description
+
+Setting `Types` to `DtoTypes.None` will not generate any DTOs.
+
+#### Bad Code
+
+```csharp
+[GenerateDtos(Types = DtoTypes.None)] // ⚠️ FAC013: No DTOs will be generated
+public class Product { }
+```
+
+#### Good Code
+
+```csharp
+[GenerateDtos(Types = DtoTypes.All)] // ✅ OK
+public class Product { }
+
+// Or specify specific types
+[GenerateDtos(Types = DtoTypes.Create | DtoTypes.Update | DtoTypes.Response)]
+public class Product { }
+```
+
+---
+
+## [Flatten] Attribute Analyzers
+
+### FAC014
+
+**Type with [Flatten] attribute must be declared as partial**
+
+- **Severity**: Error
+- **Category**: Declaration
+
+#### Description
+
+Similar to `[Facet]`, types marked with `[Flatten]` must be `partial`.
+
+#### Bad Code
+
+```csharp
+[Flatten(typeof(Person))]
+public class PersonFlat { } // ❌ FAC014
+```
+
+#### Good Code
+
+```csharp
+[Flatten(typeof(Person))]
+public partial class PersonFlat { } // ✅ OK
+```
+
+---
+
+### FAC015
+
+**Source type is not accessible or does not exist**
+
+- **Severity**: Error
+- **Category**: Usage
+
+#### Description
+
+The source type specified in the `[Flatten]` attribute must be valid and accessible.
+
+#### Bad Code
+
+```csharp
+[Flatten(typeof(NonExistentType))] // ❌ FAC015
+public partial class PersonFlat { }
+```
+
+#### Good Code
+
+```csharp
+[Flatten(typeof(Person))] // ✅ OK
+public partial class PersonFlat { }
+```
+
+---
+
+### FAC016
+
+**MaxDepth value is unusual**
+
+- **Severity**: Warning
+- **Category**: Performance
+
+#### Description
+
+For flatten scenarios, MaxDepth values should typically be between 1 and 5. Values above 10 may cause excessive property generation.
+
+#### Code Triggering Warning
+
+```csharp
+[Flatten(typeof(Person), MaxDepth = -1)] // ⚠️ FAC016: Negative
+[Flatten(typeof(Person), MaxDepth = 50)] // ⚠️ FAC016: Too large
+```
+
+#### Good Code
+
+```csharp
+[Flatten(typeof(Person), MaxDepth = 3)] // ✅ OK (default)
+[Flatten(typeof(Person), MaxDepth = 5)] // ✅ OK
+```
+
+---
+
+### FAC017
+
+**LeafOnly naming strategy may cause property name collisions**
+
+- **Severity**: Info
+- **Category**: Usage
+
+#### Description
+
+Using `FlattenNamingStrategy.LeafOnly` can cause name collisions when multiple nested objects have properties with the same name. Consider using the `Prefix` strategy instead.
+
+#### Code Triggering Warning
+
+```csharp
+[Flatten(typeof(Person),
+    NamingStrategy = FlattenNamingStrategy.LeafOnly)] // ℹ️ FAC017
+public partial class PersonFlat { }
+```
+
+#### Potential Issue
+
+```csharp
+public class Person
+{
+    public Address HomeAddress { get; set; }
+    public Address WorkAddress { get; set; }
+}
+
+public class Address
+{
+    public string Street { get; set; }
+    public string City { get; set; }
+}
+
+// With LeafOnly, both addresses map to "Street" and "City" → collision!
+```
+
+#### Recommended Code
+
+```csharp
+[Flatten(typeof(Person),
+    NamingStrategy = FlattenNamingStrategy.Prefix)] // ✅ Better
+public partial class PersonFlat { }
+
+// Generates: HomeAddressStreet, HomeAddressCity, WorkAddressStreet, WorkAddressCity
+```
+
+---
+
+## Suppressing Analyzer Rules
+
+If you need to suppress a specific analyzer rule, you can use:
+
+### In Code
+
+```csharp
+#pragma warning disable FAC002
+var dto = user.ToFacet<UserDto>();
+#pragma warning restore FAC002
+```
+
+### In .editorconfig
+
+```ini
+[*.cs]
+dotnet_diagnostic.FAC002.severity = none
+```
+
+### For Entire Project
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);FAC002</NoWarn>
+</PropertyGroup>
+```
+
+---
+
+## Configuration
+
+All analyzers are enabled by default. You can configure their severity in your `.editorconfig` file:
+
+```ini
+[*.cs]
+
+# Set a rule to error
+dotnet_diagnostic.FAC007.severity = error
+
+# Set a rule to warning
+dotnet_diagnostic.FAC002.severity = warning
+
+# Disable a rule
+dotnet_diagnostic.FAC017.severity = none
+```
+
+---
+
+## See Also
+
+- [Attribute Reference](03_AttributeReference.md)
+- [Custom Mapping](04_CustomMapping.md)
+- [Advanced Scenarios](06_AdvancedScenarios.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Welcome to the Facet documentation! This index will help you navigate all availa
 - [GenerateDtos Attribute](09_GenerateDtosAttribute.md): Auto-generate CRUD DTOs with GenerateDtos & GenerateAuditableDtos
 - [Expression Mapping](10_ExpressionMapping.md): Transform business logic expressions between entities and DTOs with Facet.Mapping.Expressions
 - [Flatten Attribute](11_FlattenAttribute.md): Automatically flatten nested objects into top-level properties for API responses and reports
+- [Analyzer Rules](13_AnalyzerRules.md): Complete guide to Facet's Roslyn analyzers and diagnostic rules
+
 - [Facet.Extensions.EFCore](../src/Facet.Extensions.EFCore/README.md): EF Core Async Extension Methods
 - [Facet.Mapping Reference](../src/Facet.Mapping/README.md): Complete Facet.Mapping Documentation
 - [Facet.Mapping.Expressions Reference](../src/Facet.Mapping.Expressions/README.md): Complete Expression Mapping Documentation

--- a/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
@@ -1,0 +1,390 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Facet.Analyzers;
+
+/// <summary>
+/// Analyzer that validates proper usage of the [Facet] attribute.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class FacetAttributeAnalyzer : DiagnosticAnalyzer
+{
+    // FAC003: Missing partial keyword
+    public static readonly DiagnosticDescriptor MissingPartialKeywordRule = new DiagnosticDescriptor(
+        "FAC003",
+        "Type with [Facet] attribute must be declared as partial",
+        "Type '{0}' is marked with [Facet] but is not declared as partial",
+        "Declaration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Types marked with [Facet] must be partial to allow the source generator to add generated members.");
+
+    // FAC004: Invalid Exclude/Include property names
+    public static readonly DiagnosticDescriptor InvalidPropertyNameRule = new DiagnosticDescriptor(
+        "FAC004",
+        "Property name does not exist in source type",
+        "Property '{0}' in {1} does not exist in source type '{2}'",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Property names in Exclude or Include parameters must match properties in the source type.");
+
+    // FAC005: Invalid source type
+    public static readonly DiagnosticDescriptor InvalidSourceTypeRule = new DiagnosticDescriptor(
+        "FAC005",
+        "Source type is not accessible or does not exist",
+        "Source type '{0}' could not be resolved or is not accessible",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The source type specified in the [Facet] attribute must be a valid, accessible type.");
+
+    // FAC006: Invalid Configuration type
+    public static readonly DiagnosticDescriptor InvalidConfigurationTypeRule = new DiagnosticDescriptor(
+        "FAC006",
+        "Configuration type does not implement required interface",
+        "Configuration type '{0}' must implement IFacetMapConfiguration or have a static Map method",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Configuration types must implement the appropriate IFacetMapConfiguration interface or provide a static Map method.");
+
+    // FAC007: Invalid NestedFacets type
+    public static readonly DiagnosticDescriptor InvalidNestedFacetRule = new DiagnosticDescriptor(
+        "FAC007",
+        "Nested facet type is not marked with [Facet] attribute",
+        "Type '{0}' in NestedFacets must be marked with [Facet] attribute",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "All types specified in the NestedFacets array must be marked with the [Facet] attribute.");
+
+    // FAC008: Circular reference warning
+    public static readonly DiagnosticDescriptor CircularReferenceWarningRule = new DiagnosticDescriptor(
+        "FAC008",
+        "Potential stack overflow with circular references",
+        "MaxDepth is 0 and PreserveReferences is false, which may cause stack overflow",
+        "Performance",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When working with nested facets, either MaxDepth or PreserveReferences should be enabled to prevent stack overflow.");
+
+    // FAC009: Both Include and Exclude specified
+    public static readonly DiagnosticDescriptor IncludeAndExcludeBothSpecifiedRule = new DiagnosticDescriptor(
+        "FAC009",
+        "Cannot specify both Include and Exclude",
+        "Cannot specify both Include and Exclude parameters",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The Include and Exclude parameters are mutually exclusive.");
+
+    // FAC010: MaxDepth warning
+    public static readonly DiagnosticDescriptor MaxDepthWarningRule = new DiagnosticDescriptor(
+        "FAC010",
+        "MaxDepth value is unusual",
+        "MaxDepth is set to {0}: {1}",
+        "Performance",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "MaxDepth values should typically be between 1 and 10 for most scenarios.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        MissingPartialKeywordRule,
+        InvalidPropertyNameRule,
+        InvalidSourceTypeRule,
+        InvalidConfigurationTypeRule,
+        InvalidNestedFacetRule,
+        CircularReferenceWarningRule,
+        IncludeAndExcludeBothSpecifiedRule,
+        MaxDepthWarningRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+
+        // Find all [Facet] attributes on this type
+        var facetAttributes = namedType.GetAttributes()
+            .Where(attr => attr.AttributeClass?.ToDisplayString() == "Facet.FacetAttribute")
+            .ToList();
+
+        if (!facetAttributes.Any())
+            return;
+
+        // Check if type is partial
+        if (!IsPartialType(namedType))
+        {
+            var diagnostic = Diagnostic.Create(
+                MissingPartialKeywordRule,
+                namedType.Locations.FirstOrDefault(),
+                namedType.Name);
+            context.ReportDiagnostic(diagnostic);
+        }
+
+        // Analyze each [Facet] attribute
+        foreach (var facetAttr in facetAttributes)
+        {
+            AnalyzeFacetAttribute(context, namedType, facetAttr);
+        }
+    }
+
+    private static void AnalyzeFacetAttribute(SymbolAnalysisContext context, INamedTypeSymbol targetType, AttributeData facetAttr)
+    {
+        // Get the source type (first constructor argument)
+        if (facetAttr.ConstructorArguments.Length == 0)
+            return;
+
+        var sourceTypeArg = facetAttr.ConstructorArguments[0];
+        if (sourceTypeArg.Value is not INamedTypeSymbol sourceType)
+        {
+            // Invalid source type
+            var diagnostic = Diagnostic.Create(
+                InvalidSourceTypeRule,
+                facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                sourceTypeArg.ToCSharpString());
+            context.ReportDiagnostic(diagnostic);
+            return;
+        }
+
+        // Check if source type is accessible
+        if (sourceType.TypeKind == TypeKind.Error)
+        {
+            var diagnostic = Diagnostic.Create(
+                InvalidSourceTypeRule,
+                facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                sourceType.ToDisplayString());
+            context.ReportDiagnostic(diagnostic);
+            return;
+        }
+
+        // Get all public properties/fields from source type
+        var sourceMembers = new HashSet<string>(sourceType.GetMembers()
+            .Where(m => m.DeclaredAccessibility == Accessibility.Public &&
+                       (m.Kind == SymbolKind.Property || m.Kind == SymbolKind.Field))
+            .Select(m => m.Name));
+
+        // Check Exclude parameter (constructor parameter)
+        if (facetAttr.ConstructorArguments.Length > 1)
+        {
+            var excludeArg = facetAttr.ConstructorArguments[1];
+            if (!excludeArg.IsNull && excludeArg.Kind == TypedConstantKind.Array)
+            {
+                foreach (var item in excludeArg.Values)
+                {
+                    if (item.Value is string propertyName && !string.IsNullOrEmpty(propertyName))
+                    {
+                        if (!sourceMembers.Contains(propertyName))
+                        {
+                            ReportInvalidPropertyName(context, facetAttr, propertyName, "Exclude", sourceType, sourceMembers);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check named arguments
+        var includeArg = facetAttr.NamedArguments.FirstOrDefault(a => a.Key == "Include");
+        var configurationArg = facetAttr.NamedArguments.FirstOrDefault(a => a.Key == "Configuration");
+        var nestedFacetsArg = facetAttr.NamedArguments.FirstOrDefault(a => a.Key == "NestedFacets");
+        var maxDepthArg = facetAttr.NamedArguments.FirstOrDefault(a => a.Key == "MaxDepth");
+        var preserveReferencesArg = facetAttr.NamedArguments.FirstOrDefault(a => a.Key == "PreserveReferences");
+
+        // Check Include parameter
+        if (!includeArg.Equals(default) && !includeArg.Value.IsNull && includeArg.Value.Kind == TypedConstantKind.Array)
+        {
+            // Check if both Include and Exclude are specified
+            bool hasExclude = facetAttr.ConstructorArguments.Length > 1 &&
+                             !facetAttr.ConstructorArguments[1].IsNull &&
+                             facetAttr.ConstructorArguments[1].Values.Length > 0;
+
+            if (hasExclude)
+            {
+                var diagnostic = Diagnostic.Create(
+                    IncludeAndExcludeBothSpecifiedRule,
+                    facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+
+            foreach (var item in includeArg.Value.Values)
+            {
+                if (item.Value is string propertyName && !string.IsNullOrEmpty(propertyName))
+                {
+                    if (!sourceMembers.Contains(propertyName))
+                    {
+                        ReportInvalidPropertyName(context, facetAttr, propertyName, "Include", sourceType, sourceMembers);
+                    }
+                }
+            }
+        }
+
+        // Check Configuration type
+        if (!configurationArg.Equals(default) && !configurationArg.Value.IsNull)
+        {
+            if (configurationArg.Value.Value is INamedTypeSymbol configurationType)
+            {
+                if (!ImplementsConfigurationInterface(configurationType, sourceType, targetType))
+                {
+                    var diagnostic = Diagnostic.Create(
+                        InvalidConfigurationTypeRule,
+                        facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                        configurationType.ToDisplayString(),
+                        sourceType.ToDisplayString(),
+                        targetType.ToDisplayString());
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        // Check NestedFacets
+        if (!nestedFacetsArg.Equals(default) && !nestedFacetsArg.Value.IsNull && nestedFacetsArg.Value.Kind == TypedConstantKind.Array)
+        {
+            foreach (var item in nestedFacetsArg.Value.Values)
+            {
+                if (item.Value is INamedTypeSymbol nestedFacetType)
+                {
+                    if (!HasFacetAttribute(nestedFacetType))
+                    {
+                        var diagnostic = Diagnostic.Create(
+                            InvalidNestedFacetRule,
+                            facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                            nestedFacetType.ToDisplayString());
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+
+        // Check MaxDepth and PreserveReferences for circular reference safety
+        int maxDepth = 10; // default
+        bool preserveReferences = true; // default
+
+        if (!maxDepthArg.Equals(default) && maxDepthArg.Value.Value is int maxDepthValue)
+        {
+            maxDepth = maxDepthValue;
+
+            // Validate MaxDepth range
+            if (maxDepthValue < 0)
+            {
+                var diagnostic = Diagnostic.Create(
+                    MaxDepthWarningRule,
+                    facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    maxDepthValue,
+                    "MaxDepth cannot be negative");
+                context.ReportDiagnostic(diagnostic);
+            }
+            else if (maxDepthValue > 100)
+            {
+                var diagnostic = Diagnostic.Create(
+                    MaxDepthWarningRule,
+                    facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    maxDepthValue,
+                    "This value is unusually large and may indicate a configuration error. Consider using a value between 1 and 10");
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        if (!preserveReferencesArg.Equals(default) && preserveReferencesArg.Value.Value is bool preserveReferencesValue)
+        {
+            preserveReferences = preserveReferencesValue;
+        }
+
+        // Check for circular reference risk
+        bool hasNestedFacets = !nestedFacetsArg.Equals(default) &&
+                              !nestedFacetsArg.Value.IsNull &&
+                              nestedFacetsArg.Value.Kind == TypedConstantKind.Array &&
+                              nestedFacetsArg.Value.Values.Length > 0;
+
+        if (hasNestedFacets && maxDepth == 0 && !preserveReferences)
+        {
+            var diagnostic = Diagnostic.Create(
+                CircularReferenceWarningRule,
+                facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private static void ReportInvalidPropertyName(
+        SymbolAnalysisContext context,
+        AttributeData facetAttr,
+        string propertyName,
+        string parameterName,
+        INamedTypeSymbol sourceType,
+        HashSet<string> validProperties)
+    {
+        var diagnostic = Diagnostic.Create(
+            InvalidPropertyNameRule,
+            facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+            propertyName,
+            parameterName,
+            sourceType.ToDisplayString());
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool IsPartialType(INamedTypeSymbol type)
+    {
+        // A type is partial if any of its declarations has the partial modifier
+        foreach (var syntaxRef in type.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax();
+            if (syntax is TypeDeclarationSyntax typeDecl)
+            {
+                if (typeDecl.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static bool HasFacetAttribute(ITypeSymbol type)
+    {
+        return type.GetAttributes().Any(attr =>
+            attr.AttributeClass?.ToDisplayString() == "Facet.FacetAttribute");
+    }
+
+    private static bool ImplementsConfigurationInterface(INamedTypeSymbol configurationType, INamedTypeSymbol sourceType, INamedTypeSymbol targetType)
+    {
+        // Check for IFacetMapConfiguration<TSource, TTarget>
+        var syncInterface = configurationType.AllInterfaces.FirstOrDefault(i =>
+            i.IsGenericType &&
+            i.ConstructedFrom.ToDisplayString() == "Facet.Mapping.IFacetMapConfiguration<TSource, TTarget>" &&
+            SymbolEqualityComparer.Default.Equals(i.TypeArguments[0], sourceType) &&
+            SymbolEqualityComparer.Default.Equals(i.TypeArguments[1], targetType));
+
+        if (syncInterface != null)
+            return true;
+
+        // Check for IFacetMapConfigurationAsync<TSource, TTarget>
+        var asyncInterface = configurationType.AllInterfaces.FirstOrDefault(i =>
+            i.IsGenericType &&
+            i.ConstructedFrom.ToDisplayString() == "Facet.Mapping.IFacetMapConfigurationAsync<TSource, TTarget>" &&
+            SymbolEqualityComparer.Default.Equals(i.TypeArguments[0], sourceType) &&
+            SymbolEqualityComparer.Default.Equals(i.TypeArguments[1], targetType));
+
+        if (asyncInterface != null)
+            return true;
+
+        // Also check for static Map method (alternative approach without interface)
+        var mapMethod = configurationType.GetMembers("Map")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.IsStatic &&
+                                m.Parameters.Length == 2 &&
+                                SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, sourceType) &&
+                                SymbolEqualityComparer.Default.Equals(m.Parameters[1].Type, targetType));
+
+        return mapMethod != null;
+    }
+}

--- a/src/Facet/Analyzers/FlattenAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/FlattenAttributeAnalyzer.cs
@@ -1,0 +1,181 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Facet.Analyzers;
+
+/// <summary>
+/// Analyzer that validates proper usage of the [Flatten] attribute.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class FlattenAttributeAnalyzer : DiagnosticAnalyzer
+{
+    // FAC014: Missing partial keyword
+    public static readonly DiagnosticDescriptor MissingPartialKeywordRule = new DiagnosticDescriptor(
+        "FAC014",
+        "Type with [Flatten] attribute must be declared as partial",
+        "Type '{0}' is marked with [Flatten] but is not declared as partial",
+        "Declaration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Types marked with [Flatten] must be partial to allow the source generator to add generated members.");
+
+    // FAC015: Invalid source type
+    public static readonly DiagnosticDescriptor InvalidSourceTypeRule = new DiagnosticDescriptor(
+        "FAC015",
+        "Source type is not accessible or does not exist",
+        "Source type '{0}' could not be resolved or is not accessible",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The source type specified in the [Flatten] attribute must be a valid, accessible type.");
+
+    // FAC016: MaxDepth warning
+    public static readonly DiagnosticDescriptor MaxDepthWarningRule = new DiagnosticDescriptor(
+        "FAC016",
+        "MaxDepth value is unusual",
+        "MaxDepth is set to {0}: {1}",
+        "Performance",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "MaxDepth values should typically be between 1 and 5 for flatten scenarios.");
+
+    // FAC017: LeafOnly naming collision warning
+    public static readonly DiagnosticDescriptor LeafOnlyCollisionWarningRule = new DiagnosticDescriptor(
+        "FAC017",
+        "LeafOnly naming strategy may cause property name collisions",
+        "Using LeafOnly naming strategy may cause property name collisions if nested objects have properties with the same name",
+        "Usage",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "The LeafOnly naming strategy can cause name collisions when multiple nested objects have properties with the same name. Consider using Prefix strategy instead.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        MissingPartialKeywordRule,
+        InvalidSourceTypeRule,
+        MaxDepthWarningRule,
+        LeafOnlyCollisionWarningRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+
+        // Find [Flatten] attributes
+        var flattenAttributes = namedType.GetAttributes()
+            .Where(attr => attr.AttributeClass?.ToDisplayString() == "Facet.FlattenAttribute")
+            .ToList();
+
+        if (!flattenAttributes.Any())
+            return;
+
+        // Check if type is partial
+        if (!IsPartialType(namedType))
+        {
+            var diagnostic = Diagnostic.Create(
+                MissingPartialKeywordRule,
+                namedType.Locations.FirstOrDefault(),
+                namedType.Name);
+            context.ReportDiagnostic(diagnostic);
+        }
+
+        // Analyze each [Flatten] attribute
+        foreach (var flattenAttr in flattenAttributes)
+        {
+            AnalyzeFlattenAttribute(context, namedType, flattenAttr);
+        }
+    }
+
+    private static void AnalyzeFlattenAttribute(SymbolAnalysisContext context, INamedTypeSymbol targetType, AttributeData flattenAttr)
+    {
+        // Get the source type (first constructor argument)
+        if (flattenAttr.ConstructorArguments.Length == 0)
+            return;
+
+        var sourceTypeArg = flattenAttr.ConstructorArguments[0];
+        if (sourceTypeArg.Value is not INamedTypeSymbol sourceType)
+        {
+            // Invalid source type
+            var diagnostic = Diagnostic.Create(
+                InvalidSourceTypeRule,
+                flattenAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                sourceTypeArg.ToCSharpString());
+            context.ReportDiagnostic(diagnostic);
+            return;
+        }
+
+        // Check if source type is accessible
+        if (sourceType.TypeKind == TypeKind.Error)
+        {
+            var diagnostic = Diagnostic.Create(
+                InvalidSourceTypeRule,
+                flattenAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                sourceType.ToDisplayString());
+            context.ReportDiagnostic(diagnostic);
+            return;
+        }
+
+        // Check MaxDepth parameter
+        var maxDepthArg = flattenAttr.NamedArguments.FirstOrDefault(a => a.Key == "MaxDepth");
+        if (!maxDepthArg.Equals(default) && maxDepthArg.Value.Value is int maxDepthValue)
+        {
+            if (maxDepthValue < 0)
+            {
+                var diagnostic = Diagnostic.Create(
+                    MaxDepthWarningRule,
+                    flattenAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    maxDepthValue,
+                    "MaxDepth cannot be negative");
+                context.ReportDiagnostic(diagnostic);
+            }
+            else if (maxDepthValue > 10)
+            {
+                var diagnostic = Diagnostic.Create(
+                    MaxDepthWarningRule,
+                    flattenAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    maxDepthValue,
+                    "This value is unusually large for flattening. Consider using a value between 1 and 5");
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        // Check NamingStrategy parameter
+        var namingStrategyArg = flattenAttr.NamedArguments.FirstOrDefault(a => a.Key == "NamingStrategy");
+        if (!namingStrategyArg.Equals(default) && namingStrategyArg.Value.Value is int namingStrategyValue)
+        {
+            if (namingStrategyValue == 1) // FlattenNamingStrategy.LeafOnly
+            {
+                var diagnostic = Diagnostic.Create(
+                    LeafOnlyCollisionWarningRule,
+                    flattenAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+
+    private static bool IsPartialType(INamedTypeSymbol type)
+    {
+        // A type is partial if any of its declarations has the partial modifier
+        foreach (var syntaxRef in type.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax();
+            if (syntax is TypeDeclarationSyntax typeDecl)
+            {
+                if (typeDecl.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/Facet/Analyzers/GenerateDtosAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/GenerateDtosAttributeAnalyzer.cs
@@ -1,0 +1,139 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Facet.Analyzers;
+
+/// <summary>
+/// Analyzer that validates proper usage of the [GenerateDtos] and [GenerateAuditableDtos] attributes.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class GenerateDtosAttributeAnalyzer : DiagnosticAnalyzer
+{
+    // FAC011: GenerateDtos on non-class type
+    public static readonly DiagnosticDescriptor NonClassTypeRule = new DiagnosticDescriptor(
+        "FAC011",
+        "[GenerateDtos] can only be applied to classes",
+        "[GenerateDtos] attribute can only be applied to class types, not {0}",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [GenerateDtos] attribute is designed for class types and cannot be applied to structs, interfaces, or other type kinds.");
+
+    // FAC012: Invalid ExcludeProperties
+    public static readonly DiagnosticDescriptor InvalidExcludePropertyRule = new DiagnosticDescriptor(
+        "FAC012",
+        "Excluded property does not exist",
+        "Property '{0}' in ExcludeProperties does not exist in type '{1}'",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Properties specified in ExcludeProperties should exist in the source type.");
+
+    // FAC013: DtoTypes.None specified
+    public static readonly DiagnosticDescriptor NoDtoTypesRule = new DiagnosticDescriptor(
+        "FAC013",
+        "No DTO types selected for generation",
+        "DtoTypes is set to None, which will not generate any DTOs",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Setting DtoTypes to None will not generate any DTOs. Consider specifying the DTO types you want to generate.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        NonClassTypeRule,
+        InvalidExcludePropertyRule,
+        NoDtoTypesRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+
+        // Find [GenerateDtos] or [GenerateAuditableDtos] attributes
+        var dtoAttributes = namedType.GetAttributes()
+            .Where(attr =>
+                attr.AttributeClass?.ToDisplayString() == "Facet.GenerateDtosAttribute" ||
+                attr.AttributeClass?.ToDisplayString() == "Facet.GenerateAuditableDtosAttribute")
+            .ToList();
+
+        if (!dtoAttributes.Any())
+            return;
+
+        // Check if type is a class
+        if (namedType.TypeKind != TypeKind.Class)
+        {
+            foreach (var attr in dtoAttributes)
+            {
+                var diagnostic = Diagnostic.Create(
+                    NonClassTypeRule,
+                    attr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    namedType.TypeKind.ToString().ToLowerInvariant());
+                context.ReportDiagnostic(diagnostic);
+            }
+            return;
+        }
+
+        // Get all public properties from the type
+        var typeProperties = new HashSet<string>(namedType.GetMembers()
+            .Where(m => m.DeclaredAccessibility == Accessibility.Public && m.Kind == SymbolKind.Property)
+            .Select(m => m.Name));
+
+        // Analyze each attribute
+        foreach (var attr in dtoAttributes)
+        {
+            AnalyzeGenerateDtosAttribute(context, namedType, attr, typeProperties);
+        }
+    }
+
+    private static void AnalyzeGenerateDtosAttribute(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol targetType,
+        AttributeData attr,
+        HashSet<string> typeProperties)
+    {
+        // Check DtoTypes parameter
+        var typesArg = attr.NamedArguments.FirstOrDefault(a => a.Key == "Types");
+        if (!typesArg.Equals(default) && typesArg.Value.Value is int typesValue)
+        {
+            if (typesValue == 0) // DtoTypes.None
+            {
+                var diagnostic = Diagnostic.Create(
+                    NoDtoTypesRule,
+                    attr.ApplicationSyntaxReference?.GetSyntax().GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        // Check ExcludeProperties parameter
+        var excludeArg = attr.NamedArguments.FirstOrDefault(a => a.Key == "ExcludeProperties");
+        if (!excludeArg.Equals(default) && !excludeArg.Value.IsNull && excludeArg.Value.Kind == TypedConstantKind.Array)
+        {
+            foreach (var item in excludeArg.Value.Values)
+            {
+                if (item.Value is string propertyName && !string.IsNullOrEmpty(propertyName))
+                {
+                    if (!typeProperties.Contains(propertyName))
+                    {
+                        var diagnostic = Diagnostic.Create(
+                            InvalidExcludePropertyRule,
+                            attr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                            propertyName,
+                            targetType.ToDisplayString());
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Facet.Tests/Facet.Tests.csproj
+++ b/test/Facet.Tests/Facet.Tests.csproj
@@ -8,6 +8,8 @@
     <IsTestProject>true</IsTestProject>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
+    <!-- Suppress analyzer warnings for test cases that intentionally use inherited properties -->
+    <NoWarn>$(NoWarn);FAC004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
| Rule   | Severity | Description                                               |
|--------|----------|-----------------------------------------------------------|
| FAC001 | Error    | Type must be annotated with [Facet] (existing)            |
| FAC002 | Info     | Performance suggestion for two-generic variant (existing) |
| FAC003 | Error    | Missing partial keyword on [Facet] type                   |
| FAC004 | Error    | Invalid property name in Exclude/Include                  |
| FAC005 | Error    | Invalid source type                                       |
| FAC006 | Error    | Invalid Configuration type                                |
| FAC007 | Warning  | Invalid NestedFacets type                                 |
| FAC008 | Warning  | Circular reference risk                                   |
| FAC009 | Error    | Both Include and Exclude specified                        |
| FAC010 | Warning  | Unusual MaxDepth value                                    |
| FAC011 | Error    | [GenerateDtos] on non-class type                          |
| FAC012 | Warning  | Invalid ExcludeProperties                                 |
| FAC013 | Warning  | No DTO types selected                                     |
| FAC014 | Error    | Missing partial keyword on [Flatten] type                 |
| FAC015 | Error    | Invalid source type in [Flatten]                          |
| FAC016 | Warning  | Unusual MaxDepth in [Flatten]                             |
| FAC017 | Info     | LeafOnly naming collision risk                            |
