### PR TITLE
Smarter GenerateToSource

### DIFF
--- a/test/Facet.Tests/TestModels/ComplexTypeTestModels.cs
+++ b/test/Facet.Tests/TestModels/ComplexTypeTestModels.cs
@@ -146,3 +146,16 @@ public partial record BobChildModel;
 
 [Facet(typeof(Bob), NestedFacets = [typeof(BobChildModel)])]
 public partial record BobModel;
+
+// Test models for GitHub issue #220 - Smarter GenerateToSource
+public class MyClass
+{
+    public string Name { get; private set; }
+
+    internal MyClass(string name) => Name = name;
+
+    public static MyClass Create(string name) => new(name);
+}
+
+[Facet(typeof(MyClass), GenerateToSource = true)]
+public partial record MyClassModel;


### PR DESCRIPTION
Fix for #220 

Current workaround in this case is to just add it yourself: 

```
[Facet(typeof(MyClass), GenerateToSource = false)]
  public partial record MyClassModel
  {
      // Add your own ToSource method
      public MyClass ToSource()
      {
          return MyClass.Create(this.Name);
      }
  }
```

Future improvement would be extending the Facet attribute with a new attribute parameter like `ToSourceFactoryMethod = nameof(MyClass.Create)` 