### PR TITLE
Nested Wrappers

### DIFF
--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -74,6 +74,7 @@ internal static class FacetConstants
     public static class AttributeNames
     {
         public const string NestedFacets = "NestedFacets";
+        public const string NestedWrappers = "NestedWrappers";
         public const string Include = "Include";
         public const string Configuration = "Configuration";
         public const string IncludeFields = "IncludeFields";

--- a/src/Facet/Generators/WrapperGenerators/WrapperMemberGenerator.cs
+++ b/src/Facet/Generators/WrapperGenerators/WrapperMemberGenerator.cs
@@ -64,17 +64,58 @@ internal static class WrapperMemberGenerator
     private static void GenerateDelegatingProperty(StringBuilder sb, WrapperTargetModel model, FacetMember member, string indent)
     {
         // For wrappers, properties delegate to the source object
+        // For nested wrappers, we wrap the nested object
         // Pattern (mutable): public TypeName PropertyName { get => _source.PropertyName; set => _source.PropertyName = value; }
+        // Pattern (nested): public NestedWrapper PropertyName { get => new NestedWrapper(_source.PropertyName); set => _source.PropertyName = value.Unwrap(); }
         // Pattern (readonly): public TypeName PropertyName { get => _source.PropertyName; }
 
         sb.AppendLine($"{indent}public {member.TypeName} {member.Name}");
         sb.AppendLine($"{indent}{{");
-        sb.AppendLine($"{indent}    get => {model.SourceFieldName}.{member.Name};");
 
-        // Only generate setter if wrapper is not ReadOnly
+        // Generate getter
+        if (member.IsNestedFacet)
+        {
+            // For nested wrappers, wrap the source property
+            // Handle nullable types
+            bool isNullable = member.TypeName.EndsWith("?");
+            string wrapperType = isNullable ? member.TypeName.TrimEnd('?') : member.TypeName;
+
+            if (isNullable)
+            {
+                sb.AppendLine($"{indent}    get => {model.SourceFieldName}.{member.Name} != null ? new {wrapperType}({model.SourceFieldName}.{member.Name}) : null;");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}    get => new {wrapperType}({model.SourceFieldName}.{member.Name});");
+            }
+        }
+        else
+        {
+            // Simple delegation
+            sb.AppendLine($"{indent}    get => {model.SourceFieldName}.{member.Name};");
+        }
+
+        // Generate setter
         if (!model.ReadOnly)
         {
-            sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value;");
+            if (member.IsNestedFacet)
+            {
+                // For nested wrappers, unwrap the value
+                bool isNullable = member.TypeName.EndsWith("?");
+                if (isNullable)
+                {
+                    sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value?.Unwrap();");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value.Unwrap();");
+                }
+            }
+            else
+            {
+                // Simple assignment
+                sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value;");
+            }
         }
 
         sb.AppendLine($"{indent}}}");
@@ -83,17 +124,57 @@ internal static class WrapperMemberGenerator
     private static void GenerateDelegatingField(StringBuilder sb, WrapperTargetModel model, FacetMember member, string indent)
     {
         // For fields in wrappers, we generate properties that delegate to the source field
+        // For nested wrappers, we wrap the nested object
         // Pattern (mutable): public TypeName FieldName { get => _source.FieldName; set => _source.FieldName = value; }
+        // Pattern (nested): public NestedWrapper FieldName { get => new NestedWrapper(_source.FieldName); set => _source.FieldName = value.Unwrap(); }
         // Pattern (readonly): public TypeName FieldName { get => _source.FieldName; }
 
         sb.AppendLine($"{indent}public {member.TypeName} {member.Name}");
         sb.AppendLine($"{indent}{{");
-        sb.AppendLine($"{indent}    get => {model.SourceFieldName}.{member.Name};");
 
-        // Only generate setter if wrapper is not ReadOnly AND field is not readonly
+        // Generate getter
+        if (member.IsNestedFacet)
+        {
+            // For nested wrappers, wrap the source field
+            bool isNullable = member.TypeName.EndsWith("?");
+            string wrapperType = isNullable ? member.TypeName.TrimEnd('?') : member.TypeName;
+
+            if (isNullable)
+            {
+                sb.AppendLine($"{indent}    get => {model.SourceFieldName}.{member.Name} != null ? new {wrapperType}({model.SourceFieldName}.{member.Name}) : null;");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}    get => new {wrapperType}({model.SourceFieldName}.{member.Name});");
+            }
+        }
+        else
+        {
+            // Simple delegation
+            sb.AppendLine($"{indent}    get => {model.SourceFieldName}.{member.Name};");
+        }
+
+        // Generate setter
         if (!model.ReadOnly && !member.IsReadOnly)
         {
-            sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value;");
+            if (member.IsNestedFacet)
+            {
+                // For nested wrappers, unwrap the value
+                bool isNullable = member.TypeName.EndsWith("?");
+                if (isNullable)
+                {
+                    sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value?.Unwrap();");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value.Unwrap();");
+                }
+            }
+            else
+            {
+                // Simple assignment
+                sb.AppendLine($"{indent}    set => {model.SourceFieldName}.{member.Name} = value;");
+            }
         }
 
         sb.AppendLine($"{indent}}}");

--- a/src/Facet/WrapperAttribute.cs
+++ b/src/Facet/WrapperAttribute.cs
@@ -51,6 +51,12 @@ public sealed class WrapperAttribute : Attribute
     public bool ReadOnly { get; set; } = false;
 
     /// <summary>
+    /// An array of nested wrapper types for complex/nested properties.
+    /// When specified, properties with matching types will be automatically wrapped.
+    /// </summary>
+    public Type[]? NestedWrappers { get; set; }
+
+    /// <summary>
     /// When true, copies attributes from the source type members to the generated wrapper members.
     /// Only copies attributes that are valid on the target (excludes internal compiler attributes and non-copiable attributes).
     /// Default is false.

--- a/test/Facet.Tests/UnitTests/Wrapper/NestedWrapperTests.cs
+++ b/test/Facet.Tests/UnitTests/Wrapper/NestedWrapperTests.cs
@@ -1,0 +1,107 @@
+namespace Facet.Tests.UnitTests.Wrapper;
+
+public class Address
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string ZipCode { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+}
+
+public class Person
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public Address Address { get; set; } = new();
+    public string SocialSecurityNumber { get; set; } = string.Empty;
+}
+
+[Wrapper(typeof(Address), "Country")]
+public partial class PublicAddressWrapper { }
+
+[Wrapper(typeof(Person), "SocialSecurityNumber", NestedWrappers = new[] { typeof(PublicAddressWrapper) })]
+public partial class PublicPersonWrapper { }
+
+public partial class NestedWrapperTests
+{
+
+    [Fact]
+    public void Nested_Wrapper_Should_Wrap_Nested_Properties()
+    {
+        // Arrange
+        var person = new Person
+        {
+            Id = 1,
+            Name = "John Doe",
+            Address = new Address
+            {
+                Street = "123 Main St",
+                City = "Springfield",
+                ZipCode = "12345",
+                Country = "USA"
+            },
+            SocialSecurityNumber = "123-45-6789"
+        };
+
+        // Act
+        var wrapper = new PublicPersonWrapper(person);
+
+        // Assert
+        wrapper.Id.Should().Be(1);
+        wrapper.Name.Should().Be("John Doe");
+        wrapper.Address.Should().NotBeNull();
+        wrapper.Address.Street.Should().Be("123 Main St");
+        wrapper.Address.City.Should().Be("Springfield");
+        wrapper.Address.ZipCode.Should().Be("12345");
+
+        // Country should be excluded by PublicAddressWrapper
+        wrapper.Address.GetType().GetProperty("Country").Should().BeNull();
+    }
+
+    [Fact]
+    public void Nested_Wrapper_Changes_Should_Propagate_To_Source()
+    {
+        // Arrange
+        var person = new Person
+        {
+            Id = 1,
+            Name = "Jane Smith",
+            Address = new Address { City = "Boston" }
+        };
+        var wrapper = new PublicPersonWrapper(person);
+
+        // Act
+        wrapper.Address.City = "New York";
+
+        // Assert
+        person.Address.City.Should().Be("New York");
+    }
+
+    [Fact]
+    public void Nested_Wrapper_Should_Unwrap_Correctly()
+    {
+        // Arrange
+        var person = new Person { Address = new Address { City = "Seattle" } };
+        var wrapper = new PublicPersonWrapper(person);
+
+        // Act
+        var unwrapped = wrapper.Unwrap();
+
+        // Assert
+        unwrapped.Should().BeSameAs(person);
+        unwrapped.Address.City.Should().Be("Seattle");
+    }
+
+    [Fact]
+    public void Nested_Wrapper_With_Nullable_Should_Handle_Null()
+    {
+        // Arrange
+        var person = new Person { Address = null! };
+
+        // Act
+        var wrapper = new PublicPersonWrapper(person);
+
+        // Assert
+        wrapper.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Update for #152 

Basic support for nested wrappers, added docs and unit tests

New parameters:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `NestedWrappers` | `Type[]?` | `null` | Wrapper types for nested complex properties |

Usage:

```csharp
public class Address
{
    public string Street { get; set; }
    public string City { get; set; }
    public string ZipCode { get; set; }
    public string Country { get; set; }
}

public class Person
{
    public int Id { get; set; }
    public string Name { get; set; }
    public Address Address { get; set; }
    public string SocialSecurityNumber { get; set; }
}

// Define wrapper for nested type
[Wrapper(typeof(Address), "Country")]
public partial class PublicAddressWrapper { }

// Reference nested wrapper in parent wrapper
[Wrapper(typeof(Person), "SocialSecurityNumber", NestedWrappers = new[] { typeof(PublicAddressWrapper) })]
public partial class PublicPersonWrapper { }

// Usage
var person = new Person
{
    Id = 1,
    Name = "John Doe",
    Address = new Address
    {
        Street = "123 Main St",
        City = "Springfield",
        ZipCode = "12345",
        Country = "USA"
    },
    SocialSecurityNumber = "123-45-6789"
};

var wrapper = new PublicPersonWrapper(person);

// Access nested wrapper
Console.WriteLine(wrapper.Address.City);       // "Springfield"
Console.WriteLine(wrapper.Address.ZipCode);    // "12345"

// Country is excluded by PublicAddressWrapper
// wrapper.Address.Country  // Compile error

// Changes propagate through nested wrappers
wrapper.Address.City = "Boston";
Console.WriteLine(person.Address.City);        // "Boston"
```