### PR TITLE
fix: static members

### DIFF
--- a/src/Facet/Generators/Shared/GeneratorUtilities.cs
+++ b/src/Facet/Generators/Shared/GeneratorUtilities.cs
@@ -103,6 +103,7 @@ internal static class GeneratorUtilities
             foreach (var member in current.GetMembers())
             {
                 if (member.DeclaredAccessibility == Accessibility.Public &&
+                    !member.IsStatic &&
                     !visited.Contains(member.Name))
                 {
                     if (member is IPropertySymbol prop)

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -33,6 +33,10 @@ public partial class UserWithEnumDto;
 [Facet(typeof(ModernUser), "PasswordHash", "Bio", PreserveRequiredProperties = true)]
 public partial record ModernUserRequiredDto;
 
+// Issue #300: static properties should not be included in facets
+[Facet(typeof(EntityWithStaticMembers))]
+public partial record StaticMemberTestDto;
+
 [Facet(typeof(User), "Password", "CreatedAt")]
 public partial record struct UserSummary;
 

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -130,6 +130,15 @@ public class Category : BaseEntity<uint>
     public string? Description { get; set; }
 }
 
+// Test entity with static/const members that should be excluded from facets (issue #300)
+public class EntityWithStaticMembers
+{
+    public const string AConst = "A";
+    public static readonly string AStaticReadonly = "A";
+    public string AProperty { get; set; } = "A";
+    public static string AStaticProperty => "A";
+}
+
 // Test entity with non-nullable reference type properties with initializers (GitHub issue)
 public class UserModel
 {
@@ -341,7 +350,7 @@ public partial class PersonWithEqualityDto;
 [Facet(typeof(PersonForCopyAndEquality), GenerateCopyConstructor = true, GenerateEquality = true)]
 public partial class PersonWithCopyAndEqualityDto;
 
-// Facet with equality on a record — equality should be ignored since records already have it
+// Facet with equality on a record ï¿½ equality should be ignored since records already have it
 [Facet(typeof(PersonForCopyAndEquality), GenerateEquality = true)]
 public partial record PersonRecordWithEquality;
 

--- a/test/Facet.Tests/UnitTests/Core/Facet/StaticMemberExclusionTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/StaticMemberExclusionTests.cs
@@ -1,0 +1,32 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// Tests that static properties, const fields, and static readonly fields
+/// are excluded from generated facets (issue #300).
+/// </summary>
+public class StaticMemberExclusionTests
+{
+    [Fact]
+    public void Facet_ShouldNotIncludeStaticProperties()
+    {
+        var dtoType = typeof(StaticMemberTestDto);
+        dtoType.GetProperty("AStaticProperty").Should().BeNull("static properties should not be in the facet");
+    }
+
+    [Fact]
+    public void Facet_ShouldIncludeInstanceProperties()
+    {
+        var dtoType = typeof(StaticMemberTestDto);
+        dtoType.GetProperty("AProperty").Should().NotBeNull("instance properties should be in the facet");
+    }
+
+    [Fact]
+    public void Facet_ShouldMapInstancePropertiesCorrectly()
+    {
+        var source = new EntityWithStaticMembers { AProperty = "Hello" };
+        var dto = source.ToFacet<EntityWithStaticMembers, StaticMemberTestDto>();
+        dto.AProperty.Should().Be("Hello");
+    }
+}


### PR DESCRIPTION
Fixes #300 

﻿Root cause: `GetAllMembersWithModifiers()` filtered members by Public accessibility but didn't exclude static members. Static properties, const fields, and static readonly fields from the source type were being included in the generated facet, causing compile errors.

Fix: Added !member.IsStatic filter
