### PR TITLE
fix: ToSource in Nested Facets

### DIFF
--- a/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
@@ -421,8 +421,11 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // Nested types in C# have access to all members of their containing type, including private
+        var isNestedInSource = IsNestedInsideType(targetType, sourceType);
+
         // For non-positional types, we need a parameterless constructor and accessible setters
-        var hasAccessibleConstructor = HasAccessibleParameterlessConstructor(sourceType, context.Compilation.Assembly);
+        var hasAccessibleConstructor = HasAccessibleParameterlessConstructor(sourceType, context.Compilation.Assembly, isNestedInSource);
 
         if (!hasAccessibleConstructor)
         {
@@ -441,7 +444,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
                            namedArgs.IncludeFields.Value.Value is bool includeFieldsValue &&
                            includeFieldsValue;
 
-        var inaccessibleProperties = GetInaccessibleSetterProperties(sourceType, excluded, included, isIncludeMode, includeFields);
+        var inaccessibleProperties = GetInaccessibleSetterProperties(sourceType, excluded, included, isIncludeMode, includeFields, isNestedInSource);
 
         if (inaccessibleProperties.Count > 0)
         {
@@ -520,7 +523,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool HasAccessibleParameterlessConstructor(INamedTypeSymbol sourceType, IAssemblySymbol? compilationAssembly = null)
+    private static bool HasAccessibleParameterlessConstructor(INamedTypeSymbol sourceType, IAssemblySymbol? compilationAssembly = null, bool isNestedInSourceType = false)
     {
         var constructors = sourceType.InstanceConstructors;
 
@@ -531,6 +534,10 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
             if (constructor.Parameters.Length == 0)
             {
                 if (constructor.DeclaredAccessibility == Accessibility.Public)
+                    return true;
+
+                // Nested types have access to all members of their containing type, including private
+                if (isNestedInSourceType)
                     return true;
 
                 // Internal constructors are accessible when the source type is in the same assembly
@@ -551,9 +558,15 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         HashSet<string> excluded,
         HashSet<string> included,
         bool isIncludeMode,
-        bool includeFields)
+        bool includeFields,
+        bool isNestedInSourceType = false)
     {
         var inaccessibleProperties = new List<string>();
+
+        // Nested types have access to all members of their containing type
+        if (isNestedInSourceType)
+            return inaccessibleProperties;
+
         var members = GetAllPublicMembers(sourceType);
 
         foreach (var member in members)
@@ -635,6 +648,22 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
     {
         return type.GetAttributes().Any(attr =>
             attr.AttributeClass?.ToDisplayString() == "Facet.FacetAttribute");
+    }
+
+    /// <summary>
+    /// Checks if the target type is nested inside the source type (at any depth).
+    /// Nested types in C# have access to all members of their containing type, including private ones.
+    /// </summary>
+    private static bool IsNestedInsideType(INamedTypeSymbol innerType, INamedTypeSymbol outerType)
+    {
+        var current = innerType.ContainingType;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, outerType))
+                return true;
+            current = current.ContainingType;
+        }
+        return false;
     }
 
     private static bool ImplementsConfigurationInterface(INamedTypeSymbol configurationType, INamedTypeSymbol sourceType, INamedTypeSymbol targetType)

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -165,9 +165,12 @@ internal static class ModelBuilder
         // skip ToSource generation to avoid compilation errors
         if (generateToSource && !hasPositionalConstructor)
         {
+            // Nested types in C# have access to all members of their containing type, including private
+            var isNestedInSource = TypeAnalyzer.IsNestedInsideType(targetSymbol, sourceType);
+
             // For non-positional types, we need a parameterless constructor and accessible setters
-            var hasAccessibleConstructor = TypeAnalyzer.HasAccessibleParameterlessConstructor(sourceType, context.SemanticModel.Compilation.Assembly);
-            var hasAccessibleSetters = TypeAnalyzer.AllPropertiesHaveAccessibleSetters(sourceType, members);
+            var hasAccessibleConstructor = TypeAnalyzer.HasAccessibleParameterlessConstructor(sourceType, context.SemanticModel.Compilation.Assembly, isNestedInSource);
+            var hasAccessibleSetters = TypeAnalyzer.AllPropertiesHaveAccessibleSetters(sourceType, members, isNestedInSource);
 
             if (!hasAccessibleConstructor || !hasAccessibleSetters)
             {

--- a/src/Facet/Generators/FacetGenerators/TypeAnalyzer.cs
+++ b/src/Facet/Generators/FacetGenerators/TypeAnalyzer.cs
@@ -125,9 +125,10 @@ internal static class TypeAnalyzer
 
     /// <summary>
     /// Checks if the source type has an accessible parameterless constructor.
-    /// For ToSource generation, we need a public or internal parameterless constructor.
+    /// For ToSource generation, we need a public or internal parameterless constructor,
+    /// or any parameterless constructor if the facet is nested inside the source type.
     /// </summary>
-    public static bool HasAccessibleParameterlessConstructor(INamedTypeSymbol sourceType, IAssemblySymbol? compilationAssembly = null)
+    public static bool HasAccessibleParameterlessConstructor(INamedTypeSymbol sourceType, IAssemblySymbol? compilationAssembly = null, bool isNestedInSourceType = false)
     {
         // Check for implicit parameterless constructor (when no constructors are defined)
         var constructors = sourceType.InstanceConstructors;
@@ -143,6 +144,10 @@ internal static class TypeAnalyzer
             {
                 // Public constructors are always accessible
                 if (constructor.DeclaredAccessibility == Accessibility.Public)
+                    return true;
+
+                // Nested types have access to all members of their containing type, including private
+                if (isNestedInSourceType)
                     return true;
 
                 // Internal constructors are accessible when the source type is in the same assembly
@@ -161,11 +166,13 @@ internal static class TypeAnalyzer
 
     /// <summary>
     /// Checks if all the specified properties have accessible setters.
-    /// For ToSource generation using object initializer syntax, we need public or internal setters.
+    /// For ToSource generation using object initializer syntax, we need public or internal setters,
+    /// or any setters if the facet is nested inside the source type.
     /// </summary>
     public static bool AllPropertiesHaveAccessibleSetters(
         INamedTypeSymbol sourceType,
-        IEnumerable<FacetMember> members)
+        IEnumerable<FacetMember> members,
+        bool isNestedInSourceType = false)
     {
         foreach (var member in members)
         {
@@ -185,6 +192,10 @@ internal static class TypeAnalyzer
             if (sourceProperty.SetMethod == null)
                 return false; // No setter at all
 
+            // Nested types have access to all members of their containing type
+            if (isNestedInSourceType)
+                continue;
+
             // Check setter accessibility
             var setterAccessibility = sourceProperty.SetMethod.DeclaredAccessibility;
             if (setterAccessibility != Accessibility.Public &&
@@ -195,5 +206,21 @@ internal static class TypeAnalyzer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Checks if the target type is nested inside the source type (at any depth).
+    /// Nested types in C# have access to all members of their containing type, including private ones.
+    /// </summary>
+    public static bool IsNestedInsideType(INamedTypeSymbol innerType, INamedTypeSymbol outerType)
+    {
+        var current = innerType.ContainingType;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, outerType))
+                return true;
+            current = current.ContainingType;
+        }
+        return false;
     }
 }

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -139,6 +139,40 @@ public class EntityWithStaticMembers
     public static string AStaticProperty => "A";
 }
 
+// DDD-style entity with private constructor and non-public setters (issue #302)
+public partial class DDDSample
+{
+    private DDDSample() { }
+
+    public static DDDSample Create(string aProperty, string aPrivateSetterProperty, string aInternalSetterProperty)
+    {
+        return new DDDSample
+        {
+            AProperty = aProperty,
+            APrivateSetterProperty = aPrivateSetterProperty,
+            AInternalSetterProperty = aInternalSetterProperty
+        };
+    }
+
+    public string AProperty { get; set; } = default!;
+    public string APrivateSetterProperty { get; private set; } = default!;
+    public string AInternalSetterProperty { get; internal set; } = default!;
+
+    // Nested facets should have access to private constructor and private setters
+    [Facet(typeof(DDDSample), GenerateToSource = true)]
+    public partial record InsideFacetRecord;
+
+    [Facet(typeof(DDDSample), GenerateToSource = true)]
+    public partial class InsideFacetClass;
+}
+
+// Outside facets cannot access private constructor, so ToSource cannot be generated
+[Facet(typeof(DDDSample))]
+public partial record OutsideFacetRecord;
+
+[Facet(typeof(DDDSample))]
+public partial class OutsideFacetClass;
+
 // Test entity with non-nullable reference type properties with initializers (GitHub issue)
 public class UserModel
 {

--- a/test/Facet.Tests/UnitTests/Core/Facet/DDDNestedFacetTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/DDDNestedFacetTests.cs
@@ -1,0 +1,83 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// Tests for DDD-style classes with private constructors and non-public setters (issue #302).
+/// Nested facets should have full access to the containing type's private members.
+/// </summary>
+public class DDDNestedFacetTests
+{
+    [Fact]
+    public void NestedRecordFacet_ShouldMapAllProperties()
+    {
+        var source = DDDSample.Create("pub", "priv", "intern");
+        var dto = source.ToFacet<DDDSample, DDDSample.InsideFacetRecord>();
+
+        dto.AProperty.Should().Be("pub");
+        dto.APrivateSetterProperty.Should().Be("priv");
+        dto.AInternalSetterProperty.Should().Be("intern");
+    }
+
+    [Fact]
+    public void NestedClassFacet_ShouldMapAllProperties()
+    {
+        var source = DDDSample.Create("pub", "priv", "intern");
+        var dto = source.ToFacet<DDDSample, DDDSample.InsideFacetClass>();
+
+        dto.AProperty.Should().Be("pub");
+        dto.APrivateSetterProperty.Should().Be("priv");
+        dto.AInternalSetterProperty.Should().Be("intern");
+    }
+
+    [Fact]
+    public void NestedRecordFacet_ShouldGenerateToSource()
+    {
+        // ToSource should be generated because the nested facet can access the private constructor
+        var source = DDDSample.Create("pub", "priv", "intern");
+        var dto = source.ToFacet<DDDSample, DDDSample.InsideFacetRecord>();
+
+        var hasToSource = typeof(DDDSample.InsideFacetRecord).GetMethod("ToSource");
+        hasToSource.Should().NotBeNull("nested facets should have ToSource generated");
+
+        var roundTripped = dto.ToSource();
+        roundTripped.AProperty.Should().Be("pub");
+        roundTripped.APrivateSetterProperty.Should().Be("priv");
+        roundTripped.AInternalSetterProperty.Should().Be("intern");
+    }
+
+    [Fact]
+    public void NestedClassFacet_ShouldGenerateToSource()
+    {
+        var source = DDDSample.Create("pub", "priv", "intern");
+        var dto = source.ToFacet<DDDSample, DDDSample.InsideFacetClass>();
+
+        var hasToSource = typeof(DDDSample.InsideFacetClass).GetMethod("ToSource");
+        hasToSource.Should().NotBeNull("nested facets should have ToSource generated");
+
+        var roundTripped = dto.ToSource();
+        roundTripped.AProperty.Should().Be("pub");
+        roundTripped.APrivateSetterProperty.Should().Be("priv");
+        roundTripped.AInternalSetterProperty.Should().Be("intern");
+    }
+
+    [Fact]
+    public void OutsideFacet_ShouldMapAllProperties()
+    {
+        // Outside facets can still read all public properties
+        var source = DDDSample.Create("pub", "priv", "intern");
+        var dto = source.ToFacet<DDDSample, OutsideFacetRecord>();
+
+        dto.AProperty.Should().Be("pub");
+        dto.APrivateSetterProperty.Should().Be("priv");
+        dto.AInternalSetterProperty.Should().Be("intern");
+    }
+
+    [Fact]
+    public void OutsideFacet_ShouldNotHaveToSource()
+    {
+        // Outside facets cannot access the private constructor, so ToSource is not generated
+        var hasToSource = typeof(OutsideFacetRecord).GetMethod("ToSource");
+        hasToSource.Should().BeNull("outside facets cannot access private constructor for ToSource");
+    }
+}


### PR DESCRIPTION
Fix for #302 

﻿Problem: Facets nested inside their source type (DDD pattern) couldn't generate ToSource because accessibility checks only considered public/internal constructors and setters. In C#, nested types have access to all members of their containing type, including private ones.