### PR TITLE
feat: support InternalsVisibleTo (#310)

### DIFF
--- a/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Facet.Generators;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -444,7 +445,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
                            namedArgs.IncludeFields.Value.Value is bool includeFieldsValue &&
                            includeFieldsValue;
 
-        var inaccessibleProperties = GetInaccessibleSetterProperties(sourceType, excluded, included, isIncludeMode, includeFields, isNestedInSource);
+        var inaccessibleProperties = GetInaccessibleSetterProperties(sourceType, excluded, included, isIncludeMode, includeFields, isNestedInSource, context.Compilation.Assembly);
 
         if (inaccessibleProperties.Count > 0)
         {
@@ -540,10 +541,10 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
                 if (isNestedInSourceType)
                     return true;
 
-                // Internal constructors are accessible when the source type is in the same assembly
+                // Internal constructors are accessible in same assembly or via [InternalsVisibleTo]
                 if (constructor.DeclaredAccessibility == Accessibility.Internal &&
                     compilationAssembly != null &&
-                    SymbolEqualityComparer.Default.Equals(sourceType.ContainingAssembly, compilationAssembly))
+                    TypeAnalyzer.IsInternalAccessible(sourceType.ContainingAssembly, compilationAssembly))
                 {
                     return true;
                 }
@@ -559,7 +560,8 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         HashSet<string> included,
         bool isIncludeMode,
         bool includeFields,
-        bool isNestedInSourceType = false)
+        bool isNestedInSourceType = false,
+        IAssemblySymbol? compilationAssembly = null)
     {
         var inaccessibleProperties = new List<string>();
 
@@ -599,11 +601,18 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
 
                 // Check setter accessibility
                 var setterAccessibility = property.SetMethod.DeclaredAccessibility;
-                if (setterAccessibility != Accessibility.Public &&
-                    setterAccessibility != Accessibility.Internal)
+                if (setterAccessibility == Accessibility.Public)
+                    continue;
+
+                // Internal setters are accessible in same assembly or via [InternalsVisibleTo]
+                if (setterAccessibility == Accessibility.Internal &&
+                    compilationAssembly != null &&
+                    TypeAnalyzer.IsInternalAccessible(sourceType.ContainingAssembly, compilationAssembly))
                 {
-                    inaccessibleProperties.Add(property.Name);
+                    continue;
                 }
+
+                inaccessibleProperties.Add(property.Name);
             }
         }
 

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -174,7 +174,7 @@ internal static class ModelBuilder
 
             // For non-positional types, we need a parameterless constructor and accessible setters
             var hasAccessibleConstructor = TypeAnalyzer.HasAccessibleParameterlessConstructor(sourceType, context.SemanticModel.Compilation.Assembly, isNestedInSource);
-            var hasAccessibleSetters = TypeAnalyzer.AllPropertiesHaveAccessibleSetters(sourceType, members, isNestedInSource);
+            var hasAccessibleSetters = TypeAnalyzer.AllPropertiesHaveAccessibleSetters(sourceType, members, isNestedInSource, context.SemanticModel.Compilation.Assembly);
 
             if (!hasAccessibleConstructor || !hasAccessibleSetters)
             {

--- a/src/Facet/Generators/FacetGenerators/TypeAnalyzer.cs
+++ b/src/Facet/Generators/FacetGenerators/TypeAnalyzer.cs
@@ -151,10 +151,11 @@ internal static class TypeAnalyzer
                     return true;
 
                 // Internal constructors are accessible when the source type is in the same assembly
-                // as the generated code (which is always the case for types in the user's project)
+                // as the generated code (which is always the case for types in the user's project),
+                // or when the source assembly grants access via [InternalsVisibleTo]
                 if (constructor.DeclaredAccessibility == Accessibility.Internal &&
                     compilationAssembly != null &&
-                    SymbolEqualityComparer.Default.Equals(sourceType.ContainingAssembly, compilationAssembly))
+                    IsInternalAccessible(sourceType.ContainingAssembly, compilationAssembly))
                 {
                     return true;
                 }
@@ -172,7 +173,8 @@ internal static class TypeAnalyzer
     public static bool AllPropertiesHaveAccessibleSetters(
         INamedTypeSymbol sourceType,
         IEnumerable<FacetMember> members,
-        bool isNestedInSourceType = false)
+        bool isNestedInSourceType = false,
+        IAssemblySymbol? compilationAssembly = null)
     {
         foreach (var member in members)
         {
@@ -198,11 +200,18 @@ internal static class TypeAnalyzer
 
             // Check setter accessibility
             var setterAccessibility = sourceProperty.SetMethod.DeclaredAccessibility;
-            if (setterAccessibility != Accessibility.Public &&
-                setterAccessibility != Accessibility.Internal)
+            if (setterAccessibility == Accessibility.Public)
+                continue;
+
+            // Internal setters are accessible in same assembly or via [InternalsVisibleTo]
+            if (setterAccessibility == Accessibility.Internal &&
+                compilationAssembly != null &&
+                IsInternalAccessible(sourceType.ContainingAssembly, compilationAssembly))
             {
-                return false; // Setter is private, protected, or otherwise inaccessible
+                continue;
             }
+
+            return false; // Setter is private, protected, or otherwise inaccessible
         }
 
         return true;
@@ -221,6 +230,38 @@ internal static class TypeAnalyzer
                 return true;
             current = current.ContainingType;
         }
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if internal members of the source assembly are accessible from the compilation assembly.
+    /// This is true when both assemblies are the same, or when the source assembly has an
+    /// [InternalsVisibleTo] attribute that references the compilation assembly.
+    /// </summary>
+    public static bool IsInternalAccessible(IAssemblySymbol sourceAssembly, IAssemblySymbol compilationAssembly)
+    {
+        // Same assembly — always accessible
+        if (SymbolEqualityComparer.Default.Equals(sourceAssembly, compilationAssembly))
+            return true;
+
+        // Check [InternalsVisibleTo] on the source assembly
+        var compilationAssemblyName = compilationAssembly.Name;
+        foreach (var attr in sourceAssembly.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == "InternalsVisibleToAttribute" &&
+                attr.AttributeClass.ContainingNamespace?.ToDisplayString() == "System.Runtime.CompilerServices" &&
+                attr.ConstructorArguments.Length > 0 &&
+                attr.ConstructorArguments[0].Value is string assemblyName)
+            {
+                // Handle assembly names with public key tokens (e.g. "MyAssembly, PublicKey=...")
+                var commaIndex = assemblyName.IndexOf(',');
+                var name = commaIndex >= 0 ? assemblyName.Substring(0, commaIndex).Trim() : assemblyName.Trim();
+
+                if (name == compilationAssemblyName)
+                    return true;
+            }
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
When a source type's assembly has `[InternalsVisibleTo]` pointing to the facet's assembly, internal constructors and internal property setters are now recognized as accessible. This enables `ToSource` generation for facets declared in a different assembly that has been given internal access.

Closes #310