### PR TITLE
feat: Generate patch DTOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Click on a section to expand/collapse
 
 - **Flatten** nested objects into top-level properties
 - **Wrapper** pattern for reference-based delegation (facades, decorators, ViewModels)
-- **Auto-generate CRUD DTOs** (Create, Update, Response, Query, Upsert)
+- **Auto-generate CRUD DTOs** (Create, Update, Response, Query, Upsert, Patch)
 - **Source signature tracking** for detecting breaking changes when source entities change
 
 </details> 
@@ -634,7 +634,7 @@ var users = await dbContext.Users
 <details>
   <summary>Automatic CRUD DTO Generation with [GenerateDtos]</summary>
   
-Generate standard Create, Update, Response, Query, and Upsert DTOs automatically:
+Generate standard Create, Update, Response, Query, Upsert, and Patch DTOs automatically:
 
 ```csharp
 // Generate all standard CRUD DTOs

--- a/src/Facet.Attributes/GenerateDtosAttribute.cs
+++ b/src/Facet.Attributes/GenerateDtosAttribute.cs
@@ -14,7 +14,8 @@ public enum DtoTypes
     Response = 4,
     Query = 8,
     Upsert = 16,
-    All = Create | Update | Response | Query | Upsert
+    Patch = 32,
+    All = Create | Update | Response | Query | Upsert | Patch
 }
 
 /// <summary>

--- a/src/Facet.Attributes/Optional.cs
+++ b/src/Facet.Attributes/Optional.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace Facet;
+
+/// <summary>
+/// Represents an optional value that can be either specified or unspecified.
+/// This is useful for PATCH operations where you need to distinguish between
+/// a value that was not provided and a value that was explicitly set to null or a specific value.
+/// </summary>
+/// <typeparam name="T">The type of the optional value.</typeparam>
+public readonly struct Optional<T>
+{
+    private readonly T _value;
+    private readonly bool _hasValue;
+
+    /// <summary>
+    /// Gets a value indicating whether this optional has a value.
+    /// </summary>
+    public bool HasValue => _hasValue;
+
+    /// <summary>
+    /// Gets the value of this optional.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when HasValue is false.</exception>
+    public T Value
+    {
+        get
+        {
+            if (!_hasValue)
+                throw new InvalidOperationException("Optional does not have a value.");
+            return _value;
+        }
+    }
+
+    /// <summary>
+    /// Creates an optional with a value.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    public Optional(T value)
+    {
+        _value = value;
+        _hasValue = true;
+    }
+
+    /// <summary>
+    /// Gets the value if present, otherwise returns the default value for the type.
+    /// </summary>
+    /// <param name="defaultValue">The default value to return if no value is present.</param>
+    /// <returns>The value if present, otherwise the default value.</returns>
+    public T GetValueOrDefault(T defaultValue = default!)
+    {
+        return _hasValue ? _value : defaultValue;
+    }
+
+    /// <summary>
+    /// Implicitly converts a value to an Optional.
+    /// </summary>
+    public static implicit operator Optional<T>(T value) => new(value);
+
+    /// <summary>
+    /// Converts the optional to its string representation.
+    /// </summary>
+    public override string ToString()
+    {
+        return _hasValue ? _value?.ToString() ?? "null" : "unspecified";
+    }
+
+    /// <summary>
+    /// Determines whether this optional equals another optional.
+    /// </summary>
+    public override bool Equals(object? obj)
+    {
+        if (obj is not Optional<T> other)
+            return false;
+
+        if (!_hasValue && !other._hasValue)
+            return true;
+
+        if (_hasValue != other._hasValue)
+            return false;
+
+        return Equals(_value, other._value);
+    }
+
+    /// <summary>
+    /// Gets the hash code for this optional.
+    /// </summary>
+    public override int GetHashCode()
+    {
+        if (!_hasValue)
+            return 0;
+
+        return _value?.GetHashCode() ?? 1;
+    }
+
+    /// <summary>
+    /// Determines whether two optionals are equal.
+    /// </summary>
+    public static bool operator ==(Optional<T> left, Optional<T> right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two optionals are not equal.
+    /// </summary>
+    public static bool operator !=(Optional<T> left, Optional<T> right) => !left.Equals(right);
+}

--- a/test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs
+++ b/test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs
@@ -21,6 +21,18 @@ public class TestUser
     public DateTime CreatedAt { get; set; }
 }
 
+// Dedicated entity for Patch DTO testing
+[GenerateDtos(Types = DtoTypes.Patch, OutputType = OutputType.Class)]
+public class PatchTestEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public bool IsActive { get; set; }
+    public DateTime? LastLoginAt { get; set; }
+    public decimal Price { get; set; }
+}
+
 [GenerateAuditableDtos(Types = DtoTypes.Create | DtoTypes.Update | DtoTypes.Response, OutputType = OutputType.Class)]
 public class TestProduct
 {

--- a/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPatchTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPatchTests.cs
@@ -1,0 +1,300 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.GenerateDtos;
+
+/// <summary>
+/// Tests for Patch DTO generation and functionality.
+/// Verifies that generated Patch DTOs work correctly for partial updates.
+/// </summary>
+public class GenerateDtosPatchTests
+{
+    [Fact]
+    public void PatchDto_ApplyTo_ShouldOnlyUpdateSpecifiedProperties()
+    {
+        // Arrange
+        var entity = new PatchTestEntity
+        {
+            Id = 1,
+            Name = "Original",
+            Email = "original@example.com",
+            IsActive = true,
+            Price = 100m
+        };
+
+        var patch = new PatchTestEntityPatch
+        {
+            Name = new Optional<string>("Updated"),
+            Price = new Optional<decimal>(200m)
+            // Email, IsActive, and Id are not set (unspecified)
+        };
+
+        // Act
+        patch.ApplyTo(entity);
+
+        // Assert
+        entity.Name.Should().Be("Updated", "Name was specified in patch");
+        entity.Price.Should().Be(200m, "Price was specified in patch");
+        entity.Email.Should().Be("original@example.com", "Email was not specified in patch");
+        entity.IsActive.Should().BeTrue("IsActive was not specified in patch");
+        entity.Id.Should().Be(1, "Id was not specified in patch");
+    }
+
+    [Fact]
+    public void PatchDto_ApplyTo_ShouldHandleExplicitNullValues()
+    {
+        // Arrange
+        var entity = new PatchTestEntity
+        {
+            Id = 1,
+            Name = "Test",
+            Email = "test@example.com",
+            LastLoginAt = DateTime.Now
+        };
+
+        var patch = new PatchTestEntityPatch
+        {
+            Email = new Optional<string?>(null),  // Explicitly set to null
+            LastLoginAt = new Optional<DateTime?>(null)  // Explicitly set to null
+        };
+
+        // Act
+        patch.ApplyTo(entity);
+
+        // Assert
+        entity.Email.Should().BeNull("Email was explicitly set to null");
+        entity.LastLoginAt.Should().BeNull("LastLoginAt was explicitly set to null");
+        entity.Name.Should().Be("Test", "Name was not modified");
+    }
+
+    [Fact]
+    public void PatchDto_ApplyTo_ShouldNotUpdateUnspecifiedProperties()
+    {
+        // Arrange
+        var originalDate = DateTime.Now;
+        var entity = new PatchTestEntity
+        {
+            Id = 1,
+            Name = "Original",
+            Email = "original@example.com",
+            IsActive = true,
+            LastLoginAt = originalDate,
+            Price = 100m
+        };
+
+        var patch = new PatchTestEntityPatch();
+        // All properties are unspecified (default Optional<T> values)
+
+        // Act
+        patch.ApplyTo(entity);
+
+        // Assert - Nothing should have changed
+        entity.Id.Should().Be(1);
+        entity.Name.Should().Be("Original");
+        entity.Email.Should().Be("original@example.com");
+        entity.IsActive.Should().BeTrue();
+        entity.LastLoginAt.Should().Be(originalDate);
+        entity.Price.Should().Be(100m);
+    }
+
+    [Fact]
+    public void PatchDto_ApplyTo_ShouldHandleValueTypes()
+    {
+        // Arrange
+        var entity = new PatchTestEntity
+        {
+            Id = 1,
+            IsActive = false,
+            Price = 100m
+        };
+
+        var patch = new PatchTestEntityPatch
+        {
+            IsActive = new Optional<bool>(true),
+            Price = new Optional<decimal>(250.50m),
+            Id = new Optional<int>(42)
+        };
+
+        // Act
+        patch.ApplyTo(entity);
+
+        // Assert
+        entity.IsActive.Should().BeTrue("IsActive was updated to true");
+        entity.Price.Should().Be(250.50m, "Price was updated");
+        entity.Id.Should().Be(42, "Id was updated");
+    }
+
+    [Fact]
+    public void PatchDto_ApplyTo_WithNullTarget_ShouldThrow()
+    {
+        // Arrange
+        var patch = new PatchTestEntityPatch
+        {
+            Name = new Optional<string>("Test")
+        };
+
+        // Act
+        Action act = () => patch.ApplyTo(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void PatchDto_ApplyTo_ShouldHandleAllPropertyUpdatesInSingleCall()
+    {
+        // Arrange
+        var entity = new PatchTestEntity
+        {
+            Id = 1,
+            Name = "Old",
+            Email = "old@example.com",
+            IsActive = false,
+            Price = 50m,
+            LastLoginAt = null
+        };
+
+        var newLoginDate = DateTime.Now;
+        var patch = new PatchTestEntityPatch
+        {
+            Id = new Optional<int>(42),
+            Name = new Optional<string>("New"),
+            Email = new Optional<string?>("new@example.com"),
+            IsActive = new Optional<bool>(true),
+            Price = new Optional<decimal>(150m),
+            LastLoginAt = new Optional<DateTime?>(newLoginDate)
+        };
+
+        // Act
+        patch.ApplyTo(entity);
+
+        // Assert
+        entity.Id.Should().Be(42);
+        entity.Name.Should().Be("New");
+        entity.Email.Should().Be("new@example.com");
+        entity.IsActive.Should().BeTrue();
+        entity.Price.Should().Be(150m);
+        entity.LastLoginAt.Should().Be(newLoginDate);
+    }
+
+    [Fact]
+    public void PatchDto_ApplyTo_ShouldDistinguishBetweenNullAndUnspecified()
+    {
+        // Arrange
+        var entity1 = new PatchTestEntity
+        {
+            Id = 1,
+            Email = "test1@example.com",
+            LastLoginAt = DateTime.Now
+        };
+
+        var entity2 = new PatchTestEntity
+        {
+            Id = 2,
+            Email = "test2@example.com",
+            LastLoginAt = DateTime.Now
+        };
+
+        var patchWithNull = new PatchTestEntityPatch
+        {
+            Email = new Optional<string?>(null),  // Explicitly null
+            LastLoginAt = new Optional<DateTime?>(null)  // Explicitly null
+        };
+
+        var patchWithUnspecified = new PatchTestEntityPatch();
+        // Email and LastLoginAt are unspecified (default Optional values)
+
+        // Act
+        patchWithNull.ApplyTo(entity1);
+        patchWithUnspecified.ApplyTo(entity2);
+
+        // Assert
+        entity1.Email.Should().BeNull("Email was explicitly set to null");
+        entity1.LastLoginAt.Should().BeNull("LastLoginAt was explicitly set to null");
+
+        entity2.Email.Should().Be("test2@example.com", "Email was unspecified, so it kept its original value");
+        entity2.LastLoginAt.Should().NotBeNull("LastLoginAt was unspecified, so it kept its original value");
+    }
+
+    [Fact]
+    public void PatchDto_ImplicitConversion_ShouldWork()
+    {
+        // Arrange
+        var entity = new PatchTestEntity
+        {
+            Name = "Original"
+        };
+
+        // Act - Use implicit conversion
+        var patch = new PatchTestEntityPatch
+        {
+            Name = "Updated"  // Implicitly converted to Optional<string>
+        };
+        patch.ApplyTo(entity);
+
+        // Assert
+        entity.Name.Should().Be("Updated");
+    }
+
+    [Fact]
+    public void PatchDto_Properties_ShouldBeOptionalType()
+    {
+        // Arrange & Act
+        var patch = new PatchTestEntityPatch();
+
+        // Assert - Verify properties are Optional<T>
+        patch.Id.Should().BeOfType<Optional<int>>();
+        patch.Name.Should().BeOfType<Optional<string>>();
+        patch.Email.Should().BeOfType<Optional<string?>>();
+        patch.IsActive.Should().BeOfType<Optional<bool>>();
+        patch.LastLoginAt.Should().BeOfType<Optional<DateTime?>>();
+        patch.Price.Should().BeOfType<Optional<decimal>>();
+    }
+
+    [Fact]
+    public void PatchDto_DefaultState_ShouldHaveNoValues()
+    {
+        // Arrange & Act
+        var patch = new PatchTestEntityPatch();
+
+        // Assert - All properties should have no value by default
+        patch.Id.HasValue.Should().BeFalse();
+        patch.Name.HasValue.Should().BeFalse();
+        patch.Email.HasValue.Should().BeFalse();
+        patch.IsActive.HasValue.Should().BeFalse();
+        patch.LastLoginAt.HasValue.Should().BeFalse();
+        patch.Price.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PatchDto_PartialUpdate_RealWorldScenario()
+    {
+        // Arrange - Simulate a real API PATCH scenario
+        var existingUser = new PatchTestEntity
+        {
+            Id = 123,
+            Name = "John Doe",
+            Email = "john@example.com",
+            IsActive = true,
+            LastLoginAt = new DateTime(2024, 1, 1),
+            Price = 99.99m
+        };
+
+        // Act - Client only wants to update name and deactivate
+        var patchFromClient = new PatchTestEntityPatch
+        {
+            Name = "Jane Doe",
+            IsActive = false
+            // Other properties intentionally not set
+        };
+
+        patchFromClient.ApplyTo(existingUser);
+
+        // Assert
+        existingUser.Id.Should().Be(123, "Id unchanged");
+        existingUser.Name.Should().Be("Jane Doe", "Name updated");
+        existingUser.Email.Should().Be("john@example.com", "Email unchanged");
+        existingUser.IsActive.Should().BeFalse("IsActive updated");
+        existingUser.LastLoginAt.Should().Be(new DateTime(2024, 1, 1), "LastLoginAt unchanged");
+        existingUser.Price.Should().Be(99.99m, "Price unchanged");
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/OptionalTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/OptionalTests.cs
@@ -1,0 +1,238 @@
+using Facet;
+
+namespace Facet.Tests.UnitTests.Core;
+
+/// <summary>
+/// Tests for the Optional&lt;T&gt; type used in Patch DTOs.
+/// </summary>
+public class OptionalTests
+{
+    [Fact]
+    public void Optional_DefaultConstructor_ShouldHaveNoValue()
+    {
+        // Arrange & Act
+        var optional = new Optional<string>();
+
+        // Assert
+        optional.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Optional_WithValue_ShouldHaveValue()
+    {
+        // Arrange & Act
+        var optional = new Optional<string>("test");
+
+        // Assert
+        optional.HasValue.Should().BeTrue();
+        optional.Value.Should().Be("test");
+    }
+
+    [Fact]
+    public void Optional_WithNullValue_ShouldHaveValue()
+    {
+        // Arrange & Act
+        var optional = new Optional<string?>(null);
+
+        // Assert
+        optional.HasValue.Should().BeTrue("null is a valid value that was explicitly set");
+        optional.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Optional_AccessingValueWhenNotSet_ShouldThrow()
+    {
+        // Arrange
+        var optional = new Optional<string>();
+
+        // Act
+        Action act = () => { var value = optional.Value; };
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Optional does not have a value.");
+    }
+
+    [Fact]
+    public void Optional_GetValueOrDefault_WhenHasValue_ShouldReturnValue()
+    {
+        // Arrange
+        var optional = new Optional<int>(42);
+
+        // Act
+        var result = optional.GetValueOrDefault(0);
+
+        // Assert
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void Optional_GetValueOrDefault_WhenNoValue_ShouldReturnDefault()
+    {
+        // Arrange
+        var optional = new Optional<int>();
+
+        // Act
+        var result = optional.GetValueOrDefault(99);
+
+        // Assert
+        result.Should().Be(99);
+    }
+
+    [Fact]
+    public void Optional_ImplicitConversion_ShouldWork()
+    {
+        // Arrange & Act
+        Optional<string> optional = "test";
+
+        // Assert
+        optional.HasValue.Should().BeTrue();
+        optional.Value.Should().Be("test");
+    }
+
+    [Fact]
+    public void Optional_Equals_BothEmpty_ShouldBeEqual()
+    {
+        // Arrange
+        var optional1 = new Optional<string>();
+        var optional2 = new Optional<string>();
+
+        // Act & Assert
+        optional1.Equals(optional2).Should().BeTrue();
+        (optional1 == optional2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Optional_Equals_SameValue_ShouldBeEqual()
+    {
+        // Arrange
+        var optional1 = new Optional<string>("test");
+        var optional2 = new Optional<string>("test");
+
+        // Act & Assert
+        optional1.Equals(optional2).Should().BeTrue();
+        (optional1 == optional2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Optional_Equals_DifferentValues_ShouldNotBeEqual()
+    {
+        // Arrange
+        var optional1 = new Optional<string>("test1");
+        var optional2 = new Optional<string>("test2");
+
+        // Act & Assert
+        optional1.Equals(optional2).Should().BeFalse();
+        (optional1 != optional2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Optional_Equals_OneEmptyOneWithValue_ShouldNotBeEqual()
+    {
+        // Arrange
+        var optional1 = new Optional<string>();
+        var optional2 = new Optional<string>("test");
+
+        // Act & Assert
+        optional1.Equals(optional2).Should().BeFalse();
+        (optional1 != optional2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Optional_ToString_WhenHasValue_ShouldReturnValueString()
+    {
+        // Arrange
+        var optional = new Optional<int>(42);
+
+        // Act
+        var result = optional.ToString();
+
+        // Assert
+        result.Should().Be("42");
+    }
+
+    [Fact]
+    public void Optional_ToString_WhenHasNullValue_ShouldReturnNull()
+    {
+        // Arrange
+        var optional = new Optional<string?>(null);
+
+        // Act
+        var result = optional.ToString();
+
+        // Assert
+        result.Should().Be("null");
+    }
+
+    [Fact]
+    public void Optional_ToString_WhenNoValue_ShouldReturnUnspecified()
+    {
+        // Arrange
+        var optional = new Optional<string>();
+
+        // Act
+        var result = optional.ToString();
+
+        // Assert
+        result.Should().Be("unspecified");
+    }
+
+    [Fact]
+    public void Optional_GetHashCode_BothEmpty_ShouldBeEqual()
+    {
+        // Arrange
+        var optional1 = new Optional<string>();
+        var optional2 = new Optional<string>();
+
+        // Act & Assert
+        optional1.GetHashCode().Should().Be(optional2.GetHashCode());
+    }
+
+    [Fact]
+    public void Optional_GetHashCode_SameValue_ShouldBeEqual()
+    {
+        // Arrange
+        var optional1 = new Optional<string>("test");
+        var optional2 = new Optional<string>("test");
+
+        // Act & Assert
+        optional1.GetHashCode().Should().Be(optional2.GetHashCode());
+    }
+
+    [Fact]
+    public void Optional_WithValueType_ShouldWork()
+    {
+        // Arrange & Act
+        var optionalInt = new Optional<int>(42);
+        var optionalBool = new Optional<bool>(true);
+        var optionalDateTime = new Optional<DateTime>(new DateTime(2024, 1, 1));
+
+        // Assert
+        optionalInt.HasValue.Should().BeTrue();
+        optionalInt.Value.Should().Be(42);
+
+        optionalBool.HasValue.Should().BeTrue();
+        optionalBool.Value.Should().BeTrue();
+
+        optionalDateTime.HasValue.Should().BeTrue();
+        optionalDateTime.Value.Should().Be(new DateTime(2024, 1, 1));
+    }
+
+    [Fact]
+    public void Optional_WithNullableValueType_ShouldDistinguishNullFromUnspecified()
+    {
+        // Arrange & Act
+        var unspecified = new Optional<int?>();
+        var explicitlyNull = new Optional<int?>(null);
+        var withValue = new Optional<int?>(42);
+
+        // Assert
+        unspecified.HasValue.Should().BeFalse("value was not specified");
+
+        explicitlyNull.HasValue.Should().BeTrue("null was explicitly set");
+        explicitlyNull.Value.Should().BeNull();
+
+        withValue.HasValue.Should().BeTrue();
+        withValue.Value.Should().Be(42);
+    }
+}


### PR DESCRIPTION
Closes #205 

Adds new type of DTO to the [GenerateDtos] attribute: patch. It has `Optional<t>` type properties and implements value tracking.