### PR TITLE
Support acces modifiers

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -13,6 +13,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public string FullName { get; }
     public TypeKind TypeKind { get; }
     public bool IsRecord { get; }
+    public string Accessibility { get; }
     public bool GenerateConstructor { get; }
     public bool GenerateParameterlessConstructor { get; }
     public bool GenerateExpressionProjection { get; }
@@ -38,6 +39,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         string fullName,
         TypeKind typeKind,
         bool isRecord,
+        string accessibility,
         bool generateConstructor,
         bool generateParameterlessConstructor,
         bool generateExpressionProjection,
@@ -62,6 +64,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         FullName = fullName;
         TypeKind = typeKind;
         IsRecord = isRecord;
+        Accessibility = accessibility;
         GenerateConstructor = generateConstructor;
         GenerateParameterlessConstructor = generateParameterlessConstructor;
         GenerateExpressionProjection = generateExpressionProjection;
@@ -92,6 +95,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && FullName == other.FullName
             && TypeKind == other.TypeKind
             && IsRecord == other.IsRecord
+            && Accessibility == other.Accessibility
             && GenerateConstructor == other.GenerateConstructor
             && GenerateParameterlessConstructor == other.GenerateParameterlessConstructor
             && GenerateExpressionProjection == other.GenerateExpressionProjection
@@ -123,6 +127,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + (FullName?.GetHashCode() ?? 0);
             hash = hash * 31 + TypeKind.GetHashCode();
             hash = hash * 31 + IsRecord.GetHashCode();
+            hash = hash * 31 + (Accessibility?.GetHashCode() ?? 0);
             hash = hash * 31 + GenerateConstructor.GetHashCode();
             hash = hash * 31 + GenerateParameterlessConstructor.GetHashCode();
             hash = hash * 31 + GenerateExpressionProjection.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -74,7 +74,7 @@ internal static class CodeBuilder
             GeneratePositionalDeclaration(sb, model, keyword, containingTypeIndent);
         }
 
-        sb.AppendLine($"{containingTypeIndent}public partial {keyword} {model.Name}");
+        sb.AppendLine($"{containingTypeIndent}{model.Accessibility} partial {keyword} {model.Name}");
         sb.AppendLine($"{containingTypeIndent}{{");
 
         var memberIndent = containingTypeIndent + "    ";
@@ -134,7 +134,8 @@ internal static class CodeBuilder
         var containingTypeIndent = "";
         foreach (var containingType in model.ContainingTypes)
         {
-            sb.AppendLine($"{containingTypeIndent}public partial class {containingType}");
+            // Don't specify accessibility for containing types - they're already defined in user code
+            sb.AppendLine($"{containingTypeIndent}partial class {containingType}");
             sb.AppendLine($"{containingTypeIndent}{{");
             containingTypeIndent += "    ";
         }
@@ -176,7 +177,7 @@ internal static class CodeBuilder
                 }
                 return param;
             }));
-        sb.AppendLine($"{indent}public partial {keyword} {model.Name}({parameters});");
+        sb.AppendLine($"{indent}{model.Accessibility} partial {keyword} {model.Name}({parameters});");
     }
 
     #endregion

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -44,6 +44,18 @@ internal static class ModelBuilder
         // Infer the type kind and whether it's a record from the target type declaration
         var (typeKind, isRecord) = TypeAnalyzer.InferTypeKind(targetSymbol);
 
+        // Get the accessibility modifier
+        var accessibility = targetSymbol.DeclaredAccessibility switch
+        {
+            Accessibility.Public => "public",
+            Accessibility.Internal => "internal",
+            Accessibility.Protected => "protected",
+            Accessibility.ProtectedOrInternal => "protected internal",
+            Accessibility.ProtectedAndInternal => "private protected",
+            Accessibility.Private => "private",
+            _ => "public"
+        };
+
         // For record types, default to preserving init-only and required modifiers
         // unless explicitly overridden by the user
         var preserveInitOnlyDefault = isRecord;
@@ -104,6 +116,7 @@ internal static class ModelBuilder
             fullName,
             typeKind,
             isRecord,
+            accessibility,
             generateConstructor,
             generateParameterlessConstructor,
             generateProjection,

--- a/src/Facet/Generators/WrapperGenerators/WrapperCodeBuilder.cs
+++ b/src/Facet/Generators/WrapperGenerators/WrapperCodeBuilder.cs
@@ -97,7 +97,8 @@ internal static class WrapperCodeBuilder
         var containingTypeIndent = "";
         foreach (var containingType in model.ContainingTypes)
         {
-            sb.AppendLine($"{containingTypeIndent}public partial class {containingType}");
+            // Don't specify accessibility for containing types - they're already defined in user code
+            sb.AppendLine($"{containingTypeIndent}partial class {containingType}");
             sb.AppendLine($"{containingTypeIndent}{{");
             containingTypeIndent += "    ";
         }

--- a/test/Facet.Tests/UnitTests/Core/Facet/AccessibilityTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/AccessibilityTests.cs
@@ -1,0 +1,116 @@
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+// Test entities
+public class AccessibilityTestEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// Internal facet - should generate with internal accessibility
+[Facet(typeof(AccessibilityTestEntity))]
+internal partial class InternalFacet;
+
+// Public facet - should generate with public accessibility
+[Facet(typeof(AccessibilityTestEntity))]
+public partial class PublicFacet;
+
+public class AccessibilityTests
+{
+    [Fact]
+    public void InternalFacet_ShouldCompileAndWork()
+    {
+        // Arrange
+        var entity = new AccessibilityTestEntity
+        {
+            Id = 1,
+            Name = "Test"
+        };
+
+        // Act
+        var facet = new InternalFacet(entity);
+
+        // Assert
+        facet.Should().NotBeNull();
+        facet.Id.Should().Be(1);
+        facet.Name.Should().Be("Test");
+    }
+
+    [Fact]
+    public void PublicFacet_ShouldCompileAndWork()
+    {
+        // Arrange
+        var entity = new AccessibilityTestEntity
+        {
+            Id = 2,
+            Name = "Public Test"
+        };
+
+        // Act
+        var facet = new PublicFacet(entity);
+
+        // Assert
+        facet.Should().NotBeNull();
+        facet.Id.Should().Be(2);
+        facet.Name.Should().Be("Public Test");
+    }
+
+    [Fact]
+    public void InternalFacet_ShouldHaveInternalAccessibility()
+    {
+        // Arrange & Act
+        var facetType = typeof(InternalFacet);
+
+        // Assert - Type should not be public (internal types are not public)
+        facetType.IsPublic.Should().BeFalse("InternalFacet should have internal accessibility");
+        facetType.IsNotPublic.Should().BeTrue("InternalFacet should have internal accessibility");
+    }
+
+    [Fact]
+    public void PublicFacet_ShouldHavePublicAccessibility()
+    {
+        // Arrange & Act
+        var facetType = typeof(PublicFacet);
+
+        // Assert
+        facetType.IsPublic.Should().BeTrue("PublicFacet should have public accessibility");
+    }
+
+    [Fact]
+    public void InternalFacet_ToSource_ShouldWork()
+    {
+        // Arrange
+        var facet = new InternalFacet
+        {
+            Id = 3,
+            Name = "ToSource Test"
+        };
+
+        // Act
+        var entity = facet.ToSource();
+
+        // Assert
+        entity.Should().NotBeNull();
+        entity.Id.Should().Be(3);
+        entity.Name.Should().Be("ToSource Test");
+    }
+
+    [Fact]
+    public void InternalFacet_Projection_ShouldWork()
+    {
+        // Arrange
+        var entities = new[]
+        {
+            new AccessibilityTestEntity { Id = 1, Name = "First" },
+            new AccessibilityTestEntity { Id = 2, Name = "Second" }
+        }.AsQueryable();
+
+        // Act
+        var facets = entities.Select(InternalFacet.Projection).ToList();
+
+        // Assert
+        facets.Should().HaveCount(2);
+        facets[0].Id.Should().Be(1);
+        facets[1].Name.Should().Be("Second");
+    }
+}


### PR DESCRIPTION
Closes #170 

Generators now always copy the acces modifier from the declaring `partial` instead of always printing `public`. Asserted in new unit tests.