### PR TITLE
fix: CS0108 warning when a Facet inherits from another Facet

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -58,6 +58,13 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     /// </summary>
     public string? ToSourceConfigurationTypeName { get; }
 
+    /// <summary>
+    /// When true, the base class of this facet already declares one or more of the generated
+    /// members (<c>FromSource</c>, <c>ToSource</c>, <c>Projection</c>, <c>BackTo</c>).
+    /// The <c>new</c> modifier will be emitted on those members to suppress CS0108.
+    /// </summary>
+    public bool BaseHidesFacetMembers { get; }
+
     public FacetTargetModel(
         string name,
         string? @namespace,
@@ -91,7 +98,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         string? convertEnumsTo = null,
         bool generateCopyConstructor = false,
         bool generateEquality = false,
-        string? toSourceConfigurationTypeName = null)
+        string? toSourceConfigurationTypeName = null,
+        bool baseHidesFacetMembers = false)
     {
         Name = name;
         Namespace = @namespace;
@@ -126,6 +134,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         GenerateCopyConstructor = generateCopyConstructor;
         GenerateEquality = generateEquality;
         ToSourceConfigurationTypeName = toSourceConfigurationTypeName;
+        BaseHidesFacetMembers = baseHidesFacetMembers;
     }
 
     public bool Equals(FacetTargetModel? other)
@@ -164,7 +173,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && ConvertEnumsTo == other.ConvertEnumsTo
             && GenerateCopyConstructor == other.GenerateCopyConstructor
             && GenerateEquality == other.GenerateEquality
-            && ToSourceConfigurationTypeName == other.ToSourceConfigurationTypeName;
+            && ToSourceConfigurationTypeName == other.ToSourceConfigurationTypeName
+            && BaseHidesFacetMembers == other.BaseHidesFacetMembers;
     }
 
     public override bool Equals(object? obj) => obj is FacetTargetModel other && Equals(other);
@@ -200,6 +210,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + GenerateCopyConstructor.GetHashCode();
             hash = hash * 31 + GenerateEquality.GetHashCode();
             hash = hash * 31 + (ToSourceConfigurationTypeName?.GetHashCode() ?? 0);
+            hash = hash * 31 + BaseHidesFacetMembers.GetHashCode();
             hash = hash * 31 + Members.Length.GetHashCode();
 
             foreach (var member in Members)

--- a/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
@@ -364,7 +364,7 @@ internal static class ConstructorGenerator
         sb.AppendLine("    /// This static factory method provides optimal performance for runtime mapping by allowing");
         sb.AppendLine("    /// direct delegate creation instead of expression compilation.");
         sb.AppendLine("    /// </remarks>");
-        sb.AppendLine($"    public static {model.Name} FromSource({model.SourceTypeName} source)");
+        sb.AppendLine($"    public static {(model.BaseHidesFacetMembers ? "new " : "")}{model.Name} FromSource({model.SourceTypeName} source)");
         sb.AppendLine("    {");
 
         if (needsDepthTracking)
@@ -413,7 +413,7 @@ internal static class ConstructorGenerator
         sb.AppendLine($"    /// for the primary constructor parameters when creating instances.");
         sb.AppendLine($"    /// Example: new {model.Name}(primaryConstructorParam) {{ PropA = source.PropA, PropB = source.PropB }}");
         sb.AppendLine($"    /// </summary>");
-        sb.AppendLine($"    public static {model.Name} FromSource({model.SourceTypeName} source, params object[] primaryConstructorArgs)");
+        sb.AppendLine($"    public static {(model.BaseHidesFacetMembers ? "new " : "")}{model.Name} FromSource({model.SourceTypeName} source, params object[] primaryConstructorArgs)");
         sb.AppendLine("    {");
 
         if (hasCustomMapping)

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -190,6 +190,9 @@ internal static class ModelBuilder
         // Extract FlattenTo types for generating collection flattening methods
         var flattenToTypes = AttributeParser.ExtractFlattenToTypes(attribute);
 
+        // Check if the base class already declares any of the generated members
+        var baseHidesFacetMembers = BaseHidesFacetMembers(targetSymbol);
+
         return new FacetTargetModel(
             targetSymbol.Name,
             ns,
@@ -223,7 +226,8 @@ internal static class ModelBuilder
             convertEnumsTo,
             generateCopyConstructor,
             generateEquality,
-            toSourceConfigurationTypeName);
+            toSourceConfigurationTypeName,
+            baseHidesFacetMembers);
     }
 
     #region Private Helper Methods
@@ -869,6 +873,35 @@ private static Dictionary<string, (string targetName, string source, bool revers
         }
 
         return memberNames.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Returns true when any base class of the target type declares a member whose name matches
+    /// one of the members Facet generates (FromSource, ToSource, BackTo, Projection).
+    /// When true, the 'new' modifier must be emitted on those members to suppress CS0108.
+    /// </summary>
+    private static bool BaseHidesFacetMembers(INamedTypeSymbol targetSymbol)
+    {
+        var generatedMemberNames = new System.Collections.Generic.HashSet<string>
+        {
+            "FromSource", "ToSource", "BackTo", "Projection"
+        };
+
+        var baseType = targetSymbol.BaseType;
+        while (baseType != null && baseType.SpecialType != SpecialType.System_Object)
+        {
+            foreach (var member in baseType.GetMembers())
+            {
+                if (generatedMemberNames.Contains(member.Name) &&
+                    member.DeclaredAccessibility == Accessibility.Public)
+                {
+                    return true;
+                }
+            }
+            baseType = baseType.BaseType;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -28,7 +28,7 @@ internal static class ProjectionGenerator
         else
         {
             GenerateProjectionDocumentation(sb, model, memberIndent);
-            sb.AppendLine($"{memberIndent}public static Expression<Func<{model.SourceTypeName}, {model.Name}>> Projection =>");
+            sb.AppendLine($"{memberIndent}public static {(model.BaseHidesFacetMembers ? "new " : "")}Expression<Func<{model.SourceTypeName}, {model.Name}>> Projection =>");
 
             // Generate object initializer projection for EF Core compatibility
             GenerateProjectionExpression(sb, model, memberIndent, facetLookup);

--- a/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
@@ -21,7 +21,7 @@ internal static class ToSourceGenerator
         sb.AppendLine($"    /// Converts this instance of <see cref=\"{model.Name}\"/> to an instance of the source type.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine($"    /// <returns>An instance of the source type with properties mapped from this instance.</returns>");
-        sb.AppendLine($"    public {model.SourceTypeName} ToSource()");
+        sb.AppendLine($"    public {(model.BaseHidesFacetMembers ? "new " : "")}{model.SourceTypeName} ToSource()");
         sb.AppendLine("    {");
 
         if (model.SourceHasPositionalConstructor)
@@ -42,7 +42,7 @@ internal static class ToSourceGenerator
         sb.AppendLine("    /// </summary>");
         sb.AppendLine($"    /// <returns>An instance of the source type with properties mapped from this instance.</returns>");
         sb.AppendLine("    [global::System.Obsolete(\"Use ToSource() instead. This method will be removed in a future version.\")]");
-        sb.AppendLine($"    public {model.SourceTypeName} BackTo() => ToSource();");
+        sb.AppendLine($"    public {(model.BaseHidesFacetMembers ? "new " : "")}{model.SourceTypeName} BackTo() => ToSource();");
     }
 
     private static void GeneratePositionalToSource(StringBuilder sb, FacetTargetModel model)

--- a/test/Facet.Tests/UnitTests/Core/Facet/InheritedMemberTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/InheritedMemberTests.cs
@@ -69,6 +69,27 @@ public partial class SettingFacetDto : ModifiedByBaseDto;
 [Facet(typeof(SettingEntity), GenerateToSource = true)]
 public partial class SettingFacetExcludeDto : ModifiedByBaseDto;
 
+// Facet inheriting from another Facet, verifies 'new' keyword on
+// FromSource / ToSource / Projection / BackTo to suppress CS0108.
+public class BaseValidationEntity
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = "";
+}
+
+public class DerivedValidationEntity : BaseValidationEntity
+{
+    public string Description { get; set; } = "";
+}
+
+// Base facet — generates FromSource, ToSource, Projection
+[Facet(typeof(BaseValidationEntity), GenerateToSource = true)]
+public partial class BaseValidationFacet;
+
+// Derived facet inherits the base facet — without 'new' this would be CS0108
+[Facet(typeof(DerivedValidationEntity), GenerateToSource = true)]
+public partial class DerivedValidationFacet : BaseValidationFacet;
+
 public class InheritedMemberTests
 {
     [Fact]
@@ -238,5 +259,57 @@ public class InheritedMemberTests
         facet.ApplicationType.Should().Be("Web");
         facet.Settings.Should().Be("{}");
         facet.UserId.Should().Be("user-1");
+    }
+
+    // -----------------------------------------------------------------------
+    // new keyword tests — if the 'new' modifier is missing the project would
+    // not compile (CS0108 is an error in strict pipelines), so a successful
+    // build already proves the fix. These tests also verify runtime behaviour.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void DerivedFacet_Constructor_ShouldMapAllProperties()
+    {
+        // Arrange
+        var entity = new DerivedValidationEntity { Id = 5, Code = "XYZ", Description = "desc" };
+
+        // Act — uses the generated constructor on the derived facet
+        var facet = new DerivedValidationFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(5);
+        facet.Code.Should().Be("XYZ");
+        facet.Description.Should().Be("desc");
+    }
+
+    [Fact]
+    public void DerivedFacet_ToSource_ShouldRoundTrip()
+    {
+        // Arrange
+        var entity = new DerivedValidationEntity { Id = 7, Code = "ABC", Description = "hello" };
+        var facet = new DerivedValidationFacet(entity);
+
+        // Act — calls the 'new' ToSource on the derived facet
+        var result = facet.ToSource();
+
+        // Assert
+        result.Id.Should().Be(7);
+        result.Code.Should().Be("ABC");
+        result.Description.Should().Be("hello");
+    }
+
+    [Fact]
+    public void DerivedFacet_FromSource_ShouldReturnDerivedInstance()
+    {
+        // Arrange
+        var entity = new DerivedValidationEntity { Id = 3, Code = "DEF", Description = "world" };
+
+        // Act — calls the 'new' static FromSource on the derived facet
+        var facet = DerivedValidationFacet.FromSource(entity);
+
+        // Assert
+        facet.Should().BeOfType<DerivedValidationFacet>();
+        facet.Id.Should().Be(3);
+        facet.Description.Should().Be("world");
     }
 }


### PR DESCRIPTION
When a derived facet's base class already has `FromSource`, `ToSource`, `BackTo`, or Projection (i.e. the base is also a Facet-generated type), the generator now emits the `new` modifier on those members.

Closes #312 