### PR TITLE
MapWhen property attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,4 @@ FodyWeavers.xsd
 /test/Facet.Tests/nul
 /nul
 /examples/GeneratedFilesOutput
+/docs/proposals

--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -436,4 +436,49 @@ public partial record ProductDto;
 
 ---
 
+## MapWhen Attribute
+
+The `[MapWhen]` attribute enables conditional property mapping based on source values.
+
+### Basic Usage
+
+```csharp
+[Facet(typeof(Order))]
+public partial class OrderDto
+{
+    [MapWhen("Status == OrderStatus.Completed")]
+    public DateTime? CompletedAt { get; set; }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Condition` | `string` | The condition expression to evaluate (required) |
+| `Default` | `object?` | Custom default value when condition is false |
+| `IncludeInProjection` | `bool` | Include condition in Projection expression (default: true) |
+
+### Supported Conditions
+
+- Boolean: `[MapWhen("IsActive")]`
+- Equality: `[MapWhen("Status == OrderStatus.Completed")]`
+- Null checks: `[MapWhen("Email != null")]`
+- Comparisons: `[MapWhen("Age >= 18")]`
+- Negation: `[MapWhen("!IsDeleted")]`
+
+### Multiple Conditions
+
+Multiple attributes are combined with AND logic:
+
+```csharp
+[MapWhen("IsActive")]
+[MapWhen("Status == OrderStatus.Completed")]
+public DateTime? CompletedAt { get; set; }
+```
+
+See [MapWhen Conditional Mapping](17_MapWhen.md) for full documentation.
+
+---
+
 See [Custom Mapping](04_CustomMapping.md) for advanced scenarios.

--- a/docs/17_MapWhen.md
+++ b/docs/17_MapWhen.md
@@ -1,0 +1,205 @@
+# MapWhen Attribute
+
+The `[MapWhen]` attribute enables conditional property mapping based on source property values. Properties are only mapped when the specified condition evaluates to true.
+
+## Basic Usage
+
+```csharp
+[Facet(typeof(Order))]
+public partial class OrderDto
+{
+    [MapWhen("Status == OrderStatus.Completed")]
+    public DateTime? CompletedAt { get; set; }
+}
+```
+
+When `Status` is `Completed`, `CompletedAt` is mapped from source. Otherwise, it defaults to `null`.
+
+## Supported Conditions
+
+### Boolean Properties
+
+```csharp
+[MapWhen("IsActive")]
+public string? Email { get; set; }
+```
+
+### Equality Comparisons
+
+```csharp
+[MapWhen("Status == OrderStatus.Completed")]
+public DateTime? CompletedAt { get; set; }
+
+[MapWhen("Status != OrderStatus.Cancelled")]
+public string? TrackingNumber { get; set; }
+```
+
+### Null Checks
+
+```csharp
+[MapWhen("Email != null")]
+public string? Email { get; set; }
+```
+
+### Numeric Comparisons
+
+```csharp
+[MapWhen("Age >= 18")]
+public string? AdultContent { get; set; }
+```
+
+### Negation
+
+```csharp
+[MapWhen("!IsDeleted")]
+public string? Content { get; set; }
+```
+
+## Multiple Conditions
+
+Multiple `[MapWhen]` attributes on the same property are combined with AND logic:
+
+```csharp
+[MapWhen("IsActive")]
+[MapWhen("Status == OrderStatus.Completed")]
+public DateTime? CompletedAt { get; set; }
+```
+
+This maps `CompletedAt` only when `IsActive` is true AND `Status` is `Completed`.
+
+## Generated Code
+
+### Constructor
+
+```csharp
+// Input
+[Facet(typeof(Order))]
+public partial class OrderDto
+{
+    [MapWhen("Status == OrderStatus.Completed")]
+    public DateTime? CompletedAt { get; set; }
+}
+
+// Generated constructor
+public OrderDto(Order source)
+{
+    Id = source.Id;
+    Status = source.Status;
+    CompletedAt = (source.Status == OrderStatus.Completed)
+        ? source.CompletedAt
+        : default;
+}
+```
+
+### Projection
+
+The same conditional logic is applied in the Projection expression for use with Entity Framework Core:
+
+```csharp
+public static Expression<Func<Order, OrderDto>> Projection => source => new OrderDto
+{
+    Id = source.Id,
+    Status = source.Status,
+    CompletedAt = (source.Status == OrderStatus.Completed)
+        ? source.CompletedAt
+        : default
+};
+```
+
+## Attribute Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Condition` | `string` | The condition expression (required) |
+| `Default` | `object?` | Custom default value when condition is false |
+| `IncludeInProjection` | `bool` | Whether to include in Projection expression (default: true) |
+
+### Custom Default Values
+
+```csharp
+[MapWhen("HasPrice", Default = 0)]
+public decimal Price { get; set; }
+```
+
+### Excluding from Projection
+
+For conditions that can't be translated to SQL:
+
+```csharp
+[MapWhen("IsActive", IncludeInProjection = false)]
+public string? Email { get; set; }
+```
+
+## Expression Syntax
+
+The condition string uses C# expression syntax:
+
+### Supported Operators
+- Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- Logical: `&&`, `||`, `!`
+
+### Property Access
+- Simple: `IsActive`, `Status`, `Email`
+- Enum values: `OrderStatus.Completed`, `Status == OrderStatus.Pending`
+
+### Literals
+- Booleans: `true`, `false`
+- Null: `null`
+- Numbers: `18`, `0`
+
+## Example Use Cases
+
+### Status-Dependent Fields
+
+```csharp
+[Facet(typeof(Subscription))]
+public partial class SubscriptionDto
+{
+    public SubscriptionStatus Status { get; set; }
+
+    [MapWhen("Status == SubscriptionStatus.Active")]
+    public DateTime? NextBillingDate { get; set; }
+
+    [MapWhen("Status == SubscriptionStatus.Cancelled")]
+    public string? CancellationReason { get; set; }
+}
+```
+
+### Conditional Sensitive Data
+
+```csharp
+[Facet(typeof(Employee))]
+public partial class EmployeeDto
+{
+    public string Name { get; set; }
+
+    [MapWhen("!IsSalaryConfidential")]
+    public decimal? Salary { get; set; }
+}
+```
+
+### Age-Gated Content
+
+```csharp
+[Facet(typeof(User))]
+public partial class UserDto
+{
+    public int Age { get; set; }
+
+    [MapWhen("Age >= 18")]
+    public string? AdultPreferences { get; set; }
+}
+```
+
+## Limitations
+
+- Method calls in conditions (like `string.IsNullOrEmpty()`) are not supported
+- Nested property access (like `Address.City`) is not supported
+- Complex expressions may need to be simplified
+
+## Best Practices
+
+1. **Keep conditions simple** - Use basic comparisons and boolean checks
+2. **Use nullable properties** - Since conditions may be false, properties should typically be nullable
+3. **Consider EF Core translation** - If using projections with a database, ensure conditions can translate to SQL
+4. **Test both paths** - Write tests for both when conditions are true and false

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to the Facet documentation! This index will help you navigate all availa
 - [Attribute Reference](03_AttributeReference.md): Facet Attribute Reference
 - [Custom Mapping](04_CustomMapping.md): Custom Mapping with IFacetMapConfiguration & Async Support
 - [Property Mapping](15_MapFromAttribute.md): Declarative property renaming with MapFrom attribute
+- [MapWhen Conditional Mapping](17_MapWhen.md): Conditionally map properties based on source values
 - [Extension Methods](05_Extensions.md): Extension Methods (LINQ, EF Core, etc.)
 - [Advanced Scenarios](06_AdvancedScenarios.md): Advanced Usage Scenarios
   - Multiple facets from one source

--- a/src/Facet/FacetMember.cs
+++ b/src/Facet/FacetMember.cs
@@ -28,6 +28,11 @@ internal sealed class FacetMember : IEquatable<FacetMember>
     public string SourcePropertyName { get; }
     public bool IsUserDeclared { get; }
 
+    // MapWhen attribute properties
+    public IReadOnlyList<string> MapWhenConditions { get; }
+    public string? MapWhenDefault { get; }
+    public bool MapWhenIncludeInProjection { get; }
+
     public FacetMember(
         string name,
         string typeName,
@@ -47,7 +52,10 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         bool mapFromReversible = false,
         bool mapFromIncludeInProjection = true,
         string? sourcePropertyName = null,
-        bool isUserDeclared = false)
+        bool isUserDeclared = false,
+        IReadOnlyList<string>? mapWhenConditions = null,
+        string? mapWhenDefault = null,
+        bool mapWhenIncludeInProjection = true)
     {
         Name = name;
         TypeName = typeName;
@@ -68,6 +76,9 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         MapFromIncludeInProjection = mapFromIncludeInProjection;
         SourcePropertyName = sourcePropertyName ?? name;
         IsUserDeclared = isUserDeclared;
+        MapWhenConditions = mapWhenConditions ?? Array.Empty<string>();
+        MapWhenDefault = mapWhenDefault;
+        MapWhenIncludeInProjection = mapWhenIncludeInProjection;
     }
 
     public bool Equals(FacetMember? other) =>
@@ -89,7 +100,10 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         MapFromIncludeInProjection == other.MapFromIncludeInProjection &&
         SourcePropertyName == other.SourcePropertyName &&
         IsUserDeclared == other.IsUserDeclared &&
-        Attributes.SequenceEqual(other.Attributes);
+        MapWhenDefault == other.MapWhenDefault &&
+        MapWhenIncludeInProjection == other.MapWhenIncludeInProjection &&
+        Attributes.SequenceEqual(other.Attributes) &&
+        MapWhenConditions.SequenceEqual(other.MapWhenConditions);
 
     public override bool Equals(object? obj) => obj is FacetMember other && Equals(other);
 
@@ -115,9 +129,14 @@ internal sealed class FacetMember : IEquatable<FacetMember>
             hash = hash * 31 + MapFromIncludeInProjection.GetHashCode();
             hash = hash * 31 + SourcePropertyName.GetHashCode();
             hash = hash * 31 + IsUserDeclared.GetHashCode();
+            hash = hash * 31 + (MapWhenDefault?.GetHashCode() ?? 0);
+            hash = hash * 31 + MapWhenIncludeInProjection.GetHashCode();
             hash = hash * 31 + Attributes.Count.GetHashCode();
             foreach (var attr in Attributes)
                 hash = hash * 31 + (attr?.GetHashCode() ?? 0);
+            hash = hash * 31 + MapWhenConditions.Count.GetHashCode();
+            foreach (var cond in MapWhenConditions)
+                hash = hash * 31 + (cond?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -42,6 +42,11 @@ internal static class FacetConstants
     public const string MapFromAttributeFullName = "Facet.MapFromAttribute";
 
     /// <summary>
+    /// The fully qualified name of the MapWhenAttribute.
+    /// </summary>
+    public const string MapWhenAttributeFullName = "Facet.MapWhenAttribute";
+
+    /// <summary>
     /// The default maximum depth for nested facet traversal to prevent stack overflow.
     /// </summary>
     public const int DefaultMaxDepth = 10;

--- a/src/Facet/MapWhenAttribute.cs
+++ b/src/Facet/MapWhenAttribute.cs
@@ -1,0 +1,106 @@
+using System;
+
+namespace Facet;
+
+/// <summary>
+/// Specifies that a property should only be mapped when a condition is met.
+/// The condition is evaluated against the source object's properties.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="MapWhenAttribute"/> allows conditional property mapping based on source values:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>Boolean check: <c>[MapWhen("IsActive")]</c></description>
+/// </item>
+/// <item>
+/// <description>Equality: <c>[MapWhen("Status == OrderStatus.Completed")]</c></description>
+/// </item>
+/// <item>
+/// <description>Null check: <c>[MapWhen("Email != null")]</c></description>
+/// </item>
+/// <item>
+/// <description>Comparison: <c>[MapWhen("Age >= 18")]</c></description>
+/// </item>
+/// </list>
+/// <para>
+/// When the condition is false, the property is set to its default value (or the specified <see cref="Default"/>).
+/// Multiple <see cref="MapWhenAttribute"/>s on the same property are combined with AND logic.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Facet(typeof(Order))]
+/// public partial class OrderDto
+/// {
+///     public OrderStatus Status { get; set; }
+///
+///     [MapWhen("Status == OrderStatus.Completed")]
+///     public DateTime? CompletedAt { get; set; }
+///
+///     [MapWhen("Price != null", Default = 0)]
+///     public decimal Price { get; set; }
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+public sealed class MapWhenAttribute : Attribute
+{
+    /// <summary>
+    /// The condition expression to evaluate against the source object.
+    /// Uses C# expression syntax with source property names.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Supported operators:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Comparison: ==, !=, &lt;, &gt;, &lt;=, &gt;=</description></item>
+    /// <item><description>Logical: &amp;&amp;, ||, !</description></item>
+    /// <item><description>Null: ??, ?.</description></item>
+    /// </list>
+    /// <para>
+    /// Property names refer to source object properties. For example, "IsActive"
+    /// checks source.IsActive.
+    /// </para>
+    /// </remarks>
+    public string Condition { get; }
+
+    /// <summary>
+    /// Default value when the condition is false.
+    /// If not specified, uses default(T) for value types or null for reference types.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For non-nullable value types, you should specify a default value to avoid
+    /// compilation errors. For example:
+    /// </para>
+    /// <code>
+    /// [MapWhen("HasPrice", Default = 0)]
+    /// public decimal Price { get; set; }
+    /// </code>
+    /// </remarks>
+    public object? Default { get; set; }
+
+    /// <summary>
+    /// Whether to include this condition in the generated Projection expression.
+    /// Default is true.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set to false for conditions that cannot be translated to SQL by Entity Framework Core.
+    /// When false, the condition will only be evaluated in the constructor, not in LINQ projections.
+    /// </para>
+    /// </remarks>
+    public bool IncludeInProjection { get; set; } = true;
+
+    /// <summary>
+    /// Creates a new MapWhenAttribute with the specified condition.
+    /// </summary>
+    /// <param name="condition">The condition expression to evaluate against the source object.</param>
+    public MapWhenAttribute(string condition)
+    {
+        Condition = condition ?? throw new ArgumentNullException(nameof(condition));
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/MapWhenTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/MapWhenTests.cs
@@ -1,0 +1,471 @@
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+// Test entities
+public class MapWhenTestEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+    public OrderStatus Status { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public decimal? Price { get; set; }
+    public int Age { get; set; }
+    public string? Email { get; set; }
+}
+
+public enum OrderStatus
+{
+    Pending,
+    Processing,
+    Completed,
+    Cancelled
+}
+
+// Basic boolean condition test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenBooleanFacet
+{
+    [MapWhen("IsActive")]
+    public string? Email { get; set; }
+}
+
+// Equality comparison test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenEqualityFacet
+{
+    [MapWhen("Status == OrderStatus.Completed")]
+    public DateTime? CompletedAt { get; set; }
+}
+
+// Null check test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenNullCheckFacet
+{
+    [MapWhen("Email != null")]
+    public string? Email { get; set; }
+}
+
+// With default value test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenDefaultValueFacet
+{
+    [MapWhen("Price != null")]
+    public decimal? Price { get; set; }
+}
+
+// Comparison operator test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenComparisonFacet
+{
+    [MapWhen("Age >= 18")]
+    public string? Email { get; set; }
+}
+
+// Multiple conditions (AND logic) test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenMultipleConditionsFacet
+{
+    [MapWhen("IsActive")]
+    [MapWhen("Status == OrderStatus.Completed")]
+    public DateTime? CompletedAt { get; set; }
+}
+
+// Combined with other properties
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenMixedFacet
+{
+    [MapWhen("IsActive")]
+    public string? Email { get; set; }
+
+    [MapWhen("Status == OrderStatus.Completed")]
+    public DateTime? CompletedAt { get; set; }
+}
+
+// Exclude from projection test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenNoProjectionFacet
+{
+    [MapWhen("IsActive", IncludeInProjection = false)]
+    public string? Email { get; set; }
+}
+
+// Negation test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenNegationFacet
+{
+    [MapWhen("!IsActive")]
+    public string? Email { get; set; }
+}
+
+// Not equal test
+[Facet(typeof(MapWhenTestEntity))]
+public partial class MapWhenNotEqualFacet
+{
+    [MapWhen("Status != OrderStatus.Cancelled")]
+    public DateTime? CompletedAt { get; set; }
+}
+
+public class MapWhenTests
+{
+    [Fact]
+    public void Constructor_ShouldMapWhenBooleanConditionIsTrue()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Name = "Test",
+            IsActive = true,
+            Email = "test@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenBooleanFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(1);
+        facet.Name.Should().Be("Test");
+        facet.Email.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenBooleanConditionIsFalse()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Name = "Test",
+            IsActive = false,
+            Email = "test@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenBooleanFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(1);
+        facet.Name.Should().Be("Test");
+        facet.Email.Should().BeNull(); // Condition false, so default
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenEqualityConditionIsTrue()
+    {
+        // Arrange
+        var completedTime = new DateTime(2024, 1, 15, 10, 30, 0);
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Name = "Order",
+            Status = OrderStatus.Completed,
+            CompletedAt = completedTime
+        };
+
+        // Act
+        var facet = new MapWhenEqualityFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(1);
+        facet.CompletedAt.Should().Be(completedTime);
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenEqualityConditionIsFalse()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Name = "Order",
+            Status = OrderStatus.Pending,
+            CompletedAt = DateTime.Now
+        };
+
+        // Act
+        var facet = new MapWhenEqualityFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(1);
+        facet.CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenNullCheckPasses()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Email = "test@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenNullCheckFacet(entity);
+
+        // Assert
+        facet.Email.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenNullCheckFails()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Email = null
+        };
+
+        // Act
+        var facet = new MapWhenNullCheckFacet(entity);
+
+        // Assert
+        facet.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldReturnDefaultWhenConditionIsFalse()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Price = null
+        };
+
+        // Act
+        var facet = new MapWhenDefaultValueFacet(entity);
+
+        // Assert
+        facet.Price.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenConditionIsTrue_WithNullableProperty()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Price = 99.99m
+        };
+
+        // Act
+        var facet = new MapWhenDefaultValueFacet(entity);
+
+        // Assert
+        facet.Price.Should().Be(99.99m);
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenComparisonConditionIsTrue()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Age = 21,
+            Email = "adult@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenComparisonFacet(entity);
+
+        // Assert
+        facet.Email.Should().Be("adult@example.com");
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenComparisonConditionIsFalse()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Age = 16,
+            Email = "minor@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenComparisonFacet(entity);
+
+        // Assert
+        facet.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenAllMultipleConditionsAreTrue()
+    {
+        // Arrange
+        var completedTime = new DateTime(2024, 1, 15, 10, 30, 0);
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            IsActive = true,
+            Status = OrderStatus.Completed,
+            CompletedAt = completedTime
+        };
+
+        // Act
+        var facet = new MapWhenMultipleConditionsFacet(entity);
+
+        // Assert
+        facet.CompletedAt.Should().Be(completedTime);
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenAnyMultipleConditionIsFalse()
+    {
+        // Arrange - IsActive is false
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            IsActive = false,
+            Status = OrderStatus.Completed,
+            CompletedAt = DateTime.Now
+        };
+
+        // Act
+        var facet = new MapWhenMultipleConditionsFacet(entity);
+
+        // Assert
+        facet.CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Projection_ShouldApplyConditions()
+    {
+        // Arrange
+        var entities = new[]
+        {
+            new MapWhenTestEntity { Id = 1, Name = "Active", IsActive = true, Email = "active@example.com" },
+            new MapWhenTestEntity { Id = 2, Name = "Inactive", IsActive = false, Email = "inactive@example.com" }
+        }.AsQueryable();
+
+        // Act
+        var facets = entities.Select(MapWhenBooleanFacet.Projection).ToList();
+
+        // Assert
+        facets.Should().HaveCount(2);
+        facets[0].Email.Should().Be("active@example.com");
+        facets[1].Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void Projection_ShouldApplyEqualityConditions()
+    {
+        // Arrange
+        var completedTime = new DateTime(2024, 1, 15);
+        var entities = new[]
+        {
+            new MapWhenTestEntity { Id = 1, Status = OrderStatus.Completed, CompletedAt = completedTime },
+            new MapWhenTestEntity { Id = 2, Status = OrderStatus.Pending, CompletedAt = completedTime }
+        }.AsQueryable();
+
+        // Act
+        var facets = entities.Select(MapWhenEqualityFacet.Projection).ToList();
+
+        // Assert
+        facets[0].CompletedAt.Should().Be(completedTime);
+        facets[1].CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapMixedProperties()
+    {
+        // Arrange
+        var completedTime = new DateTime(2024, 1, 15);
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Name = "Test Order",
+            IsActive = true,
+            Status = OrderStatus.Completed,
+            Email = "test@example.com",
+            CompletedAt = completedTime
+        };
+
+        // Act
+        var facet = new MapWhenMixedFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(1);
+        facet.Name.Should().Be("Test Order");
+        facet.Email.Should().Be("test@example.com");
+        facet.CompletedAt.Should().Be(completedTime);
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenNegationConditionIsTrue()
+    {
+        // Arrange - !IsActive is true when IsActive is false
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            IsActive = false,
+            Email = "inactive@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenNegationFacet(entity);
+
+        // Assert
+        facet.Email.Should().Be("inactive@example.com");
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenNegationConditionIsFalse()
+    {
+        // Arrange - !IsActive is false when IsActive is true
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            IsActive = true,
+            Email = "active@example.com"
+        };
+
+        // Act
+        var facet = new MapWhenNegationFacet(entity);
+
+        // Assert
+        facet.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapWhenNotEqualConditionIsTrue()
+    {
+        // Arrange
+        var completedTime = new DateTime(2024, 1, 15);
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Status = OrderStatus.Completed,
+            CompletedAt = completedTime
+        };
+
+        // Act
+        var facet = new MapWhenNotEqualFacet(entity);
+
+        // Assert
+        facet.CompletedAt.Should().Be(completedTime);
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotMapWhenNotEqualConditionIsFalse()
+    {
+        // Arrange
+        var entity = new MapWhenTestEntity
+        {
+            Id = 1,
+            Status = OrderStatus.Cancelled,
+            CompletedAt = DateTime.Now
+        };
+
+        // Act
+        var facet = new MapWhenNotEqualFacet(entity);
+
+        // Assert
+        facet.CompletedAt.Should().BeNull();
+    }
+}


### PR DESCRIPTION
# Add MapWhen Conditional Mapping

## Summary

Adds a new `[MapWhen]` attribute that enables conditional property mapping based on source values. Properties are only mapped when the specified condition evaluates to true.

## Features

- **Boolean conditions**: `[MapWhen("IsActive")]`
- **Equality comparisons**: `[MapWhen("Status == OrderStatus.Completed")]`
- **Null checks**: `[MapWhen("Email != null")]`
- **Numeric comparisons**: `[MapWhen("Age >= 18")]`
- **Multiple conditions** (AND logic): Stack multiple attributes
- **EF Core support**: Conditions translate to SQL in projections

## Example

```csharp
[Facet(typeof(Order))]
public partial class OrderDto
{
    [MapWhen("Status == OrderStatus.Completed")]
    public DateTime? CompletedAt { get; set; }

    [MapWhen("IsActive")]
    public string? Email { get; set; }
}
```

Closes #178 