### PR TITLE
fix: static usings for nested facets

### DIFF
--- a/src/Facet/FacetMember.cs
+++ b/src/Facet/FacetMember.cs
@@ -21,6 +21,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
     public bool IsCollection { get; }
     public string? CollectionWrapper { get; }
     public string? SourceMemberTypeName { get; }
+    public bool IsNestedType { get; }
 
     // MapFrom attribute properties
     public string? MapFromSource { get; }
@@ -77,7 +78,8 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         IReadOnlyList<string>? attributeNamespaces = null,
         string? defaultValue = null,
         bool isEnumConversion = false,
-        string? originalEnumTypeName = null)
+        string? originalEnumTypeName = null,
+        bool isNestedType = false)
     {
         Name = name;
         TypeName = typeName;
@@ -105,6 +107,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         DefaultValue = defaultValue;
         IsEnumConversion = isEnumConversion;
         OriginalEnumTypeName = originalEnumTypeName;
+        IsNestedType = isNestedType;
     }
 
     public bool Equals(FacetMember? other) =>
@@ -131,6 +134,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         DefaultValue == other.DefaultValue &&
         IsEnumConversion == other.IsEnumConversion &&
         OriginalEnumTypeName == other.OriginalEnumTypeName &&
+        IsNestedType == other.IsNestedType &&
         Attributes.SequenceEqual(other.Attributes) &&
         AttributeNamespaces.SequenceEqual(other.AttributeNamespaces) &&
         MapWhenConditions.SequenceEqual(other.MapWhenConditions);
@@ -164,6 +168,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
             hash = hash * 31 + (DefaultValue?.GetHashCode() ?? 0);
             hash = hash * 31 + IsEnumConversion.GetHashCode();
             hash = hash * 31 + (OriginalEnumTypeName?.GetHashCode() ?? 0);
+            hash = hash * 31 + IsNestedType.GetHashCode();
             hash = hash * 31 + Attributes.Count.GetHashCode();
             foreach (var attr in Attributes)
                 hash = hash * 31 + (attr?.GetHashCode() ?? 0);

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -329,6 +329,10 @@ internal static class ModelBuilder
         bool isCollection = false;
         string? collectionWrapper = null;
 
+        // Detect if the property type is a nested type (has a containing type)
+        // This is needed to generate 'using static' instead of 'using' for the containing type
+        bool isNestedType = GeneratorUtilities.IsNestedType(property.Type);
+
         // Check if the property type is nullable (reference types)
         bool isNullableReferenceType = property.Type.NullableAnnotation == NullableAnnotation.Annotated;
         bool shouldTreatAsNullable = isNullableReferenceType;
@@ -501,7 +505,8 @@ internal static class ModelBuilder
             attributeNamespaces,
             defaultValue,
             isEnumConversion,
-            originalEnumTypeName));
+            originalEnumTypeName,
+            isNestedType));
         addedMembers.Add(memberName);
     }
 

--- a/src/Facet/Generators/Shared/GeneratorUtilities.cs
+++ b/src/Facet/Generators/Shared/GeneratorUtilities.cs
@@ -323,6 +323,31 @@ internal static class GeneratorUtilities
     }
 
     /// <summary>
+    /// Determines if a type symbol represents a nested type (a type declared within another type).
+    /// Unwraps nullable annotations and collection element types to check the underlying type.
+    /// </summary>
+    /// <param name="typeSymbol">The type symbol to check.</param>
+    /// <returns>True if the underlying type is nested within another type; otherwise, false.</returns>
+    public static bool IsNestedType(ITypeSymbol typeSymbol)
+    {
+        // For collections, check the element type
+        if (TryGetCollectionElementType(typeSymbol, out var elementType, out _) && elementType != null)
+        {
+            return elementType.ContainingType != null;
+        }
+
+        // For Nullable<T> value types, check the inner type
+        if (typeSymbol is INamedTypeSymbol namedType &&
+            namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            return namedType.TypeArguments[0].ContainingType != null;
+        }
+
+        // For regular types (including nullable reference types), ContainingType is on the type itself
+        return typeSymbol.ContainingType != null;
+    }
+
+    /// <summary>
     /// Wraps an element type name in the appropriate collection type.
     /// </summary>
     /// <param name="elementTypeName">The fully qualified element type name.</param>

--- a/test/Facet.Tests/TestModels/StaticClassTestModels.cs
+++ b/test/Facet.Tests/TestModels/StaticClassTestModels.cs
@@ -6,6 +6,10 @@ namespace Application.Example1
         {
             public string Name { get; set; } = string.Empty;
             public int Value { get; set; }
+
+            public Arr? Arr1 { get; set; }
+
+            public sealed class Arr { public int Length { get; set; } }
         }
     }
 }

--- a/test/Facet.Tests/UnitTests/Core/Facet/StaticClassNestedTypeTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/StaticClassNestedTypeTests.cs
@@ -2,9 +2,6 @@ using Facet.Tests.TestModels.StaticClassTest;
 
 namespace Facet.Tests.UnitTests.Core.Facet;
 
-/// <summary>
-/// Tests for issue #145: Generator fails to create static imports
-/// </summary>
 public class StaticClassNestedTypeTests
 {
     [Fact]
@@ -43,5 +40,46 @@ public class StaticClassNestedTypeTests
         dto.Should().NotBeNull();
         dto.Name.Should().Be("Test");
         dto.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Facet_ShouldGenerateCorrectly_WhenSourceHasNestedClassProperty()
+    {
+        // Arrange - issue #272: nested class property should generate using static, not using
+        var bar = new Application.Example1.Foo.Bar
+        {
+            Name = "Test",
+            Value = 42,
+            Arr1 = new Application.Example1.Foo.Bar.Arr { Length = 10 }
+        };
+
+        // Act
+        var dto = new BarDto(bar);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Name.Should().Be("Test");
+        dto.Value.Should().Be(42);
+        dto.Arr1.Should().NotBeNull();
+        dto.Arr1!.Length.Should().Be(10);
+    }
+
+    [Fact]
+    public void Facet_ShouldHandleNullNestedClassProperty()
+    {
+        // Arrange
+        var bar = new Application.Example1.Foo.Bar
+        {
+            Name = "Test",
+            Value = 42,
+            Arr1 = null
+        };
+
+        // Act
+        var dto = new BarDto(bar);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Arr1.Should().BeNull();
     }
 }


### PR DESCRIPTION
Fixes #272 

When a source type contains a property whose type is a nested class (e.g., `Bar.Arr`), the generator emitted `using Application.Example1.Foo.Bar;`, This is invalid C# because `Bar` is a class, not a namespace. It should be `using static Application.Example1.Foo.Bar;`.

### Changes

- **FacetMember**: Added `IsNestedType` property to track whether a member's type is declared inside another type
- **GeneratorUtilities**: Added `IsNestedType(ITypeSymbol)` helper that checks `ContainingType`, unwrapping collections and `Nullable<T>`
- **ModelBuilder**: Detects nested types via Roslyn's `ContainingType` and passes the flag through to `FacetMember`
- **CodeGenerationHelpers**: Skips `IsNestedType` members from regular `using` collection; emits `using static` for their containing types instead
- **Tests**: Added nested `Arr` class to static class test model and two new test cases