### PR TITLE
Override global default Facet configuration in csproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Instead of manually creating each facet, **Facet** auto-generates them from a si
 - **[Facet Dashboard](https://github.com/Tim-Maes/Facet/tree/master/src/Facet.Dashboard)**
 - [What is being generated?](docs/07_WhatIsBeingGenerated.md)
 - [Configure generated files output location](docs/12_GeneratedFilesOutput.md)
+- [Global configuration defaults](docs/21_GlobalConfigurationDefaults.md) - Override attribute defaults project-wide
 - [Comprehensive article about Facetting](https://tim-maes.com/blog/2025/09/28/facets-in-dotnet-(2)/)
 
 ## :star: Features
@@ -54,6 +55,7 @@ Instead of manually creating each facet, **Facet** auto-generates them from a si
 
 ### Mapping & Customization
 - Include/exclude properties with simple attribute arguments
+- **Global Configuration** - override default attribute settings project-wide via MSBuild properties ([docs](docs/21_GlobalConfigurationDefaults.md))
 - **`[MapFrom]`** - declarative property renaming with optional reverse mapping and expression support
 - **`[MapWhen]`** - conditional mapping based on runtime values, works in SQL projections
 - **Before/After hooks** - inject validation, defaults, or computed values around auto-mapping

--- a/docs/21_GlobalConfigurationDefaults.md
+++ b/docs/21_GlobalConfigurationDefaults.md
@@ -1,0 +1,184 @@
+# Global Configuration Defaults
+
+## Overview
+
+Facet allows you to override the default values for attribute properties globally using MSBuild properties. This is useful when you want to apply consistent settings across all your facets without having to specify the same property on every attribute.
+
+## Use Case
+
+When working with mapping libraries like [Mapperly](https://mapperly.riok.app/), you may need to disable certain Facet features (like constructor generation) to avoid conflicts. Instead of setting `GenerateConstructor = false` on every facet, you can configure this globally.
+
+## Supported Configuration Properties
+
+The following properties can be configured globally for the `[Facet]` attribute:
+
+| Property | Default | MSBuild Property |
+|----------|---------|------------------|
+| `GenerateConstructor` | `true` | `Facet_GenerateConstructor` |
+| `GenerateParameterlessConstructor` | `true` | `Facet_GenerateParameterlessConstructor` |
+| `GenerateProjection` | `true` | `Facet_GenerateProjection` |
+| `GenerateToSource` | `false` | `Facet_GenerateToSource` |
+| `IncludeFields` | `false` | `Facet_IncludeFields` |
+| `ChainToParameterlessConstructor` | `false` | `Facet_ChainToParameterlessConstructor` |
+| `NullableProperties` | `false` | `Facet_NullableProperties` |
+| `CopyAttributes` | `false` | `Facet_CopyAttributes` |
+| `UseFullName` | `false` | `Facet_UseFullName` |
+| `GenerateCopyConstructor` | `false` | `Facet_GenerateCopyConstructor` |
+| `GenerateEquality` | `false` | `Facet_GenerateEquality` |
+| `MaxDepth` | `10` | `Facet_MaxDepth` |
+| `PreserveReferences` | `true` | `Facet_PreserveReferences` |
+
+## How to Configure
+
+### Option 1: Project File (.csproj)
+
+Add MSBuild properties to your `.csproj` file:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <!-- Override Facet defaults -->
+    <Facet_GenerateConstructor>false</Facet_GenerateConstructor>
+    <Facet_GenerateProjection>true</Facet_GenerateProjection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Facet" Version="5.7.0" />
+  </ItemGroup>
+</Project>
+```
+
+### Option 2: Directory.Build.props
+
+For multi-project solutions, create a `Directory.Build.props` file at the solution root:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <!-- Override Facet defaults for all projects -->
+    <Facet_GenerateConstructor>false</Facet_GenerateConstructor>
+    <Facet_GenerateParameterlessConstructor>true</Facet_GenerateParameterlessConstructor>
+  </PropertyGroup>
+</Project>
+```
+
+This approach applies the settings to all projects in the solution directory tree.
+
+## Example: Using with Mapperly
+
+When using Facet alongside [Mapperly](https://mapperly.riok.app/) for mapping, you may want to disable Facet's constructor generation to let Mapperly handle the mapping logic:
+
+**Directory.Build.props:**
+```xml
+<Project>
+  <PropertyGroup>
+    <!-- Disable constructor generation for Mapperly compatibility -->
+    <Facet_GenerateConstructor>false</Facet_GenerateConstructor>
+  </PropertyGroup>
+</Project>
+```
+
+**Your code:**
+```csharp
+// Domain model
+public class User
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Email { get; set; }
+}
+
+// Facet DTO - constructor generation is disabled globally
+[Facet(typeof(User))]
+public partial class UserDto;
+
+// Mapperly mapper
+[Mapper]
+public partial class UserMapper
+{
+    public partial UserDto MapToDto(User user);
+}
+```
+
+Now all facets will have `GenerateConstructor = false` by default, unless explicitly overridden on the attribute.
+
+## Overriding Global Defaults
+
+You can still override the global default on individual facets by explicitly setting the property:
+
+```csharp
+// This facet will generate a constructor despite the global setting
+[Facet(typeof(User), GenerateConstructor = true)]
+public partial class UserDtoWithConstructor;
+
+// This facet uses the global default (no constructor)
+[Facet(typeof(User))]
+public partial class UserDtoWithoutConstructor;
+```
+
+## Precedence
+
+The configuration precedence from highest to lowest is:
+
+1. **Explicit attribute property** > Set directly on the `[Facet]` attribute
+2. **Global MSBuild property** > Set via `Facet_PropertyName` in .csproj or Directory.Build.props
+3. **Hardcoded default** > The default value defined in the Facet library
+
+## Example Scenarios
+
+### Scenario 1: All Facets as Query DTOs
+
+Make all facets nullable by default for query/filter scenarios:
+
+```xml
+<PropertyGroup>
+  <Facet_NullableProperties>true</Facet_NullableProperties>
+</PropertyGroup>
+```
+
+### Scenario 2: Disable All Code Generation Except Properties
+
+```xml
+<PropertyGroup>
+  <Facet_GenerateConstructor>false</Facet_GenerateConstructor>
+  <Facet_GenerateParameterlessConstructor>false</Facet_GenerateParameterlessConstructor>
+  <Facet_GenerateProjection>false</Facet_GenerateProjection>
+</PropertyGroup>
+```
+
+### Scenario 3: Enable Full Name Generation
+
+Avoid naming conflicts by using full type names for all generated files:
+
+```xml
+<PropertyGroup>
+  <Facet_UseFullName>true</Facet_UseFullName>
+</PropertyGroup>
+```
+
+### Scenario 4: Copy All Attributes by Default
+
+Preserve validation and serialization attributes from source types:
+
+```xml
+<PropertyGroup>
+  <Facet_CopyAttributes>true</Facet_CopyAttributes>
+</PropertyGroup>
+```
+
+## Notes
+
+- Global defaults are read at build time from MSBuild properties
+- Changes to global configuration require a rebuild to take effect
+- These settings only affect the `[Facet]` attribute (support for `[Wrapper]` and `[GenerateDtos]` may be added in future versions)
+- Boolean values should be `true` or `false` (case-insensitive)
+- Numeric values (like `MaxDepth`) should be valid integers
+
+## Related Documentation
+
+- [Attribute Reference](03_AttributeReference.md) - Complete list of attribute properties
+- [GenerateDtosAttribute](09_GenerateDtosAttribute.md) - DTO generation
+- [WrapperAttribute](14_WrapperAttribute.md) - Wrapper generation

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Welcome to the Facet documentation! This index will help you navigate all availa
 - [Analyzer Rules](13_AnalyzerRules.md): Complete guide to Facet's Roslyn analyzers and diagnostic rules
 - [Source Signature Change Tracking](16_SourceSignature.md): Track source entity changes with compile-time signature verification
 - [Enum Conversion](20_ConvertEnumsTo.md): Convert enum properties to string or int with ConvertEnumsTo
+- [Global Configuration Defaults](21_GlobalConfigurationDefaults.md): Override default attribute settings globally using MSBuild properties
 
  ## Ecosystem packages
 - [Facet.Extensions.EFCore](../src/Facet.Extensions.EFCore/README.md): EF Core Async Extension Methods

--- a/src/Facet/Generators/FacetGenerators/FacetGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/FacetGenerator.cs
@@ -12,11 +12,17 @@ public sealed class FacetGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        // Read global configuration defaults from MSBuild properties
+        var globalOptions = context.AnalyzerConfigOptionsProvider
+            .Select(static (provider, _) => GlobalConfigurationDefaults.FromOptions(provider.GlobalOptions));
+
         var facets = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 FacetConstants.FacetAttributeFullName,
                 predicate: static (node, _) => node is TypeDeclarationSyntax,
-                transform: static (ctx, token) => ModelBuilder.BuildModel(ctx, token))
+                transform: static (ctx, token) => (ctx, token))
+            .Combine(globalOptions)
+            .Select(static (combined, token) => ModelBuilder.BuildModel(combined.Left.ctx, combined.Right, combined.Left.token))
             .Where(static m => m is not null);
 
         // Collect all facet models to enable nested facet lookup during generation

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -17,7 +17,10 @@ internal static class ModelBuilder
     /// <summary>
     /// Builds a FacetTargetModel from the generator attribute syntax context.
     /// </summary>
-    public static FacetTargetModel? BuildModel(GeneratorAttributeSyntaxContext context, CancellationToken token)
+    public static FacetTargetModel? BuildModel(
+        GeneratorAttributeSyntaxContext context,
+        GlobalConfigurationDefaults globalDefaults,
+        CancellationToken token)
     {
         token.ThrowIfCancellationRequested();
         if (context.TargetSymbol is not INamedTypeSymbol targetSymbol) return null;
@@ -33,13 +36,13 @@ internal static class ModelBuilder
         var excluded = AttributeParser.ExtractExcludedMembers(attribute);
         var (included, isIncludeMode) = AttributeParser.ExtractIncludedMembers(attribute);
 
-        // Extract configuration settings
-        var includeFields = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.IncludeFields, false);
-        var generateConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateConstructor, true);
-        var generateParameterlessConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateParameterlessConstructor, true);
-        var chainToParameterlessConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.ChainToParameterlessConstructor, false);
-        var generateProjection = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateProjection, true);
-        var generateToSource = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateToSource, false);
+        // Extract configuration settings - use global defaults when not explicitly set on the attribute
+        var includeFields = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.IncludeFields, globalDefaults.IncludeFields);
+        var generateConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateConstructor, globalDefaults.GenerateConstructor);
+        var generateParameterlessConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateParameterlessConstructor, globalDefaults.GenerateParameterlessConstructor);
+        var chainToParameterlessConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.ChainToParameterlessConstructor, globalDefaults.ChainToParameterlessConstructor);
+        var generateProjection = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateProjection, globalDefaults.GenerateProjection);
+        var generateToSource = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateToSource, globalDefaults.GenerateToSource);
         var configurationTypeName = AttributeParser.ExtractConfigurationTypeName(attribute);
         var beforeMapConfigurationTypeName = AttributeParser.ExtractBeforeMapConfigurationTypeName(attribute);
         var afterMapConfigurationTypeName = AttributeParser.ExtractAfterMapConfigurationTypeName(attribute);
@@ -66,17 +69,17 @@ internal static class ModelBuilder
 
         var preserveInitOnly = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveInitOnlyProperties, preserveInitOnlyDefault);
         var preserveRequired = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveRequiredProperties, preserveRequiredDefault);
-        var nullableProperties = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.NullableProperties, false);
-        var copyAttributes = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.CopyAttributes, false);
-        var maxDepth = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.MaxDepth, FacetConstants.DefaultMaxDepth);
-        var preserveReferences = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveReferences, FacetConstants.DefaultPreserveReferences);
+        var nullableProperties = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.NullableProperties, globalDefaults.NullableProperties);
+        var copyAttributes = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.CopyAttributes, globalDefaults.CopyAttributes);
+        var maxDepth = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.MaxDepth, globalDefaults.MaxDepth);
+        var preserveReferences = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveReferences, globalDefaults.PreserveReferences);
 
         // Extract ConvertEnumsTo parameter
         var convertEnumsTo = AttributeParser.ExtractConvertEnumsTo(attribute);
 
-        // Extract GenerateCopyConstructor and GenerateEquality parameters
-        var generateCopyConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateCopyConstructor, false);
-        var generateEquality = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateEquality, false);
+        // Extract GenerateCopyConstructor and GenerateEquality parameters - use global defaults
+        var generateCopyConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateCopyConstructor, globalDefaults.GenerateCopyConstructor);
+        var generateEquality = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateEquality, globalDefaults.GenerateEquality);
 
         // Extract nested facets parameter and build mapping from source type to child facet type
         var nestedFacetMappings = AttributeParser.ExtractNestedFacetMappings(attribute, context.SemanticModel.Compilation);
@@ -119,8 +122,8 @@ internal static class ModelBuilder
             ? null
             : targetSymbol.ContainingNamespace.ToDisplayString();
 
-        // Determine full name
-        var useFullName = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.UseFullName, false);
+        // Determine full name - use global default
+        var useFullName = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.UseFullName, globalDefaults.UseFullName);
 
         // Get containing types for nested classes
         var containingTypes = TypeAnalyzer.GetContainingTypes(targetSymbol);

--- a/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
+++ b/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
@@ -1,0 +1,163 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Facet.Generators.Shared;
+
+/// <summary>
+/// Reads global configuration defaults from MSBuild properties or .editorconfig.
+/// These defaults override the hardcoded attribute defaults when the attribute property is not explicitly set.
+/// </summary>
+internal sealed class GlobalConfigurationDefaults
+{
+    /// <summary>
+    /// Default value for GenerateConstructor (default: true).
+    /// Can be overridden by setting the Facet_GenerateConstructor MSBuild property.
+    /// </summary>
+    public bool GenerateConstructor { get; }
+
+    /// <summary>
+    /// Default value for GenerateParameterlessConstructor (default: true).
+    /// Can be overridden by setting the Facet_GenerateParameterlessConstructor MSBuild property.
+    /// </summary>
+    public bool GenerateParameterlessConstructor { get; }
+
+    /// <summary>
+    /// Default value for GenerateProjection (default: true).
+    /// Can be overridden by setting the Facet_GenerateProjection MSBuild property.
+    /// </summary>
+    public bool GenerateProjection { get; }
+
+    /// <summary>
+    /// Default value for GenerateToSource (default: false).
+    /// Can be overridden by setting the Facet_GenerateToSource MSBuild property.
+    /// </summary>
+    public bool GenerateToSource { get; }
+
+    /// <summary>
+    /// Default value for IncludeFields (default: false).
+    /// Can be overridden by setting the Facet_IncludeFields MSBuild property.
+    /// </summary>
+    public bool IncludeFields { get; }
+
+    /// <summary>
+    /// Default value for ChainToParameterlessConstructor (default: false).
+    /// Can be overridden by setting the Facet_ChainToParameterlessConstructor MSBuild property.
+    /// </summary>
+    public bool ChainToParameterlessConstructor { get; }
+
+    /// <summary>
+    /// Default value for NullableProperties (default: false).
+    /// Can be overridden by setting the Facet_NullableProperties MSBuild property.
+    /// </summary>
+    public bool NullableProperties { get; }
+
+    /// <summary>
+    /// Default value for CopyAttributes (default: false).
+    /// Can be overridden by setting the Facet_CopyAttributes MSBuild property.
+    /// </summary>
+    public bool CopyAttributes { get; }
+
+    /// <summary>
+    /// Default value for UseFullName (default: false).
+    /// Can be overridden by setting the Facet_UseFullName MSBuild property.
+    /// </summary>
+    public bool UseFullName { get; }
+
+    /// <summary>
+    /// Default value for GenerateCopyConstructor (default: false).
+    /// Can be overridden by setting the Facet_GenerateCopyConstructor MSBuild property.
+    /// </summary>
+    public bool GenerateCopyConstructor { get; }
+
+    /// <summary>
+    /// Default value for GenerateEquality (default: false).
+    /// Can be overridden by setting the Facet_GenerateEquality MSBuild property.
+    /// </summary>
+    public bool GenerateEquality { get; }
+
+    /// <summary>
+    /// Default value for MaxDepth (default: 10).
+    /// Can be overridden by setting the Facet_MaxDepth MSBuild property.
+    /// </summary>
+    public int MaxDepth { get; }
+
+    /// <summary>
+    /// Default value for PreserveReferences (default: true).
+    /// Can be overridden by setting the Facet_PreserveReferences MSBuild property.
+    /// </summary>
+    public bool PreserveReferences { get; }
+
+    private GlobalConfigurationDefaults(
+        bool generateConstructor,
+        bool generateParameterlessConstructor,
+        bool generateProjection,
+        bool generateToSource,
+        bool includeFields,
+        bool chainToParameterlessConstructor,
+        bool nullableProperties,
+        bool copyAttributes,
+        bool useFullName,
+        bool generateCopyConstructor,
+        bool generateEquality,
+        int maxDepth,
+        bool preserveReferences)
+    {
+        GenerateConstructor = generateConstructor;
+        GenerateParameterlessConstructor = generateParameterlessConstructor;
+        GenerateProjection = generateProjection;
+        GenerateToSource = generateToSource;
+        IncludeFields = includeFields;
+        ChainToParameterlessConstructor = chainToParameterlessConstructor;
+        NullableProperties = nullableProperties;
+        CopyAttributes = copyAttributes;
+        UseFullName = useFullName;
+        GenerateCopyConstructor = generateCopyConstructor;
+        GenerateEquality = generateEquality;
+        MaxDepth = maxDepth;
+        PreserveReferences = preserveReferences;
+    }
+
+    /// <summary>
+    /// Reads global configuration defaults from analyzer configuration options.
+    /// Falls back to hardcoded defaults if not specified.
+    /// </summary>
+    public static GlobalConfigurationDefaults FromOptions(AnalyzerConfigOptions? globalOptions)
+    {
+        return new GlobalConfigurationDefaults(
+            generateConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateConstructor", defaultValue: true),
+            generateParameterlessConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateParameterlessConstructor", defaultValue: true),
+            generateProjection: GetBoolOption(globalOptions, "build_property.Facet_GenerateProjection", defaultValue: true),
+            generateToSource: GetBoolOption(globalOptions, "build_property.Facet_GenerateToSource", defaultValue: false),
+            includeFields: GetBoolOption(globalOptions, "build_property.Facet_IncludeFields", defaultValue: false),
+            chainToParameterlessConstructor: GetBoolOption(globalOptions, "build_property.Facet_ChainToParameterlessConstructor", defaultValue: false),
+            nullableProperties: GetBoolOption(globalOptions, "build_property.Facet_NullableProperties", defaultValue: false),
+            copyAttributes: GetBoolOption(globalOptions, "build_property.Facet_CopyAttributes", defaultValue: false),
+            useFullName: GetBoolOption(globalOptions, "build_property.Facet_UseFullName", defaultValue: false),
+            generateCopyConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateCopyConstructor", defaultValue: false),
+            generateEquality: GetBoolOption(globalOptions, "build_property.Facet_GenerateEquality", defaultValue: false),
+            maxDepth: GetIntOption(globalOptions, "build_property.Facet_MaxDepth", defaultValue: FacetConstants.DefaultMaxDepth),
+            preserveReferences: GetBoolOption(globalOptions, "build_property.Facet_PreserveReferences", defaultValue: FacetConstants.DefaultPreserveReferences));
+    }
+
+    private static bool GetBoolOption(AnalyzerConfigOptions? options, string key, bool defaultValue)
+    {
+        if (options == null)
+            return defaultValue;
+
+        if (options.TryGetValue(key, out var value) && bool.TryParse(value, out var result))
+            return result;
+
+        return defaultValue;
+    }
+
+    private static int GetIntOption(AnalyzerConfigOptions? options, string key, int defaultValue)
+    {
+        if (options == null)
+            return defaultValue;
+
+        if (options.TryGetValue(key, out var value) && int.TryParse(value, out var result))
+            return result;
+
+        return defaultValue;
+    }
+}


### PR DESCRIPTION
Fixes #282 

## How to Configure

### Option 1: Project File (.csproj)

Add MSBuild properties to your `.csproj` file:

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net9.0</TargetFramework>

    <!-- Override Facet defaults -->
    <Facet_GenerateConstructor>false</Facet_GenerateConstructor>
    <Facet_GenerateProjection>true</Facet_GenerateProjection>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Facet" Version="5.7.0" />
  </ItemGroup>
</Project>
```

### Option 2: Directory.Build.props

For multi-project solutions, create a `Directory.Build.props` file at the solution root:

```xml
<Project>
  <PropertyGroup>
    <!-- Override Facet defaults for all projects -->
    <Facet_GenerateConstructor>false</Facet_GenerateConstructor>
    <Facet_GenerateParameterlessConstructor>true</Facet_GenerateParameterlessConstructor>
  </PropertyGroup>
</Project>
```

The following properties can be configured globally for the `[Facet]` attribute:

| Property | Default | MSBuild Property |
|----------|---------|------------------|
| `GenerateConstructor` | `true` | `Facet_GenerateConstructor` |
| `GenerateParameterlessConstructor` | `true` | `Facet_GenerateParameterlessConstructor` |
| `GenerateProjection` | `true` | `Facet_GenerateProjection` |
| `GenerateToSource` | `false` | `Facet_GenerateToSource` |
| `IncludeFields` | `false` | `Facet_IncludeFields` |
| `ChainToParameterlessConstructor` | `false` | `Facet_ChainToParameterlessConstructor` |
| `NullableProperties` | `false` | `Facet_NullableProperties` |
| `CopyAttributes` | `false` | `Facet_CopyAttributes` |
| `UseFullName` | `false` | `Facet_UseFullName` |
| `GenerateCopyConstructor` | `false` | `Facet_GenerateCopyConstructor` |
| `GenerateEquality` | `false` | `Facet_GenerateEquality` |
| `MaxDepth` | `10` | `Facet_MaxDepth` |
| `PreserveReferences` | `true` | `Facet_PreserveReferences` |

## Notes

- Global defaults are read at build time from MSBuild properties
- Changes to global configuration require a rebuild to take effect
- These settings only affect the `[Facet]` attribute (support for `[Wrapper]` and `[GenerateDtos]` may be added in future versions)
- Boolean values should be `true` or `false` (case-insensitive)