### PR TITLE
Fix package structure

### DIFF
--- a/src/Facet/Facet.csproj
+++ b/src/Facet/Facet.csproj
@@ -12,6 +12,11 @@
         <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
+
+        <!-- Prevent the assembly from being included in lib/ folder - it should only be in analyzers/ -->
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <!-- Mark this as a development dependency -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #154 

When the assembly is in lib/, the AOT compiler treats it as a runtime dependency and tries to resolve all its type references, including `Microsoft.CodeAnalysis...` assemblies. Even though marked those as PrivateAssets="all", the presence of Facet.dll in the runtime causes the dependency resolution to fail