### PR TITLE
fix: ambiguous constructor call

### DIFF
--- a/src/Facet/Generators/Shared/GeneratorUtilities.cs
+++ b/src/Facet/Generators/Shared/GeneratorUtilities.cs
@@ -237,7 +237,7 @@ internal static class GeneratorUtilities
             var t when t.StartsWith("System.TimeSpan") => "default",
             var t when t.StartsWith("System.Guid") => "default",
             // For other types, use default() expression
-            _ => "default"
+            _ => $"default({typeName})"
         };
     }
 

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -45,6 +45,12 @@ public partial class UserIncludeDto;
 [Facet(typeof(User), Include = new[] { "FirstName" })]
 public partial class UserSingleIncludeDto;
 
+[Facet(typeof(User), Include = new[] { "DateOfBirth" })]
+public partial record UserSingleObjectIncludeDto;
+
+[Facet(typeof(Tenant))]
+public partial record TenantSingleObjectIncludeDto;
+
 [Facet(typeof(Product), Include = new[] { "Name", "Price" })]
 public partial class ProductIncludeDto;
 

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -14,6 +14,11 @@ public class User
     public string AddedProperty { get; set; } = string.Empty;
 }
 
+public record Tenant
+{
+    public Guid Id { get; set; }
+}
+
 public class Product
 {
     public int Id { get; set; }

--- a/test/Facet.Tests/UnitTests/Core/Facet/IncludePropertyTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/IncludePropertyTests.cs
@@ -19,7 +19,7 @@ public class IncludePropertyTests
         dto.FirstName.Should().Be("John");
         dto.LastName.Should().Be("Doe");
         dto.Email.Should().Be(user.Email);
-        
+
         // Verify that excluded properties are not present
         var dtoType = dto.GetType();
         dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
@@ -39,15 +39,54 @@ public class IncludePropertyTests
         // Act
         var dto = user.ToFacet<User, UserSingleIncludeDto>();
 
+
         // Assert
         dto.Should().NotBeNull();
         dto.FirstName.Should().Be("Jane");
-        
         // Verify that all other properties are not present
         var dtoType = dto.GetType();
         dtoType.GetProperty("LastName").Should().BeNull("LastName should not be included");
         dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
         dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_WithInclude_ShouldWorkWithSingleObjectProperty()
+    {
+        // Arrange
+        var user = TestDataFactory.CreateUser("Jane", "Smith", "", DateTime.Today);
+
+        // Act
+        var dto = user.ToFacet<User, UserSingleObjectIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.DateOfBirth.Should().Be(DateTime.Today);
+
+        // Verify that all other properties are not present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("LastName").Should().BeNull("LastName should not be included");
+        dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
+        dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
+    }
+
+    [Fact]
+    public void ToFacet_ShouldWorkWithSingleObjectProperty()
+    {
+        var id = Guid.NewGuid();
+        // Arrange
+        var tenant = TestDataFactory.CreateTenant(id);
+
+        // Act
+        var dto = tenant.ToFacet<Tenant, TenantSingleObjectIncludeDto>();
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(id);
+
+        // Verify that all properties are present
+        var dtoType = dto.GetType();
+        dtoType.GetProperty("Id").Should().NotBeNull("LastName should be included");
     }
 
     [Fact]
@@ -63,7 +102,7 @@ public class IncludePropertyTests
         dto.Should().NotBeNull();
         dto.Name.Should().Be("Test Product");
         dto.Price.Should().Be(99.99m);
-        
+
         // Verify that excluded properties are not present
         var dtoType = dto.GetType();
         dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
@@ -88,13 +127,13 @@ public class IncludePropertyTests
         var firstNameProp = dtoType.GetProperty("FirstName");
         var lastNameProp = dtoType.GetProperty("LastName");
         var emailProp = dtoType.GetProperty("Email");
-        
+
         firstNameProp.Should().NotBeNull();
         firstNameProp!.PropertyType.Should().Be(typeof(string));
-        
+
         lastNameProp.Should().NotBeNull();
         lastNameProp!.PropertyType.Should().Be(typeof(string));
-        
+
         emailProp.Should().NotBeNull();
         emailProp!.PropertyType.Should().Be(typeof(string));
     }
@@ -113,7 +152,7 @@ public class IncludePropertyTests
         dto.FirstName.Should().Be("Include"); // From User base class
         dto.LastName.Should().Be("Test"); // From User base class
         dto.Department.Should().Be("Engineering"); // From Employee class
-        
+
         // Verify excluded properties are not present
         var dtoType = dto.GetType();
         dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
@@ -135,10 +174,10 @@ public class IncludePropertyTests
         dto.Should().NotBeNull();
         dto.FirstName.Should().Be("Custom");
         dto.LastName.Should().Be("Props");
-        
+
         // Custom property should exist and have default value
         dto.FullName.Should().Be(string.Empty);
-        
+
         // Verify excluded properties are not present
         var dtoType = dto.GetType();
         dtoType.GetProperty("Email").Should().BeNull("Email should not be included");
@@ -158,7 +197,7 @@ public class IncludePropertyTests
         dto.Should().NotBeNull();
         dto.FirstName.Should().Be("Modern");
         dto.LastName.Should().Be("Include");
-        
+
         // Verify excluded properties are not present
         var dtoType = dto.GetType();
         dtoType.GetProperty("Id").Should().BeNull("Id should not be included");
@@ -187,14 +226,14 @@ public class IncludePropertyTests
         dto.Should().NotBeNull();
         dto.Name.Should().Be("Field Test");
         dto.Age.Should().Be(25);
-        
+
         // Verify excluded field is not present
         var dtoType = dto.GetType();
         dtoType.GetField("Id").Should().BeNull("Id field should not be included");
         dtoType.GetProperty("Email").Should().BeNull("Email property should not be included");
     }
 
-    [Fact] 
+    [Fact]
     public void ToFacet_WithInclude_ShouldNotIncludeFields_WhenIncludeFieldsIsFalse()
     {
         // This test verifies that IncludeFields defaults to false for include mode
@@ -213,7 +252,7 @@ public class IncludePropertyTests
         // Assert
         dto.Should().NotBeNull();
         dto.Email.Should().Be("test@test.com"); // Property should be included
-        
+
         // Verify fields are not included even if specified in include array
         var dtoType = dto.GetType();
         dtoType.GetField("Name").Should().BeNull("Name field should not be included when IncludeFields = false");
@@ -235,7 +274,7 @@ public class IncludePropertyTests
         backToSource.FirstName.Should().Be("Back");
         backToSource.LastName.Should().Be("To");
         backToSource.Email.Should().Be(user.Email);
-        
+
         // Properties not included in facet should have default values
         backToSource.Id.Should().Be(0); // Default for int
         backToSource.DateOfBirth.Should().Be(default(DateTime));

--- a/test/Facet.Tests/Utilities/TestDataFactory.cs
+++ b/test/Facet.Tests/Utilities/TestDataFactory.cs
@@ -1,4 +1,5 @@
 using Facet.Tests.TestModels;
+using System;
 
 namespace Facet.Tests.Utilities;
 
@@ -117,7 +118,7 @@ public static class TestDataFactory
             PasswordHash = "hashed_password_modern"
         };
     }
-    
+
     public static ClassicUser CreateClassicUser(
         string firstName = "Classic",
         string lastName = "User")
@@ -150,4 +151,13 @@ public static class TestDataFactory
             Email = $"{name.Replace(" ", ".").ToLower()}@fields.com"
         };
     }
+
+    public static Tenant CreateTenant(Guid? id = null)
+    {
+        return new Tenant
+        {
+            Id = id ?? Guid.NewGuid(),
+        };
+    }
+
 }


### PR DESCRIPTION
The source generator failed when trying to generate facets with single property or include
Error message: 
**The call is ambiguous between the following methods or properties: 'Request.Request(DateTime)' and 'Request.Request(Request)'**

``` cs
using Facet;
using N1;

var tenant = new Tenant { };

var tenantDto = new Request();


namespace N1
{
    public class Tenant
    {
        public DateTime Id { get; set; }
    }

    [Facet(typeof(Tenant))]

    internal partial record Request
    {

    }
}
```
