### PR TITLE
fix: fix XML documentation syntax for constructor generator

### DIFF
--- a/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
@@ -298,7 +298,7 @@ internal static class ConstructorGenerator
     {
         sb.AppendLine();
         sb.AppendLine("    /// <summary>");
-        sb.AppendLine($"    /// Creates a new instance of <see cref=\"{model.Name}\"/> from the specified <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\".");
+        sb.AppendLine($"    /// Creates a new instance of <see cref=\"{model.Name}\"/> from the specified <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\"/>.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine($"    /// <param name=\"source\">The source <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\"/> object to copy data from.</param>");
         sb.AppendLine($"    /// <returns>A new <see cref=\"{model.Name}\"/> instance with all properties initialized from the source.</returns>");


### PR DESCRIPTION
This was leading to build warnings, which are treated as errors in my application.