### PR TITLE
Fix: PreserveRequiredProperties for record class facets (#298)

### DIFF
--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -66,9 +66,14 @@ internal static class CodeBuilder
         }
 
         var keyword = GetTypeKeyword(model);
-        var isPositional = model.IsRecord && !model.HasExistingPrimaryConstructor;
         var hasInitOnlyProperties = model.Members.Any(m => m.IsInitOnly);
         var hasRequiredProperties = model.Members.Any(m => m.IsRequired);
+
+        // For record classes, avoid positional declarations when there are required members,
+        // because C# doesn't support the 'required' modifier on positional parameters of record classes.
+        // Record structs DO support 'required' on positional parameters, so they can stay positional.
+        var isPositional = model.IsRecord && !model.HasExistingPrimaryConstructor
+            && !(model.TypeKind == TypeKind.Class && hasRequiredProperties);
         var hasCustomMapping = !string.IsNullOrWhiteSpace(model.ConfigurationTypeName);
 
         // Determine if we need to generate equality (skip for records which already have value equality)

--- a/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
@@ -201,9 +201,8 @@ internal static class ConstructorGenerator
             else
             {
                 // No custom mapping - copy properties directly
-                // Cache filtered members to avoid multiple enumerations
-                var assignableMembers = model.Members.Where(x => !x.IsInitOnly).ToArray();
-                foreach (var m in assignableMembers)
+                // Init-only properties are included because constructors can set init accessors
+                foreach (var m in model.Members)
                 {
                     var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source");
                     sb.AppendLine($"        this.{m.Name} = {sourceValue};");
@@ -338,9 +337,8 @@ internal static class ConstructorGenerator
         else
         {
             // No custom mapping - copy properties directly with depth tracking
-            // Cache filtered members to avoid multiple enumerations
-            var assignableMembers = model.Members.Where(x => !x.IsInitOnly).ToArray();
-            foreach (var m in assignableMembers)
+            // Init-only properties are included because constructors can set init accessors
+            foreach (var m in model.Members)
             {
                 var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences);
                 sb.AppendLine($"        this.{m.Name} = {sourceValue};");

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -29,6 +29,10 @@ public partial record ModernUserDto
 [Facet(typeof(UserWithEnum), GenerateToSource = true)]
 public partial class UserWithEnumDto;
 
+// Exact scenario from issue #298: plain record facet with required properties, no () workaround
+[Facet(typeof(ModernUser), "PasswordHash", "Bio", PreserveRequiredProperties = true)]
+public partial record ModernUserRequiredDto;
+
 [Facet(typeof(User), "Password", "CreatedAt")]
 public partial record struct UserSummary;
 

--- a/test/Facet.Tests/UnitTests/Core/Facet/ModernRecordTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ModernRecordTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Facet.Tests.TestModels;
 using Facet.Tests.Utilities;
 
@@ -170,5 +171,50 @@ public class ModernRecordTests
         var dtoType = dto.GetType();
         dtoType.GetProperty("FirstName").Should().NotBeNull();
         dtoType.GetProperty("firstname").Should().BeNull(); // lowercase should not exist
+    }
+
+    [Fact]
+    public void RecordFacet_ShouldPreserveRequiredModifier_WithoutWorkaround()
+    {
+        // Issue #298: PreserveRequiredProperties should work for record facets
+        // without needing the empty primary constructor () workaround
+        var dtoType = typeof(ModernUserRequiredDto);
+
+        // Verify required properties from source are marked required in the generated record
+        var idProp = dtoType.GetProperty("Id")!;
+        idProp.Should().NotBeNull();
+        idProp.GetCustomAttribute<System.Runtime.CompilerServices.RequiredMemberAttribute>()
+            .Should().NotBeNull("Id should be marked as required");
+
+        var firstNameProp = dtoType.GetProperty("FirstName")!;
+        firstNameProp.Should().NotBeNull();
+        firstNameProp.GetCustomAttribute<System.Runtime.CompilerServices.RequiredMemberAttribute>()
+            .Should().NotBeNull("FirstName should be marked as required");
+
+        var lastNameProp = dtoType.GetProperty("LastName")!;
+        lastNameProp.Should().NotBeNull();
+        lastNameProp.GetCustomAttribute<System.Runtime.CompilerServices.RequiredMemberAttribute>()
+            .Should().NotBeNull("LastName should be marked as required");
+    }
+
+    [Fact]
+    public void RecordFacet_WithRequiredProperties_ShouldMapCorrectly()
+    {
+        // Issue #298: Verify the record facet with required properties maps correctly
+        var modernUser = new ModernUser
+        {
+            Id = "test-id",
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        var dto = modernUser.ToFacet<ModernUser, ModernUserRequiredDto>();
+
+        dto.Id.Should().Be("test-id");
+        dto.FirstName.Should().Be("Jane");
+        dto.LastName.Should().Be("Doe");
+        dto.Email.Should().Be("jane@example.com");
     }
 }


### PR DESCRIPTION
Fixes issue #298 

Record classes with required members were incorrectly generated as positional declarations (e.g., record Foo(string Bar)), which silently dropped the required modifier since C# doesn't support required on positional parameters of record classes (only record structs support this).

Now, when a record class has required members, the generator uses non-positional declarations with proper required property syntax instead.

Also fixed constructor body to assign init-only properties, which was previously skipped but is valid C# in constructors.