### PR TITLE
Feature: ChainToParameterlessConstructor

### DIFF
--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -27,6 +27,7 @@ public partial class MyFacet { }
 | `IncludeFields`                | `bool`    | Include public fields from the source type (default: false for include mode, false for exclude mode). |
 | `GenerateConstructor`          | `bool`    | Generate a constructor that copies values from the source (default: true).   |
 | `GenerateParameterlessConstructor` | `bool` | Generate a parameterless constructor for testing and initialization (default: true). |
+| `ChainToParameterlessConstructor` | `bool` | Chain generated constructors to the user-defined parameterless constructor using `: this()` (default: false). See [Constructor Chaining](#constructor-chaining) below. |
 | `Configuration`                | `Type?`   | Custom mapping config type (see [Custom Mapping](04_CustomMapping.md)).      |
 | `GenerateProjection`           | `bool`    | Generate a static LINQ projection (default: true).                          |
 | `GenerateToSource`             | `bool`    | Generate a method to map back from facet to source type (default: false).    |
@@ -44,7 +45,7 @@ public partial class MyFacet { }
 The `Include` and `Exclude` parameters are mutually exclusive:
 
 - **Exclude Mode**: Include all properties except those listed in `exclude` (default behavior)
-- **Include Mode**: Only include properties listed in `Include` array
+- **Include Mode**: Only include properties listed in the `Include` array
 
 ### Include Mode Behavior
 

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -264,6 +264,49 @@ public sealed class FacetAttribute : Attribute
     public Type? AfterMapConfiguration { get; set; }
 
     /// <summary>
+    /// When true, the generated constructor that takes the source type will chain to the 
+    /// parameterless constructor using `: this()`. This ensures any custom initialization 
+    /// logic in your parameterless constructor runs before property mapping.
+    /// Default is false. Set to true when you have initialization logic in your parameterless 
+    /// constructor that needs to execute during mapping.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is useful when you need to initialize computed properties or run setup logic
+    /// that isn't simply copying values from the source.
+    /// </para>
+    /// <para>
+    /// Example usage:
+    /// <code>
+    /// public class ModelType
+    /// {
+    ///     public int MaxValue { get; set; }
+    /// }
+    ///
+    /// [Facet(typeof(ModelType), GenerateParameterlessConstructor = false, ChainToParameterlessConstructor = true)]
+    /// public partial class MyType
+    /// {
+    ///     public int Value { get; set; }
+    ///
+    ///     public MyType()
+    ///     {
+    ///         // Custom initialization logic
+    ///         Value = 100; // Default value
+    ///     }
+    /// }
+    /// </code>
+    /// The generated constructor will be:
+    /// <code>
+    /// public MyType(ModelType source) : this()
+    /// {
+    ///     this.MaxValue = source.MaxValue;
+    /// }
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public bool ChainToParameterlessConstructor { get; set; } = false;
+
+    /// <summary>
     /// Creates a new FacetAttribute that targets a given source type and excludes specified members.
     /// </summary>
     /// <param name="sourceType">The type to generate from.</param>

--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -16,6 +16,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public string Accessibility { get; }
     public bool GenerateConstructor { get; }
     public bool GenerateParameterlessConstructor { get; }
+    public bool ChainToParameterlessConstructor { get; }
     public bool GenerateExpressionProjection { get; }
     public bool GenerateToSource { get; }
     public string SourceTypeName { get; }
@@ -65,7 +66,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         ImmutableArray<string> baseClassMemberNames = default,
         ImmutableArray<string> flattenToTypes = default,
         string? beforeMapConfigurationTypeName = null,
-        string? afterMapConfigurationTypeName = null)
+        string? afterMapConfigurationTypeName = null,
+        bool chainToParameterlessConstructor = false)
     {
         Name = name;
         Namespace = @namespace;
@@ -75,6 +77,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         Accessibility = accessibility;
         GenerateConstructor = generateConstructor;
         GenerateParameterlessConstructor = generateParameterlessConstructor;
+        ChainToParameterlessConstructor = chainToParameterlessConstructor;
         GenerateExpressionProjection = generateExpressionProjection;
         GenerateToSource = generateToSource;
         SourceTypeName = sourceTypeName;
@@ -110,6 +113,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && Accessibility == other.Accessibility
             && GenerateConstructor == other.GenerateConstructor
             && GenerateParameterlessConstructor == other.GenerateParameterlessConstructor
+            && ChainToParameterlessConstructor == other.ChainToParameterlessConstructor
             && GenerateExpressionProjection == other.GenerateExpressionProjection
             && SourceTypeName == other.SourceTypeName
             && SourceContainingTypes.SequenceEqual(other.SourceContainingTypes)
@@ -146,6 +150,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + (Accessibility?.GetHashCode() ?? 0);
             hash = hash * 31 + GenerateConstructor.GetHashCode();
             hash = hash * 31 + GenerateParameterlessConstructor.GetHashCode();
+            hash = hash * 31 + ChainToParameterlessConstructor.GetHashCode();
             hash = hash * 31 + GenerateExpressionProjection.GetHashCode();
             hash = hash * 31 + (SourceTypeName?.GetHashCode() ?? 0);
             hash = hash * 31 + (ConfigurationTypeName?.GetHashCode() ?? 0);

--- a/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
@@ -139,6 +139,11 @@ internal static class ConstructorGenerator
                 model.Members.Select(m => ExpressionBuilder.GetSourceValueExpression(m, "source")));
             ctorSig += $" : this({args})";
         }
+        else if (model.ChainToParameterlessConstructor && !isPositional)
+        {
+            // Chain to user-defined parameterless constructor
+            ctorSig += " : this()";
+        }
 
         if (hasRequiredProperties)
         {
@@ -270,6 +275,11 @@ internal static class ConstructorGenerator
             var args = string.Join(", ",
                 model.Members.Select(m => ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences)));
             ctorSig += $" : this({args})";
+        }
+        else if (model.ChainToParameterlessConstructor && !isPositional)
+        {
+            // Chain to user-defined parameterless constructor
+            ctorSig += " : this()";
         }
 
         if (hasRequiredProperties)

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -36,6 +36,7 @@ internal static class ModelBuilder
         var includeFields = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.IncludeFields, false);
         var generateConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateConstructor, true);
         var generateParameterlessConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateParameterlessConstructor, true);
+        var chainToParameterlessConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.ChainToParameterlessConstructor, false);
         var generateProjection = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateProjection, true);
         var generateToSource = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateToSource, false);
         var configurationTypeName = AttributeParser.ExtractConfigurationTypeName(attribute);
@@ -198,7 +199,8 @@ internal static class ModelBuilder
             baseClassMemberNames,
             flattenToTypes,
             beforeMapConfigurationTypeName,
-            afterMapConfigurationTypeName);
+            afterMapConfigurationTypeName,
+            chainToParameterlessConstructor);
     }
 
     #region Private Helper Methods

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -95,6 +95,7 @@ internal static class FacetConstants
         public const string IncludeFields = "IncludeFields";
         public const string GenerateConstructor = "GenerateConstructor";
         public const string GenerateParameterlessConstructor = "GenerateParameterlessConstructor";
+        public const string ChainToParameterlessConstructor = "ChainToParameterlessConstructor";
         public const string GenerateProjection = "GenerateProjection";
         public const string GenerateToSource = "GenerateToSource";
         public const string PreserveInitOnlyProperties = "PreserveInitOnlyProperties";

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -201,3 +201,53 @@ public class ModelWithNullableList
 
 [Facet(typeof(ModelWithNullableList))]
 public partial record RecordWithNullableList;
+
+// When user has initialization logic in their parameterless constructor,
+// the generated constructor should chain to it
+public class ModelTypeForChaining
+{
+    public int MaxValue { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[Facet(typeof(ModelTypeForChaining), GenerateParameterlessConstructor = false, ChainToParameterlessConstructor = true)]
+public partial class ChainedConstructorDto
+{
+    public int Value { get; set; }
+    public bool Initialized { get; set; }
+
+    public ChainedConstructorDto()
+    {
+        // Custom initialization logic that should run when mapping
+        Value = 100;
+        Initialized = true;
+    }
+}
+
+// Test without chaining (default behavior) for comparison
+[Facet(typeof(ModelTypeForChaining), GenerateParameterlessConstructor = false)]
+public partial class NonChainedConstructorDto
+{
+    public int Value { get; set; }
+    public bool Initialized { get; set; }
+
+    public NonChainedConstructorDto()
+    {
+        Value = 100;
+        Initialized = true;
+    }
+}
+
+// Test chaining with generated parameterless constructor disabled but still using the user's
+[Facet(typeof(ModelTypeForChaining), GenerateParameterlessConstructor = false, ChainToParameterlessConstructor = true, MaxDepth = 0, PreserveReferences = false)]
+public partial class ChainedConstructorNoDepthDto
+{
+    public int Value { get; set; }
+    public bool Initialized { get; set; }
+
+    public ChainedConstructorNoDepthDto()
+    {
+        Value = 200;
+        Initialized = true;
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/ChainToParameterlessConstructorTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ChainToParameterlessConstructorTests.cs
@@ -1,0 +1,104 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// When a user has initialization logic in their parameterless constructor,
+/// the generated constructor should be able to chain to it using `: this()`.
+/// </summary>
+public class ChainToParameterlessConstructorTests
+{
+    [Fact]
+    public void ChainedConstructor_ShouldCallParameterlessConstructorFirst()
+    {
+        // Arrange
+        var source = new ModelTypeForChaining
+        {
+            MaxValue = 42,
+            Name = "Test"
+        };
+
+        // Act
+        var dto = new ChainedConstructorDto(source);
+
+        // Assert - Parameterless constructor should have run, setting Value = 100 and Initialized = true
+        // Then the source properties should be mapped
+        dto.Initialized.Should().BeTrue("Parameterless constructor should have run");
+        dto.Value.Should().Be(100, "Value should be initialized by parameterless constructor");
+        dto.MaxValue.Should().Be(42, "MaxValue should be mapped from source");
+        dto.Name.Should().Be("Test", "Name should be mapped from source");
+    }
+
+    [Fact]
+    public void NonChainedConstructor_ShouldNotCallParameterlessConstructor()
+    {
+        // Arrange
+        var source = new ModelTypeForChaining
+        {
+            MaxValue = 42,
+            Name = "Test"
+        };
+
+        // Act
+        var dto = new NonChainedConstructorDto(source);
+
+        // Assert - Parameterless constructor should NOT have run
+        // The Initialized and Value properties should have their default values
+        dto.Initialized.Should().BeFalse("Parameterless constructor should NOT have run");
+        dto.Value.Should().Be(0, "Value should have default value since parameterless ctor didn't run");
+        dto.MaxValue.Should().Be(42, "MaxValue should still be mapped from source");
+        dto.Name.Should().Be("Test", "Name should still be mapped from source");
+    }
+
+    [Fact]
+    public void ChainedConstructorNoDepth_ShouldCallParameterlessConstructor()
+    {
+        // Arrange
+        var source = new ModelTypeForChaining
+        {
+            MaxValue = 99,
+            Name = "NoDepth"
+        };
+
+        // Act
+        var dto = new ChainedConstructorNoDepthDto(source);
+
+        // Assert - Parameterless constructor should have run with different Value
+        dto.Initialized.Should().BeTrue("Parameterless constructor should have run");
+        dto.Value.Should().Be(200, "Value should be 200 from this specific parameterless constructor");
+        dto.MaxValue.Should().Be(99, "MaxValue should be mapped from source");
+        dto.Name.Should().Be("NoDepth", "Name should be mapped from source");
+    }
+
+    [Fact]
+    public void ChainedConstructor_ManualParameterlessCall_ShouldWork()
+    {
+        // Arrange & Act - Call the user's parameterless constructor directly
+        var dto = new ChainedConstructorDto();
+
+        // Assert
+        dto.Initialized.Should().BeTrue();
+        dto.Value.Should().Be(100);
+        dto.MaxValue.Should().Be(0, "MaxValue should have default int value");
+        // Note: Name won't be set by parameterless constructor, but the property has a default value from the source
+    }
+
+    [Fact]
+    public void ChainedConstructor_FromSource_ShouldWorkWithChaining()
+    {
+        // Arrange
+        var source = new ModelTypeForChaining
+        {
+            MaxValue = 123,
+            Name = "FromSource"
+        };
+
+        // Act
+        var dto = ChainedConstructorDto.FromSource(source);
+
+        // Assert - FromSource should also use the constructor that chains
+        dto.Initialized.Should().BeTrue("Initialization should have occurred");
+        dto.Value.Should().Be(100, "Value should be set by parameterless constructor");
+        dto.MaxValue.Should().Be(123, "MaxValue should be mapped from source");
+    }
+}


### PR DESCRIPTION
fixes #253  

When using `[Facet]` with `GenerateParameterlessConstructor = false`, users who have custom initialization logic in their parameterless constructor had no way to ensure that logic runs when using `ToFacet<>()` or constructing from a source.

```csharp
public class ModelType
{
    public int MaxValue { get; set; }
}

[Facet(typeof(ModelType), GenerateParameterlessConstructor = false)]
public partial class MyType
{
    public int Value { get; set; }

    public MyType()
    {
        // This initialization logic was NOT being called when mapping
        Value = 100;
    }
}
```

## Feature

Added a new `ChainToParameterlessConstructor` property to the `[Facet]` attribute. When set to `true`, the generated constructor that takes the source type will chain to the parameterless constructor using `: this()`.

## Usage

```csharp
public class ModelType
{
    public int MaxValue { get; set; }
}

[Facet(typeof(ModelType), GenerateParameterlessConstructor = false, ChainToParameterlessConstructor = true)]
public partial class MyType
{
    public int Value { get; set; }
    public bool Initialized { get; set; }

    public MyType()
    {
        // This initialization logic WILL now run when mapping
        Value = 100;
        Initialized = true;
    }
}

// Usage
var source = new ModelType { MaxValue = 42 };
var dto = new MyType(source);

// dto.Value == 100 (from parameterless constructor)
// dto.Initialized == true (from parameterless constructor)
// dto.MaxValue == 42 (from source mapping)
```

## Generated Code

With `ChainToParameterlessConstructor = true`:

```csharp
public partial class MyType
{
    public int MaxValue { get; set; }

    public MyType(ModelType source) : this()  // <-- Chains to parameterless ctor
    {
        this.MaxValue = source.MaxValue;
    }
}
```

Without chaining (default behavior):

```csharp
public partial class MyType
{
    public int MaxValue { get; set; }

    public MyType(ModelType source)  // <-- No chaining
    {
        this.MaxValue = source.MaxValue;
    }
}
```

## Notes

- This feature works with both the main constructor and the depth-aware constructor
- Default value is `false` to maintain backward compatibility
- Can be combined with other attributes like `Configuration`, `BeforeMapConfiguration`, etc.
