### PR TITLE
fix: non-nullable reference type properties without initializers

### DIFF
--- a/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
@@ -465,6 +465,13 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             propDef += " { get; set; }";
         }
 
+        // For non-nullable reference type properties without a required modifier,
+        // add "= default!" to suppress CS8618 warnings in the generated code
+        if (!member.IsValueType && !member.IsRequired && !NullabilityAnalyzer.IsNullableTypeName(member.TypeName))
+        {
+            propDef += " = default!;";
+        }
+
         if (member.IsRequired)
         {
             propDef = $"required {propDef}";
@@ -487,6 +494,12 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         {
             var defaultValue = GeneratorUtilities.GetDefaultValueForType(member.TypeName);
             fieldDef += $" = {defaultValue}";
+        }
+        else if (!member.IsValueType && !member.IsRequired && !NullabilityAnalyzer.IsNullableTypeName(member.TypeName))
+        {
+            // For non-nullable reference type fields without a required modifier,
+            // add "= default!" to suppress CS8618 warnings
+            fieldDef += " = default!";
         }
 
         fieldDef += ";";

--- a/src/Facet/Generators/FacetGenerators/MemberGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/MemberGenerator.cs
@@ -68,6 +68,12 @@ internal static class MemberGenerator
         {
             propDef += $" = {member.DefaultValue};";
         }
+        else if (!member.IsValueType && !member.IsRequired && !NullabilityAnalyzer.IsNullableTypeName(member.TypeName))
+        {
+            // For non-nullable reference type properties without an initializer and not marked as required,
+            // add "= default!" to suppress CS8618 warnings in the generated code 
+            propDef += " = default!;";
+        }
 
         if (member.IsRequired)
         {
@@ -85,6 +91,12 @@ internal static class MemberGenerator
         if (!string.IsNullOrEmpty(member.DefaultValue))
         {
             fieldDef += $" = {member.DefaultValue}";
+        }
+        else if (!member.IsValueType && !member.IsRequired && !NullabilityAnalyzer.IsNullableTypeName(member.TypeName))
+        {
+            // For non-nullable reference type fields without an initializer and not marked as required,
+            // add "= default!" to suppress CS8618 warnings in the generated code
+            fieldDef += " = default!";
         }
         
         fieldDef += ";";

--- a/src/Facet/Generators/FlattenGenerators/FlattenCodeBuilder.cs
+++ b/src/Facet/Generators/FlattenGenerators/FlattenCodeBuilder.cs
@@ -108,7 +108,11 @@ internal static class FlattenCodeBuilder
             }
 
             // Property declaration
-            sb.AppendLine($"    public {property.TypeName} {property.Name} {{ get; set; }}");
+            // For non-nullable reference type properties, add "= default!" to suppress CS8618 warnings
+            var defaultSuffix = (!property.IsValueType && !NullabilityAnalyzer.IsNullableTypeName(property.TypeName))
+                ? " = default!;"
+                : "";
+            sb.AppendLine($"    public {property.TypeName} {property.Name} {{ get; set; }}{defaultSuffix}");
             sb.AppendLine();
         }
     }

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -301,3 +301,22 @@ public class TeamModelWithRequiredMembers
 
 [Facet(typeof(TeamModelWithRequiredMembers), PreserveRequiredProperties = true, NestedFacets = [typeof(UserSettingsFacet)])]
 public partial class TeamWithRequiredMembersFacet;
+
+// This entity has non-nullable string properties WITHOUT initializers
+// The generated facet should not trigger CS8618 warnings
+public class EntityWithNonNullableProperties
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public string ComputedValue => $"{Name}-{Id}";
+    public string? NullableField { get; set; }
+    public int NumericValue { get; set; }
+}
+
+[Facet(typeof(EntityWithNonNullableProperties))]
+public partial class NonNullablePropertyFacet;
+
+// Also test with a required property - should not get default!
+[Facet(typeof(EntityWithNonNullableProperties), PreserveRequiredProperties = false)]
+public partial class NonNullablePropertyFacetNoRequired;


### PR DESCRIPTION
Fix for #266 

When a source type has non-nullable reference type properties without initializers (e.g. computed properties with no backing field), the generated `.g.cs` file triggers **CS8618**:

> Non-nullable property '\<name\>' must contain a non-null value when exiting constructor.

The generator now appends `= default!` to non-nullable reference type properties/fields that:
- Don't already have an initializer from the source (e.g. `= string.Empty`)
- Aren't marked as `required`
- Aren't nullable (type doesn't end with `?`)
- Aren't value types

