### PR TITLE
feat: ApplyFacet

### DIFF
--- a/src/Facet.Extensions/README.md
+++ b/src/Facet.Extensions/README.md
@@ -4,10 +4,18 @@ Provider-agnostic extension methods for the Facet library, enabling one-line map
 
 ## Key Features
 
-- Constructor-based mapping `(ToFacet<>)` for any object graph
-- Enumerable mapping `(SelectFacets<>)` via LINQ
-- IQueryable projection `(SelectFacet<>)` using the generated Projection expression
+- **Forward Mapping**: Source > Facet
+  - Constructor-based mapping `(ToFacet<>)` for any object graph
+  - Enumerable mapping `(SelectFacets<>)` via LINQ
+  - IQueryable projection `(SelectFacet<>)` using the generated Projection expression
 
+- **Reverse Mapping**: Facet > Source
+  - Generate source from facet: `ToSource<TFacetSource>()`
+
+- **Patch/update source**: Facet > Source
+  - Selective source updates: `ApplyFacet<TSource, TFacet>()`
+  - Update with change tracking: `ApplyFacetWithChanges<TSource, TFacet>()`
+ 
 All methods are zero-boilerplate and leverage your already generated ctor or Projection property.
 
 ## Getting Started
@@ -45,10 +53,10 @@ using Facet;
 public partial class PersonDto { }
 ```
 
-### 4. Map to facets
+### 4. Map to and from facets
 
 ```csharp
-// Single-object mapping
+// Forward mapping: Source -> Facet
 var dto = person.ToFacet<PersonDto>();
 
 // Enumerable mapping (in-memory)
@@ -57,9 +65,115 @@ var dtos = people.SelectFacets<PersonDto>().ToList();
 // IQueryable projection (deferred)
 var query = dbContext.People.SelectFacet<PersonDto>();
 var list  = query.ToList();
+
+// Reverse mapping: Facet -> Source (apply changes back to source)
+var updatedDto = new PersonDto { Name = "Jane", Email = "jane@example.com" };
+person.ApplyFacet(updatedDto);  // Only updates changed properties
+
+// Track changes for auditing
+var result = person.ApplyFacetWithChanges<Person, PersonDto>(updatedDto);
+if (result.HasChanges)
+{
+    Console.WriteLine($"Changed: {string.Join(", ", result.ChangedProperties)}");
+}
+```
+
+## Forward Mapping (Source -> Facet)
+
+### Single Object Mapping
+
+```csharp
+var person = new Person { Id = 1, Name = "John", Email = "john@example.com" };
+var dto = person.ToFacet<PersonDto>();
+```
+
+### Enumerable Mapping
+
+```csharp
+var people = GetPeople();
+var dtos = people.SelectFacets<PersonDto>().ToList();
+```
+
+### IQueryable Projection
+
+```csharp
+var query = dbContext.People.SelectFacet<PersonDto>();
+var list = query.ToList();
+```
+
+## Reverse Mapping (Facet -> Source)
+
+Apply changes from a facet DTO back to the source object. Only properties that exist in both types and have different values will be updated.
+
+### Basic Usage
+
+```csharp
+var person = new Person { Id = 1, Name = "John", Email = "john@example.com" };
+var dto = new PersonDto { Name = "Jane", Email = "jane@example.com" };
+
+// Apply changes from facet to source
+person.ApplyFacet(dto);
+// person.Name is now "Jane", Email is "jane@example.com"
+
+// Fluent API support
+var updatedPerson = person.ApplyFacet(dto);
+```
+
+### Change Tracking
+
+Track which properties were changed for auditing or logging:
+
+```csharp
+var result = person.ApplyFacetWithChanges<Person, PersonDto>(dto);
+
+if (result.HasChanges)
+{
+    Console.WriteLine($"Updated properties: {string.Join(", ", result.ChangedProperties)}");
+    // Output: "Updated properties: Name, Email"
+}
+
+// Access the updated source
+var updatedPerson = result.Source;
+```
+
+### Common Scenarios
+
+```csharp
+// API scenario: Apply user updates
+[HttpPut("{id}")]
+public IActionResult UpdatePerson(int id, PersonDto dto)
+{
+    var person = repository.GetById(id);
+    if (person == null) return NotFound();
+
+    var result = person.ApplyFacetWithChanges<Person, PersonDto>(dto);
+
+    if (result.HasChanges)
+    {
+        repository.Save(person);
+        logger.LogInformation("Person {Id} updated: {Changes}",
+            id, string.Join(", ", result.ChangedProperties));
+    }
+
+    return NoContent();
+}
+
+// Partial updates: Only defined properties in the DTO are updated
+public partial class UpdatePersonDto  // Might exclude sensitive fields
+{
+    public string Name { get; set; }
+    public string Email { get; set; }
+    // Password, CreatedAt, etc. not included = won't be updated
+}
+
+var person = repository.GetById(1);
+var updateDto = new UpdatePersonDto { Name = "Jane" };
+person.ApplyFacet(updateDto);  // Only Name is updated
 ```
 
 ## API Reference
+
+### Forward Mapping
 
 | Method |  Description    |
 | ------- |------
@@ -69,6 +183,26 @@ var list  = query.ToList();
 | `SelectFacets<TSource,TTarget>()`     |  Map an `IEnumerable<TSource>` via constructor   |
 | `SelectFacet<TTarget>()`    |  Project `IQueryable<TSource>` to `IQueryable<TTarget>`   |
 | `SelectFacet<TSource,TTarget>()`    |  Project `IQueryable<TSource>` to `IQueryable<TTarget>`   |
+| `ToSource<TFacetSource>()`    |  Map facet back to source via generated ToSource method   |
+| `ToSource<TFacet,TFacetSource>()`    |  Map facet back to source via generated ToSource method   |
+| `SelectFacetSources<TFacetSource>()`     |  Map facets back to sources   |
+| `SelectFacetSources<TFacet,TFacetSource>()`     |  Map facets back to sources   |
+
+### Reverse Mapping (Patch/Update)
+
+| Method |  Description    | Use Case |
+| ------- |------ |------
+| `ApplyFacet<TSource, TFacet>()`    |   Apply changed properties from facet to source  | Updates, PATCH endpoints |
+| `ApplyFacet<TFacet>()`    |   Apply changed properties (type inferred)  | Updates with type inference |
+| `ApplyFacetWithChanges<TSource, TFacet>()`    |   Apply changes and return `FacetApplyResult` with changed property names  | Auditing, logging |
+
+## Performance Considerations
+
+The `ApplyFacet` methods use reflection to discover and update properties. For most scenarios, the performance overhead is negligible. The methods are optimized to:
+
+- Only enumerate properties once per call
+- Only update properties that have different values
+- Skip properties that don't exist in both types
 
 ## Requirements
 
@@ -77,4 +211,9 @@ var list  = query.ToList();
 
 ---
 
-For EF Core async support, see [Facet.Extensions.EFCore](https://www.nuget.org/packages/Facet.Extensions.EFCore).
+## Related Packages
+
+- For EF Core async support and `DbContext`-aware updates, see [Facet.Extensions.EFCore](https://www.nuget.org/packages/Facet.Extensions.EFCore)
+  - `UpdateFromFacet()` - Similar to `ApplyFacet()` but with EF Core change tracking
+  - `UpdateFromFacetAsync()` - Async version
+  - `UpdateFromFacetWithChanges()` - With change tracking

--- a/test/Facet.Tests/UnitTests/Extensions/ApplyFacetTests.cs
+++ b/test/Facet.Tests/UnitTests/Extensions/ApplyFacetTests.cs
@@ -1,0 +1,256 @@
+using Facet.Extensions;
+using Facet.Tests.TestModels;
+using Facet.Tests.Utilities;
+
+namespace Facet.Tests.UnitTests.Extensions;
+
+public class ApplyFacetTests
+{
+    [Fact]
+    public void ApplyFacet_ShouldUpdateChangedProperties_WhenFacetHasDifferentValues()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = "Jane",  // Changed
+            LastName = "Doe",    // Unchanged
+            Email = "jane@example.com",  // Changed
+            IsActive = user.IsActive,     // Unchanged
+            DateOfBirth = user.DateOfBirth,  // Unchanged
+            LastLoginAt = user.LastLoginAt   // Unchanged
+        };
+
+        // Act
+        user.ApplyFacet<User, UserDto>(facet);
+
+        // Assert
+        user.FirstName.Should().Be("Jane");
+        user.Email.Should().Be("jane@example.com");
+        user.LastName.Should().Be("Doe");
+        user.IsActive.Should().Be(facet.IsActive);
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldNotUpdateUnchangedProperties()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var originalLastName = user.LastName;
+        var originalEmail = user.Email;
+
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = "Jane",  // Changed
+            LastName = originalLastName,  // Unchanged
+            Email = originalEmail,  // Unchanged
+            IsActive = user.IsActive,
+            DateOfBirth = user.DateOfBirth,
+            LastLoginAt = user.LastLoginAt
+        };
+
+        // Act
+        user.ApplyFacet<User, UserDto>(facet);
+
+        // Assert
+        user.FirstName.Should().Be("Jane");
+        user.LastName.Should().Be(originalLastName);
+        user.Email.Should().Be(originalEmail);
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldHandleNullableProperties()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser();
+        user.LastLoginAt = DateTime.Now;
+
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = user.FirstName,
+            LastName = user.LastName,
+            Email = user.Email,
+            IsActive = user.IsActive,
+            DateOfBirth = user.DateOfBirth,
+            LastLoginAt = null  // Changed to null
+        };
+
+        // Act
+        user.ApplyFacet<User, UserDto>(facet);
+
+        // Assert
+        user.LastLoginAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldReturnSourceInstance_ForFluentChaining()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser();
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = "Updated",
+            LastName = user.LastName,
+            Email = user.Email,
+            IsActive = user.IsActive,
+            DateOfBirth = user.DateOfBirth,
+            LastLoginAt = user.LastLoginAt
+        };
+
+        // Act
+        var result = user.ApplyFacet<User, UserDto>(facet);
+
+        // Assert
+        result.Should().BeSameAs(user);
+        result.FirstName.Should().Be("Updated");
+    }
+
+    [Fact]
+    public void ApplyFacet_WithInferredType_ShouldUpdateProperties()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = "Jane",
+            LastName = "Smith",
+            Email = user.Email,
+            IsActive = user.IsActive,
+            DateOfBirth = user.DateOfBirth,
+            LastLoginAt = user.LastLoginAt
+        };
+
+        // Act
+        user.ApplyFacet(facet);
+
+        // Assert
+        user.FirstName.Should().Be("Jane");
+        user.LastName.Should().Be("Smith");
+        user.Email.Should().Be(facet.Email);
+    }
+
+    [Fact]
+    public void ApplyFacetWithChanges_ShouldReturnChangedPropertyNames()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var facet = user.ToFacet<User, UserDto>();
+
+        // Modify specific properties
+        facet.FirstName = "Jane";  // Changed
+        facet.Email = "jane@example.com";  // Changed
+        // LastName unchanged
+
+        // Act
+        var result = user.ApplyFacetWithChanges<User, UserDto>(facet);
+
+        // Assert
+        result.Source.Should().BeSameAs(user);
+        result.HasChanges.Should().BeTrue();
+        result.ChangedProperties.Should().Contain("FirstName");
+        result.ChangedProperties.Should().Contain("Email");
+        result.ChangedProperties.Should().NotContain("LastName");
+        result.ChangedProperties.Should().NotContain("Id");
+        result.ChangedProperties.Should().HaveCountGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public void ApplyFacetWithChanges_ShouldReturnNoChanges_WhenAllPropertiesMatch()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var facet = user.ToFacet<User, UserDto>();
+
+        // Act
+        var result = user.ApplyFacetWithChanges<User, UserDto>(facet);
+
+        // Assert
+        result.HasChanges.Should().BeFalse();
+        result.ChangedProperties.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldThrowArgumentNullException_WhenSourceIsNull()
+    {
+        // Arrange
+        User? user = null;
+        var facet = new UserDto();
+
+        // Act & Assert
+        var act = () => user!.ApplyFacet<User, UserDto>(facet);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("source");
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldThrowArgumentNullException_WhenFacetIsNull()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser();
+        UserDto? facet = null;
+
+        // Act & Assert
+        var act = () => user.ApplyFacet<User, UserDto>(facet!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("facet");
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldHandleBooleanChanges()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser(isActive: true);
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = user.FirstName,
+            LastName = user.LastName,
+            Email = user.Email,
+            IsActive = false,  // Changed
+            DateOfBirth = user.DateOfBirth,
+            LastLoginAt = user.LastLoginAt
+        };
+
+        // Act
+        user.ApplyFacet<User, UserDto>(facet);
+
+        // Assert
+        user.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyFacet_ShouldOnlyUpdatePropertiesExistingInBoth()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var originalPassword = user.Password;
+        var originalCreatedAt = user.CreatedAt;
+
+        var facet = new UserDto
+        {
+            Id = user.Id,
+            FirstName = "Jane",
+            LastName = "Smith",
+            Email = "jane@example.com",
+            IsActive = false,
+            DateOfBirth = user.DateOfBirth,
+            LastLoginAt = user.LastLoginAt
+        };
+
+        // Act
+        user.ApplyFacet<User, UserDto>(facet);
+
+        // Assert
+        user.FirstName.Should().Be("Jane");
+        user.LastName.Should().Be("Smith");
+        user.Email.Should().Be("jane@example.com");
+        user.IsActive.Should().BeFalse();
+
+        // Properties not in facet should remain unchanged
+        user.Password.Should().Be(originalPassword);
+        user.CreatedAt.Should().Be(originalCreatedAt);
+    }
+}


### PR DESCRIPTION
Closes #210 

Adds new extension methods to apply changes from a facet DTO back to a source object, enabling partial updates without requiring EF Core.

### Patch/put scenario

```csharp
[HttpPut("{id}")]
public IActionResult UpdatePerson(int id, PersonDto dto)
{
    var person = repository.GetById(id);
    if (person == null) return NotFound();

    person.ApplyFacet(dto);  // Only updates changed properties
    repository.Save(person);

    return NoContent();
}
```

### Auditing & Logging

```csharp
var result = user.ApplyFacetWithChanges<User, UserDto>(dto);
if (result.HasChanges)
{
    logger.LogInformation("User {Id} updated: {Props}",
        id, string.Join(", ", result.ChangedProperties));
}
```

### Partial Updates

```csharp
[Facet(typeof(User), "Password", "CreatedAt")]  // Exclude sensitive fields
public partial class UpdateUserDto { }

user.ApplyFacet(updateDto);  // Password and CreatedAt won't be updated
```

