### PR TITLE
feat: GenerateCopyConstructor & GenerateEquality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Instead of manually creating each facet, **Facet** auto-generates them from a si
 - **`[MapWhen]`** - conditional mapping based on runtime values, works in SQL projections
 - **Before/After hooks** - inject validation, defaults, or computed values around auto-mapping
 - **`ConvertEnumsTo`** - convert all enums to `string` or `int` with full round-trip support
+- **`GenerateCopyConstructor`** - generate a copy constructor for cloning and MVVM scenarios
+- **`GenerateEquality`** - generate value-based `Equals`, `GetHashCode`, `==`, `!=` for class DTOs
 - Sync and async custom mapping configurations (static or DI-resolved instances)
 
 ### Advanced Features
@@ -616,6 +618,63 @@ public partial class EntityIntDto;
 [Facet(typeof(User), ConvertEnumsTo = typeof(string), NullableProperties = true)]
 public partial class UserQueryDto;
 // All properties nullable + enums converted to string
+```
+
+</details>
+
+<details>
+  <summary>Copy Constructor and Value Equality</summary>
+
+Generate a copy constructor for cloning DTOs, and/or value-based equality members for class-based facets:
+
+#### Copy Constructor
+
+```csharp
+[Facet(typeof(User), GenerateCopyConstructor = true)]
+public partial class UserDto;
+
+// Clone a DTO
+var original = new UserDto(user);
+var copy = new UserDto(original); // Copy constructor
+
+// Modify the copy without affecting the original
+copy.FirstName = "Changed";
+original.FirstName; // Still "John"
+```
+
+Use cases: MVVM undo/redo, caching snapshots, editing copies while preserving originals.
+
+#### Value Equality
+
+```csharp
+[Facet(typeof(User), GenerateEquality = true)]
+public partial class UserDto;
+
+var dto1 = new UserDto(user);
+var dto2 = new UserDto(user);
+
+dto1 == dto2;          // true — value-based comparison
+dto1.Equals(dto2);     // true
+dto1.GetHashCode() == dto2.GetHashCode(); // true
+
+// Works in collections
+var set = new HashSet<UserDto> { dto1 };
+set.Contains(dto2);    // true
+```
+
+The generated type implements `IEquatable<T>` with `Equals(T)`, `Equals(object)`, `GetHashCode()`, `==`, and `!=`.
+
+> **Note:** `GenerateEquality` is automatically ignored for record types, which already have built-in value equality.
+
+#### Combining Both
+
+```csharp
+[Facet(typeof(User), GenerateCopyConstructor = true, GenerateEquality = true)]
+public partial class UserDto;
+
+var original = new UserDto(user);
+var copy = new UserDto(original);
+original == copy; // true — same values, different instances
 ```
 
 </details>

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -326,6 +326,51 @@ public sealed class FacetAttribute : Attribute
     public Type? ConvertEnumsTo { get; set; }
 
     /// <summary>
+    /// When true, generates a copy constructor that accepts another instance of the same facet type
+    /// and copies all generated member values. This is useful for MVVM scenarios where you need to
+    /// create copies of view models, or for general DTO cloning.
+    /// Default is false.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [Facet(typeof(User), GenerateCopyConstructor = true)]
+    /// public partial class UserDto;
+    ///
+    /// // Generated:
+    /// // public UserDto(UserDto other)
+    /// // {
+    /// //     this.Id = other.Id;
+    /// //     this.FirstName = other.FirstName;
+    /// //     ...
+    /// // }
+    ///
+    /// var original = new UserDto(user);
+    /// var copy = new UserDto(original); // Copy constructor
+    /// </code>
+    /// </example>
+    public bool GenerateCopyConstructor { get; set; } = false;
+
+    /// <summary>
+    /// When true, generates value-based equality members: <c>Equals(T)</c>, <c>Equals(object)</c>,
+    /// <c>GetHashCode()</c>, and the <c>==</c> and <c>!=</c> operators.
+    /// The generated type will implement <see cref="System.IEquatable{T}"/>.
+    /// This is useful for class-based DTOs that need value comparison semantics without using records.
+    /// Default is false. Ignored for record types (which already have value-based equality).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [Facet(typeof(User), GenerateEquality = true)]
+    /// public partial class UserDto;
+    ///
+    /// var dto1 = new UserDto(user);
+    /// var dto2 = new UserDto(user);
+    /// dto1.Equals(dto2); // true — value-based comparison
+    /// dto1 == dto2;      // true — operator overload
+    /// </code>
+    /// </example>
+    public bool GenerateEquality { get; set; } = false;
+
+    /// <summary>
     /// Creates a new FacetAttribute that targets a given source type and excludes specified members.
     /// </summary>
     /// <param name="sourceType">The type to generate from.</param>

--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -43,6 +43,16 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     /// </summary>
     public string? ConvertEnumsTo { get; }
 
+    /// <summary>
+    /// Whether to generate a copy constructor that accepts another instance of the same facet type.
+    /// </summary>
+    public bool GenerateCopyConstructor { get; }
+
+    /// <summary>
+    /// Whether to generate value-based equality members (Equals, GetHashCode, ==, !=).
+    /// </summary>
+    public bool GenerateEquality { get; }
+
     public FacetTargetModel(
         string name,
         string? @namespace,
@@ -73,7 +83,9 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         string? beforeMapConfigurationTypeName = null,
         string? afterMapConfigurationTypeName = null,
         bool chainToParameterlessConstructor = false,
-        string? convertEnumsTo = null)
+        string? convertEnumsTo = null,
+        bool generateCopyConstructor = false,
+        bool generateEquality = false)
     {
         Name = name;
         Namespace = @namespace;
@@ -105,6 +117,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         BaseClassMemberNames = baseClassMemberNames.IsDefault ? ImmutableArray<string>.Empty : baseClassMemberNames;
         FlattenToTypes = flattenToTypes.IsDefault ? ImmutableArray<string>.Empty : flattenToTypes;
         ConvertEnumsTo = convertEnumsTo;
+        GenerateCopyConstructor = generateCopyConstructor;
+        GenerateEquality = generateEquality;
     }
 
     public bool Equals(FacetTargetModel? other)
@@ -140,7 +154,9 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && PreserveReferences == other.PreserveReferences
             && BaseClassMemberNames.SequenceEqual(other.BaseClassMemberNames)
             && FlattenToTypes.SequenceEqual(other.FlattenToTypes)
-            && ConvertEnumsTo == other.ConvertEnumsTo;
+            && ConvertEnumsTo == other.ConvertEnumsTo
+            && GenerateCopyConstructor == other.GenerateCopyConstructor
+            && GenerateEquality == other.GenerateEquality;
     }
 
     public override bool Equals(object? obj) => obj is FacetTargetModel other && Equals(other);
@@ -173,6 +189,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + MaxDepth.GetHashCode();
             hash = hash * 31 + PreserveReferences.GetHashCode();
             hash = hash * 31 + (ConvertEnumsTo?.GetHashCode() ?? 0);
+            hash = hash * 31 + GenerateCopyConstructor.GetHashCode();
+            hash = hash * 31 + GenerateEquality.GetHashCode();
             hash = hash * 31 + Members.Length.GetHashCode();
 
             foreach (var member in Members)

--- a/src/Facet/Generators/FacetGenerators/CopyConstructorGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/CopyConstructorGenerator.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using System.Text;
+
+namespace Facet.Generators;
+
+/// <summary>
+/// Generates copy constructors for facet types that copy all member values from another instance.
+/// </summary>
+internal static class CopyConstructorGenerator
+{
+    /// <summary>
+    /// Generates a copy constructor that accepts another instance of the same facet type
+    /// and copies all generated member values.
+    /// </summary>
+    public static void Generate(StringBuilder sb, FacetTargetModel model, string indent)
+    {
+        var hasRequiredProperties = model.Members.Any(m => m.IsRequired);
+
+        sb.AppendLine();
+        sb.AppendLine($"{indent}/// <summary>");
+        sb.AppendLine($"{indent}/// Initializes a new instance of the <see cref=\"{model.Name}\"/> class by copying all");
+        sb.AppendLine($"{indent}/// member values from another <see cref=\"{model.Name}\"/> instance.");
+        sb.AppendLine($"{indent}/// </summary>");
+        sb.AppendLine($"{indent}/// <param name=\"other\">The instance to copy values from.</param>");
+        sb.AppendLine($"{indent}/// <exception cref=\"System.ArgumentNullException\">Thrown when <paramref name=\"other\"/> is null.</exception>");
+
+        if (hasRequiredProperties)
+        {
+            sb.AppendLine($"{indent}[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
+        }
+
+        sb.AppendLine($"{indent}public {model.Name}({model.Name} other)");
+        sb.AppendLine($"{indent}{{");
+
+        // Add null check for reference types (classes)
+        if (model.TypeKind == Microsoft.CodeAnalysis.TypeKind.Class)
+        {
+            sb.AppendLine($"{indent}    if (other is null) throw new System.ArgumentNullException(nameof(other));");
+        }
+
+        // Copy all members
+        foreach (var m in model.Members)
+        {
+            // Skip init-only properties — they can't be assigned in a constructor body
+            // unless this is a positional record (handled differently)
+            if (m.IsInitOnly)
+                continue;
+
+            sb.AppendLine($"{indent}    this.{m.Name} = other.{m.Name};");
+        }
+
+        sb.AppendLine($"{indent}}}");
+    }
+}

--- a/src/Facet/Generators/FacetGenerators/EqualityGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/EqualityGenerator.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Facet.Generators;
+
+/// <summary>
+/// Generates value-based equality members (Equals, GetHashCode, ==, !=) for facet types.
+/// </summary>
+internal static class EqualityGenerator
+{
+    /// <summary>
+    /// Generates IEquatable&lt;T&gt; implementation, Equals, GetHashCode, and equality operators.
+    /// </summary>
+    public static void Generate(StringBuilder sb, FacetTargetModel model, string indent)
+    {
+        GenerateEqualsT(sb, model, indent);
+        GenerateEqualsObject(sb, model, indent);
+        GenerateGetHashCode(sb, model, indent);
+        GenerateEqualityOperators(sb, model, indent);
+    }
+
+    /// <summary>
+    /// Gets the interface declaration text that should be appended to the type declaration.
+    /// Returns "System.IEquatable&lt;TypeName&gt;" for use in the partial type declaration.
+    /// </summary>
+    public static string GetEquatableInterface(FacetTargetModel model)
+    {
+        return $"System.IEquatable<{model.Name}>";
+    }
+
+    private static void GenerateEqualsT(StringBuilder sb, FacetTargetModel model, string indent)
+    {
+        sb.AppendLine();
+        sb.AppendLine($"{indent}/// <summary>");
+        sb.AppendLine($"{indent}/// Determines whether the specified <see cref=\"{model.Name}\"/> is equal to the current instance.");
+        sb.AppendLine($"{indent}/// </summary>");
+        sb.AppendLine($"{indent}/// <param name=\"other\">The object to compare with the current instance.</param>");
+        sb.AppendLine($"{indent}/// <returns><c>true</c> if the specified object has equal member values; otherwise, <c>false</c>.</returns>");
+
+        bool isClass = model.TypeKind == Microsoft.CodeAnalysis.TypeKind.Class;
+
+        if (isClass)
+        {
+            sb.AppendLine($"{indent}public bool Equals({model.Name}? other)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    if (other is null) return false;");
+            sb.AppendLine($"{indent}    if (ReferenceEquals(this, other)) return true;");
+        }
+        else
+        {
+            // struct
+            sb.AppendLine($"{indent}public bool Equals({model.Name} other)");
+            sb.AppendLine($"{indent}{{");
+        }
+
+        if (model.Members.Length == 0)
+        {
+            sb.AppendLine($"{indent}    return true;");
+        }
+        else
+        {
+            sb.Append($"{indent}    return ");
+            var first = true;
+            foreach (var m in model.Members)
+            {
+                if (!first)
+                {
+                    sb.AppendLine();
+                    sb.Append($"{indent}        && ");
+                }
+                first = false;
+
+                sb.Append(GetEqualityExpression(m));
+            }
+            sb.AppendLine(";");
+        }
+
+        sb.AppendLine($"{indent}}}");
+    }
+
+    private static void GenerateEqualsObject(StringBuilder sb, FacetTargetModel model, string indent)
+    {
+        sb.AppendLine();
+        sb.AppendLine($"{indent}/// <inheritdoc/>");
+        sb.AppendLine($"{indent}public override bool Equals(object? obj) => obj is {model.Name} other && Equals(other);");
+    }
+
+    private static void GenerateGetHashCode(StringBuilder sb, FacetTargetModel model, string indent)
+    {
+        sb.AppendLine();
+        sb.AppendLine($"{indent}/// <inheritdoc/>");
+        sb.AppendLine($"{indent}public override int GetHashCode()");
+        sb.AppendLine($"{indent}{{");
+
+        if (model.Members.Length == 0)
+        {
+            sb.AppendLine($"{indent}    return 0;");
+        }
+        else
+        {
+            sb.AppendLine($"{indent}    unchecked");
+            sb.AppendLine($"{indent}    {{");
+            sb.AppendLine($"{indent}        int hash = 17;");
+            foreach (var m in model.Members)
+            {
+                sb.AppendLine($"{indent}        hash = hash * 31 + {GetHashCodeExpression(m)};");
+            }
+            sb.AppendLine($"{indent}        return hash;");
+            sb.AppendLine($"{indent}    }}");
+        }
+
+        sb.AppendLine($"{indent}}}");
+    }
+
+    private static void GenerateEqualityOperators(StringBuilder sb, FacetTargetModel model, string indent)
+    {
+        bool isClass = model.TypeKind == Microsoft.CodeAnalysis.TypeKind.Class;
+
+        sb.AppendLine();
+        sb.AppendLine($"{indent}/// <summary>Determines whether two <see cref=\"{model.Name}\"/> instances are equal.</summary>");
+
+        if (isClass)
+        {
+            sb.AppendLine($"{indent}public static bool operator ==({model.Name}? left, {model.Name}? right)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    if (left is null) return right is null;");
+            sb.AppendLine($"{indent}    return left.Equals(right);");
+            sb.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            sb.AppendLine($"{indent}public static bool operator ==({model.Name} left, {model.Name} right) => left.Equals(right);");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"{indent}/// <summary>Determines whether two <see cref=\"{model.Name}\"/> instances are not equal.</summary>");
+
+        if (isClass)
+        {
+            sb.AppendLine($"{indent}public static bool operator !=({model.Name}? left, {model.Name}? right) => !(left == right);");
+        }
+        else
+        {
+            sb.AppendLine($"{indent}public static bool operator !=({model.Name} left, {model.Name} right) => !(left == right);");
+        }
+    }
+
+    private static string GetEqualityExpression(FacetMember member)
+    {
+        // For value types, use direct comparison
+        if (member.IsValueType)
+        {
+            return $"this.{member.Name} == other.{member.Name}";
+        }
+
+        // For reference types, use EqualityComparer<T>.Default to handle nulls
+        return $"System.Collections.Generic.EqualityComparer<{member.TypeName}>.Default.Equals(this.{member.Name}, other.{member.Name})";
+    }
+
+    private static string GetHashCodeExpression(FacetMember member)
+    {
+        if (member.IsValueType)
+        {
+            return $"{member.Name}.GetHashCode()";
+        }
+
+        // For reference types, guard against null
+        return $"({member.Name}?.GetHashCode() ?? 0)";
+    }
+}

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -74,6 +74,10 @@ internal static class ModelBuilder
         // Extract ConvertEnumsTo parameter
         var convertEnumsTo = AttributeParser.ExtractConvertEnumsTo(attribute);
 
+        // Extract GenerateCopyConstructor and GenerateEquality parameters
+        var generateCopyConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateCopyConstructor, false);
+        var generateEquality = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateEquality, false);
+
         // Extract nested facets parameter and build mapping from source type to child facet type
         var nestedFacetMappings = AttributeParser.ExtractNestedFacetMappings(attribute, context.SemanticModel.Compilation);
 
@@ -206,7 +210,9 @@ internal static class ModelBuilder
             beforeMapConfigurationTypeName,
             afterMapConfigurationTypeName,
             chainToParameterlessConstructor,
-            convertEnumsTo);
+            convertEnumsTo,
+            generateCopyConstructor,
+            generateEquality);
     }
 
     #region Private Helper Methods

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -107,5 +107,7 @@ internal static class FacetConstants
         public const string UseFullName = "UseFullName";
         public const string ReadOnly = "ReadOnly";
         public const string ConvertEnumsTo = "ConvertEnumsTo";
+        public const string GenerateCopyConstructor = "GenerateCopyConstructor";
+        public const string GenerateEquality = "GenerateEquality";
     }
 }

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -161,7 +161,6 @@ public class InitOnlyWithInitializers
 [Facet(typeof(InitOnlyWithInitializers))]
 public partial class InitOnlyWithInitializersDto;
 
-// Test entity for GitHub issue #251 - Nullable issues with object properties
 // When a model has a single reference type property like List<string>,
 // the generated record positional constructor can become ambiguous with
 // the compiler-generated copy constructor
@@ -290,7 +289,6 @@ public class UserModelWithOptionalSettings
 [Facet(typeof(UserModelWithOptionalSettings), NestedFacets = [typeof(UserSettingsFacet)])]
 public partial class UserWithOptionalSettingsFacet;
 
-// Test entities for GitHub issue #258 - Required collection nested facets
 // When source has a required non-nullable collection nested property
 public class TeamModelWithRequiredMembers
 {
@@ -320,3 +318,33 @@ public partial class NonNullablePropertyFacet;
 // Also test with a required property - should not get default!
 [Facet(typeof(EntityWithNonNullableProperties), PreserveRequiredProperties = false)]
 public partial class NonNullablePropertyFacetNoRequired;
+
+// Test entity for GenerateCopyConstructor and GenerateEquality
+public class PersonForCopyAndEquality
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public int Age { get; set; }
+    public DateTime? BirthDate { get; set; }
+}
+
+// Facet with copy constructor
+[Facet(typeof(PersonForCopyAndEquality), GenerateCopyConstructor = true)]
+public partial class PersonWithCopyConstructorDto;
+
+// Facet with equality
+[Facet(typeof(PersonForCopyAndEquality), GenerateEquality = true)]
+public partial class PersonWithEqualityDto;
+
+// Facet with both copy constructor and equality
+[Facet(typeof(PersonForCopyAndEquality), GenerateCopyConstructor = true, GenerateEquality = true)]
+public partial class PersonWithCopyAndEqualityDto;
+
+// Facet with equality on a record — equality should be ignored since records already have it
+[Facet(typeof(PersonForCopyAndEquality), GenerateEquality = true)]
+public partial record PersonRecordWithEquality;
+
+// Facet with copy constructor on a struct
+[Facet(typeof(PersonForCopyAndEquality), GenerateCopyConstructor = true, GenerateEquality = true)]
+public partial struct PersonStructWithCopyAndEquality;

--- a/test/Facet.Tests/UnitTests/Core/Facet/CopyConstructorTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CopyConstructorTests.cs
@@ -1,0 +1,135 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// Tests for the GenerateCopyConstructor feature
+/// Verifies that a copy constructor is generated that copies all member values from another instance.
+/// </summary>
+public class CopyConstructorTests
+{
+    [Fact]
+    public void CopyConstructor_ShouldCopyAllProperties()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 42,
+            Name = "Alice",
+            Email = "alice@example.com",
+            Age = 30,
+            BirthDate = new DateTime(1994, 6, 15)
+        };
+        var original = new PersonWithCopyConstructorDto(source);
+
+        // Act
+        var copy = new PersonWithCopyConstructorDto(original);
+
+        // Assert
+        copy.Should().NotBeSameAs(original);
+        copy.Id.Should().Be(42);
+        copy.Name.Should().Be("Alice");
+        copy.Email.Should().Be("alice@example.com");
+        copy.Age.Should().Be(30);
+        copy.BirthDate.Should().Be(new DateTime(1994, 6, 15));
+    }
+
+    [Fact]
+    public void CopyConstructor_ShouldHandleNullableProperties()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Bob",
+            Email = "bob@example.com",
+            Age = 25,
+            BirthDate = null
+        };
+        var original = new PersonWithCopyConstructorDto(source);
+
+        // Act
+        var copy = new PersonWithCopyConstructorDto(original);
+
+        // Assert
+        copy.BirthDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void CopyConstructor_ShouldCreateIndependentCopy()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Charlie",
+            Email = "charlie@example.com",
+            Age = 35,
+            BirthDate = new DateTime(1989, 1, 1)
+        };
+        var original = new PersonWithCopyConstructorDto(source);
+
+        // Act
+        var copy = new PersonWithCopyConstructorDto(original);
+        // Modify the original — the copy should remain unchanged
+        original.Name = "Changed";
+        original.Age = 99;
+
+        // Assert
+        copy.Name.Should().Be("Charlie");
+        copy.Age.Should().Be(35);
+    }
+
+    [Fact]
+    public void CopyConstructor_ShouldThrowOnNull_ForClassFacets()
+    {
+        // Act & Assert
+        var act = () => new PersonWithCopyConstructorDto((PersonWithCopyConstructorDto)null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CopyConstructor_ShouldWorkWithBothFeatures()
+    {
+        // Arrange — facet with both GenerateCopyConstructor and GenerateEquality
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 7,
+            Name = "Diana",
+            Email = "diana@example.com",
+            Age = 28,
+            BirthDate = new DateTime(1996, 3, 20)
+        };
+        var original = new PersonWithCopyAndEqualityDto(source);
+
+        // Act
+        var copy = new PersonWithCopyAndEqualityDto(original);
+
+        // Assert — copy should equal the original
+        copy.Should().Be(original);
+        copy.Id.Should().Be(7);
+    }
+
+    [Fact]
+    public void CopyConstructor_ShouldWorkOnStruct()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 10,
+            Name = "Eve",
+            Email = "eve@example.com",
+            Age = 22
+        };
+        var original = new PersonStructWithCopyAndEquality(source);
+
+        // Act
+        var copy = new PersonStructWithCopyAndEquality(original);
+
+        // Assert
+        copy.Id.Should().Be(10);
+        copy.Name.Should().Be("Eve");
+        copy.Email.Should().Be("eve@example.com");
+        copy.Age.Should().Be(22);
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/EqualityTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/EqualityTests.cs
@@ -1,0 +1,251 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// Tests for the GenerateEquality feature (GitHub issue #277).
+/// Verifies that value-based equality members are generated for class-based facets.
+/// </summary>
+public class EqualityTests
+{
+    [Fact]
+    public void Equality_ShouldReturnTrue_ForEqualInstances()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Alice",
+            Email = "alice@example.com",
+            Age = 30,
+            BirthDate = new DateTime(1994, 6, 15)
+        };
+
+        var dto1 = new PersonWithEqualityDto(source);
+        var dto2 = new PersonWithEqualityDto(source);
+
+        // Act & Assert
+        dto1.Equals(dto2).Should().BeTrue();
+        (dto1 == dto2).Should().BeTrue();
+        (dto1 != dto2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equality_ShouldReturnFalse_ForDifferentInstances()
+    {
+        // Arrange
+        var source1 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30 };
+        var source2 = new PersonForCopyAndEquality { Id = 2, Name = "Bob", Email = "b@b.com", Age = 25 };
+
+        var dto1 = new PersonWithEqualityDto(source1);
+        var dto2 = new PersonWithEqualityDto(source2);
+
+        // Act & Assert
+        dto1.Equals(dto2).Should().BeFalse();
+        (dto1 == dto2).Should().BeFalse();
+        (dto1 != dto2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equality_ShouldReturnFalse_WhenComparedToNull()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30 };
+        var dto = new PersonWithEqualityDto(source);
+
+        // Act & Assert
+        dto.Equals(null).Should().BeFalse();
+        (dto == null).Should().BeFalse();
+        (null == dto).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equality_ShouldReturnTrue_ForSameReference()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30 };
+        var dto = new PersonWithEqualityDto(source);
+
+        // Act & Assert
+        dto.Equals(dto).Should().BeTrue();
+#pragma warning disable CS1718 // Comparison made to same variable
+        (dto == dto).Should().BeTrue();
+#pragma warning restore CS1718
+    }
+
+    [Fact]
+    public void Equality_EqualsObject_ShouldWork()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30 };
+        var dto1 = new PersonWithEqualityDto(source);
+        var dto2 = new PersonWithEqualityDto(source);
+
+        // Act & Assert
+        dto1.Equals((object)dto2).Should().BeTrue();
+        dto1.Equals((object)"not a dto").Should().BeFalse();
+        dto1.Equals((object?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldBeEqual_ForEqualInstances()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Alice",
+            Email = "alice@example.com",
+            Age = 30,
+            BirthDate = new DateTime(1994, 6, 15)
+        };
+
+        var dto1 = new PersonWithEqualityDto(source);
+        var dto2 = new PersonWithEqualityDto(source);
+
+        // Act & Assert
+        dto1.GetHashCode().Should().Be(dto2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldTypicallyDiffer_ForDifferentInstances()
+    {
+        // Arrange
+        var source1 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30 };
+        var source2 = new PersonForCopyAndEquality { Id = 2, Name = "Bob", Email = "b@b.com", Age = 25 };
+
+        var dto1 = new PersonWithEqualityDto(source1);
+        var dto2 = new PersonWithEqualityDto(source2);
+
+        // Act & Assert — not guaranteed but very likely for different data
+        dto1.GetHashCode().Should().NotBe(dto2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_ShouldHandleNullablePropertyDifferences()
+    {
+        // Arrange
+        var source1 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30, BirthDate = new DateTime(1994, 1, 1) };
+        var source2 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30, BirthDate = null };
+
+        var dto1 = new PersonWithEqualityDto(source1);
+        var dto2 = new PersonWithEqualityDto(source2);
+
+        // Act & Assert — different because BirthDate differs
+        dto1.Equals(dto2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equality_ShouldHandleBothNullablePropertiesNull()
+    {
+        // Arrange
+        var source1 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30, BirthDate = null };
+        var source2 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30, BirthDate = null };
+
+        var dto1 = new PersonWithEqualityDto(source1);
+        var dto2 = new PersonWithEqualityDto(source2);
+
+        // Act & Assert
+        dto1.Equals(dto2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equality_ShouldWorkWithCopyConstructor()
+    {
+        // Arrange — both features enabled
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Alice",
+            Email = "alice@example.com",
+            Age = 30,
+            BirthDate = new DateTime(1994, 6, 15)
+        };
+        var original = new PersonWithCopyAndEqualityDto(source);
+        var copy = new PersonWithCopyAndEqualityDto(original);
+
+        // Act & Assert
+        original.Equals(copy).Should().BeTrue();
+        (original == copy).Should().BeTrue();
+        original.GetHashCode().Should().Be(copy.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_ShouldWorkOnStruct()
+    {
+        // Arrange
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Alice",
+            Email = "alice@example.com",
+            Age = 30
+        };
+        var dto1 = new PersonStructWithCopyAndEquality(source);
+        var dto2 = new PersonStructWithCopyAndEquality(source);
+
+        // Act & Assert
+        dto1.Equals(dto2).Should().BeTrue();
+        (dto1 == dto2).Should().BeTrue();
+        (dto1 != dto2).Should().BeFalse();
+        dto1.GetHashCode().Should().Be(dto2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_ShouldBeIgnoredForRecords()
+    {
+        // Arrange — records already have value equality from the language
+        var source = new PersonForCopyAndEquality
+        {
+            Id = 1,
+            Name = "Alice",
+            Email = "alice@example.com",
+            Age = 30,
+            BirthDate = new DateTime(1994, 6, 15)
+        };
+        var dto1 = new PersonRecordWithEquality(source);
+        var dto2 = new PersonRecordWithEquality(source);
+
+        // Assert — record equality still works (built-in)
+        dto1.Should().Be(dto2);
+
+        // The generated type should NOT implement IEquatable<T> explicitly since it's a record
+        // (records implement it implicitly through the language)
+        var facetType = typeof(PersonRecordWithEquality);
+        var interfaces = facetType.GetInterfaces();
+        // Records get IEquatable<T> from the compiler, not from us
+        // We just verify records still work correctly
+        dto1.Equals(dto2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equality_ShouldImplementIEquatable()
+    {
+        // Arrange
+        var facetType = typeof(PersonWithEqualityDto);
+
+        // Act
+        var implementsIEquatable = typeof(IEquatable<PersonWithEqualityDto>).IsAssignableFrom(facetType);
+
+        // Assert
+        implementsIEquatable.Should().BeTrue("the generated class should implement IEquatable<T>");
+    }
+
+    [Fact]
+    public void Equality_ShouldWorkInCollections()
+    {
+        // Arrange
+        var source1 = new PersonForCopyAndEquality { Id = 1, Name = "Alice", Email = "a@a.com", Age = 30 };
+        var source2 = new PersonForCopyAndEquality { Id = 2, Name = "Bob", Email = "b@b.com", Age = 25 };
+
+        var dto1 = new PersonWithEqualityDto(source1);
+        var dto2 = new PersonWithEqualityDto(source2);
+        var dto1Copy = new PersonWithEqualityDto(source1);
+
+        var set = new HashSet<PersonWithEqualityDto> { dto1, dto2 };
+
+        // Act & Assert — HashSet should find dto1Copy as already existing
+        set.Contains(dto1Copy).Should().BeTrue();
+        set.Should().HaveCount(2);
+    }
+}


### PR DESCRIPTION
Addresses #277 - this PR introduces 2 new parameters to the `Facet` attribute

### `GenerateCopyConstructor` (default: `false`)
Generates a constructor that accepts another instance of the same facet type and copies all member values. Useful for MVVM undo/redo, DTO cloning, and snapshot patterns.

```csharp
[Facet(typeof(User), GenerateCopyConstructor = true)]
public partial class UserDto;

var copy = new UserDto(original);
```

### `GenerateEquality` (default: `false`)
Generates value-based `Equals(T)`, `Equals(object)`, `GetHashCode()`, `==`, `!=` and implements `IEquatable<T>`. Automatically ignored for record types which already have value equality.

```csharp
[Facet(typeof(User), GenerateEquality = true)]
public partial class UserDto;

dto1 == dto2; // true if all member values match