### PR TITLE
SmartLeaf

### DIFF
--- a/src/Facet/FlattenAttribute.cs
+++ b/src/Facet/FlattenAttribute.cs
@@ -127,5 +127,12 @@ public enum FlattenNamingStrategy
     /// Example: Address.Street becomes "Street"
     /// Warning: This can cause name collisions if multiple nested objects have properties with the same name.
     /// </summary>
-    LeafOnly = 1
+    LeafOnly = 1,
+
+    /// <summary>
+    /// Use leaf property name, but add immediate parent name prefix when collisions occur.
+    /// Example: Position.Name and Type.Name become "PositionName" and "TypeName"
+    /// Non-colliding properties use leaf names only.
+    /// </summary>
+    SmartLeaf = 2
 }

--- a/test/Facet.Tests/TestModels/FlattenTestModels.cs
+++ b/test/Facet.Tests/TestModels/FlattenTestModels.cs
@@ -180,3 +180,81 @@ public partial class OrderWithFksFlatDto
     // Should skip: Customer.Id, Customer.HomeAddressId, ShippingAddress.Id, Customer.HomeAddress.Id
     // Should include: CustomerName, CustomerEmail, ShippingAddressLine1, etc.
 }
+
+// Test models for SmartLeaf naming strategy
+public class Position
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class ItemType
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class ExtendedData
+{
+    public int Id { get; set; }
+    public int PositionId { get; set; }
+    public Position Position { get; set; } = null!;
+    public int TypeId { get; set; }
+    public ItemType Type { get; set; } = null!;
+}
+
+public class DataItem
+{
+    public int Id { get; set; }
+    public string DataValue { get; set; } = string.Empty;
+    public int ExtendedDataId { get; set; }
+    public ExtendedData ExtendedData { get; set; } = null!;
+}
+
+[Flatten(typeof(DataItem), NamingStrategy = FlattenNamingStrategy.SmartLeaf, IgnoreNestedIds = true)]
+public partial class DataItemSmartLeafDto
+{
+    // Expected properties:
+    // Id (root)
+    // DataValue (no collision)
+    // PositionName (collision resolved with parent)
+    // TypeName (collision resolved with parent)
+}
+
+[Flatten(typeof(DataItem), NamingStrategy = FlattenNamingStrategy.LeafOnly, IgnoreNestedIds = true)]
+public partial class DataItemLeafOnlyDto
+{
+    // Expected properties with numeric suffixes:
+    // Id, DataValue, Name, Name2
+}
+
+// Test model with multiple collisions from same parent
+public class CatalogProduct
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+}
+
+public class CatalogCategory
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+}
+
+public class ProductCatalog
+{
+    public int Id { get; set; }
+    public CatalogProduct Product { get; set; } = null!;
+    public CatalogCategory Category { get; set; } = null!;
+}
+
+[Flatten(typeof(ProductCatalog), NamingStrategy = FlattenNamingStrategy.SmartLeaf, IgnoreNestedIds = true)]
+public partial class ProductCatalogSmartLeafDto
+{
+    // Expected properties:
+    // Id
+    // ProductName, ProductCode (collisions resolved)
+    // CategoryName, CategoryCode (collisions resolved)
+}

--- a/test/Facet.Tests/UnitTests/Flatten/FlattenSmartLeafTests.cs
+++ b/test/Facet.Tests/UnitTests/Flatten/FlattenSmartLeafTests.cs
@@ -1,0 +1,214 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Flatten;
+
+public class FlattenSmartLeafTests
+{
+    [Fact]
+    public void DataItemSmartLeafDto_ShouldResolveCollisionsWithParentName()
+    {
+        // Arrange
+        var dataItem = new DataItem
+        {
+            Id = 1,
+            DataValue = "Test Value",
+            ExtendedDataId = 10,
+            ExtendedData = new ExtendedData
+            {
+                Id = 10,
+                PositionId = 100,
+                Position = new Position
+                {
+                    Id = 100,
+                    Name = "Manager"
+                },
+                TypeId = 200,
+                Type = new ItemType
+                {
+                    Id = 200,
+                    Name = "Full-Time"
+                }
+            }
+        };
+
+        // Act
+        var dto = new DataItemSmartLeafDto(dataItem);
+
+        // Assert - verify SmartLeaf naming (parent prefix only on collision)
+        var type = typeof(DataItemSmartLeafDto);
+
+        // Root properties should exist as-is
+        Assert.Equal(1, dto.Id);
+
+        // Non-colliding property should use leaf name only
+        Assert.NotNull(type.GetProperty("DataValue"));
+        Assert.Equal("Test Value", type.GetProperty("DataValue")!.GetValue(dto));
+
+        // Colliding "Name" properties should use parent prefix
+        Assert.NotNull(type.GetProperty("PositionName"));
+        Assert.NotNull(type.GetProperty("TypeName"));
+        Assert.Equal("Manager", type.GetProperty("PositionName")!.GetValue(dto));
+        Assert.Equal("Full-Time", type.GetProperty("TypeName")!.GetValue(dto));
+
+        // Should NOT have numeric suffix names
+        Assert.Null(type.GetProperty("Name"));
+        Assert.Null(type.GetProperty("Name2"));
+
+        // Should NOT have full prefix names
+        Assert.Null(type.GetProperty("ExtendedDataPositionName"));
+        Assert.Null(type.GetProperty("ExtendedDataTypeName"));
+    }
+
+    [Fact]
+    public void DataItemLeafOnlyDto_ShouldUseNumericSuffixForCollisions()
+    {
+        // Arrange
+        var dataItem = new DataItem
+        {
+            Id = 1,
+            DataValue = "Test Value",
+            ExtendedDataId = 10,
+            ExtendedData = new ExtendedData
+            {
+                Id = 10,
+                PositionId = 100,
+                Position = new Position
+                {
+                    Id = 100,
+                    Name = "Manager"
+                },
+                TypeId = 200,
+                Type = new ItemType
+                {
+                    Id = 200,
+                    Name = "Full-Time"
+                }
+            }
+        };
+
+        // Act
+        var dto = new DataItemLeafOnlyDto(dataItem);
+
+        // Assert - verify LeafOnly naming (numeric suffix on collision)
+        var type = typeof(DataItemLeafOnlyDto);
+
+        // Should have numeric suffix names for collisions
+        Assert.NotNull(type.GetProperty("Name"));
+        Assert.NotNull(type.GetProperty("Name2"));
+
+        // Should NOT have parent prefix names
+        Assert.Null(type.GetProperty("PositionName"));
+        Assert.Null(type.GetProperty("TypeName"));
+    }
+
+    [Fact]
+    public void ProductCatalogSmartLeafDto_ShouldResolveMultipleCollisionsFromSameParent()
+    {
+        // Arrange
+        var catalog = new ProductCatalog
+        {
+            Id = 1,
+            Product = new CatalogProduct
+            {
+                Id = 10,
+                Name = "Widget",
+                Code = "WGT-001"
+            },
+            Category = new CatalogCategory
+            {
+                Id = 20,
+                Name = "Tools",
+                Code = "TLS"
+            }
+        };
+
+        // Act
+        var dto = new ProductCatalogSmartLeafDto(catalog);
+
+        // Assert - verify multiple collisions resolved
+        var type = typeof(ProductCatalogSmartLeafDto);
+
+        // Root Id
+        Assert.Equal(1, dto.Id);
+
+        // Both Name and Code collide, so both should get parent prefix
+        Assert.NotNull(type.GetProperty("ProductName"));
+        Assert.NotNull(type.GetProperty("ProductCode"));
+        Assert.NotNull(type.GetProperty("CategoryName"));
+        Assert.NotNull(type.GetProperty("CategoryCode"));
+
+        Assert.Equal("Widget", type.GetProperty("ProductName")!.GetValue(dto));
+        Assert.Equal("WGT-001", type.GetProperty("ProductCode")!.GetValue(dto));
+        Assert.Equal("Tools", type.GetProperty("CategoryName")!.GetValue(dto));
+        Assert.Equal("TLS", type.GetProperty("CategoryCode")!.GetValue(dto));
+
+        // Should NOT have unprefixed names
+        Assert.Null(type.GetProperty("Name"));
+        Assert.Null(type.GetProperty("Code"));
+    }
+
+    [Fact]
+    public void DataItemSmartLeafDto_ShouldHandleNullNestedObjects()
+    {
+        // Arrange
+        var dataItem = new DataItem
+        {
+            Id = 1,
+            DataValue = "Test Value",
+            ExtendedDataId = 10,
+            ExtendedData = null!
+        };
+
+        // Act
+        var dto = new DataItemSmartLeafDto(dataItem);
+
+        // Assert
+        var type = typeof(DataItemSmartLeafDto);
+        Assert.Equal(1, dto.Id);
+        Assert.Equal("Test Value", type.GetProperty("DataValue")!.GetValue(dto));
+        Assert.Null(type.GetProperty("PositionName")!.GetValue(dto));
+        Assert.Null(type.GetProperty("TypeName")!.GetValue(dto));
+    }
+
+    [Fact]
+    public void DataItemSmartLeafDto_Projection_ShouldWork()
+    {
+        // Arrange
+        var dataItem = new DataItem
+        {
+            Id = 1,
+            DataValue = "Test Value",
+            ExtendedDataId = 10,
+            ExtendedData = new ExtendedData
+            {
+                Id = 10,
+                PositionId = 100,
+                Position = new Position { Id = 100, Name = "Manager" },
+                TypeId = 200,
+                Type = new ItemType { Id = 200, Name = "Full-Time" }
+            }
+        };
+
+        // Act
+        var projection = DataItemSmartLeafDto.Projection.Compile();
+        var dto = projection(dataItem);
+
+        // Assert
+        var type = typeof(DataItemSmartLeafDto);
+        Assert.Equal(1, dto.Id);
+        Assert.Equal("Test Value", type.GetProperty("DataValue")!.GetValue(dto));
+        Assert.Equal("Manager", type.GetProperty("PositionName")!.GetValue(dto));
+        Assert.Equal("Full-Time", type.GetProperty("TypeName")!.GetValue(dto));
+    }
+
+    [Fact]
+    public void DataItemSmartLeafDto_ParameterlessConstructor_ShouldWork()
+    {
+        // Act
+        var dto = new DataItemSmartLeafDto();
+
+        // Assert
+        Assert.NotNull(dto);
+        Assert.Equal(0, dto.Id);
+    }
+}


### PR DESCRIPTION
proposal for #168 

Adds a new `SmartLeaf` naming strategy for the `[Flatten]` attribute that resolves property name collisions by prefixing with the immediate parent name instead of using numeric suffixes.

When using `LeafOnly` naming strategy with entities that have multiple navigation properties with same-named fields, the generated property names become unclear:

```csharp
// LeafOnly generates unclear names
public string Name { get; set; }   // Position.Name
public string Name2 { get; set; }  // Type.Name - which entity is this?
```

`SmartLeaf` uses leaf-only names for non-colliding properties, but adds the immediate parent name as prefix when collisions occur:

```csharp
[Flatten(typeof(Data), NamingStrategy = FlattenNamingStrategy.SmartLeaf)]
public partial class DataFlat
{
    public int Id { get; set; }
    public string DataValue { get; set; }      // No collision - leaf only
    public string PositionName { get; set; }   // Collision resolved
    public string TypeName { get; set; }       // Collision resolved
}
```

### Comparison

| Strategy | `Position.Name` | `Type.Name` | `DataValue` |
|----------|-----------------|-------------|-------------|
| `Prefix` | `ExtendedDataPositionName` | `ExtendedDataTypeName` | `DataValue` |
| `LeafOnly` | `Name` | `Name2` | `DataValue` |
| `SmartLeaf` | `PositionName` | `TypeName` | `DataValue` |

### Changes

- Added `SmartLeaf = 2` to `FlattenNamingStrategy` enum
- Implemented two-pass collision detection in `FlattenModelBuilder`
- Added 6 unit tests covering various scenarios

Closes #168 