### PR TITLE
feat: Collection Type Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Instead of manually creating each facet, **Facet** auto-generates them from a si
 - **`[MapWhen]`** - conditional mapping based on runtime values, works in SQL projections
 - **Before/After hooks** - inject validation, defaults, or computed values around auto-mapping
 - **`ConvertEnumsTo`** - convert all enums to `string` or `int` with full round-trip support
+- **`CollectionTargetType`** - remap source collection types (e.g. `Collection<T>`) to `List<T>` or any target collection type globally per facet; per-property via `[MapFrom(..., AsCollection = typeof(List<>))]`
 - **`GenerateCopyConstructor`** - generate a copy constructor for cloning and MVVM scenarios
 - **`GenerateEquality`** - generate value-based `Equals`, `GetHashCode`, `==`, `!=` for class DTOs
 
@@ -208,7 +209,7 @@ Create focused facets for different scenarios:
   public partial record UserDetailDto;
   // Multi-level nesting supported
 
-  // 7. Collections - Automatic collection mapping
+  // 7. Collections - Automatic collection mapping, with type override support
   [Facet(typeof(Project))]
   public partial record ProjectDto;
 
@@ -217,7 +218,15 @@ Create focused facets for different scenarios:
       NestedFacets = [typeof(ProjectDto)])]
   public partial record UserWithProjectsDto;
   // List<Project> -> List<ProjectDto> automatically!
-  // Arrays, ICollection<T>, IEnumerable<T> all supported
+  // Arrays, ICollection<T>, IEnumerable<T>, Collection<T> all supported
+
+  // 7b. Collection type override - remap Collection<T> (EF Core) to List<T> in DTOs
+  [Facet(typeof(User),
+      NestedFacets = [typeof(ProjectDto)],
+      CollectionTargetType = typeof(List<>))]
+  public partial record UserListDto;
+  // Collection<Project> on entity -> List<ProjectDto> in DTO
+  // ToSource() restores the original Collection<T> automatically
 
   // 8. Everything Combined
   [Facet(typeof(User),

--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -41,6 +41,7 @@ public partial class MyFacet { }
 | `PreserveReferences`           | `bool`    | Enable runtime circular reference detection using object tracking (default: true). See [Circular Reference Protection](#circular-reference-protection) below. |
 | `SourceSignature`              | `string?` | Hash signature to track source entity changes. Emits FAC022 warning when source structure changes. See [Source Signature Change Tracking](16_SourceSignature.md). |
 | `ConvertEnumsTo`               | `Type?`   | When set, all enum properties are converted to the specified type (`typeof(string)` or `typeof(int)`) in the generated facet. Default is null (enums retain their original types). See [Enum Conversion](20_ConvertEnumsTo.md). |
+| `CollectionTargetType`         | `Type?`   | Overrides the collection type used for **all** mapped collection properties on this facet. Use an open generic type such as `typeof(List<>)` to remap source collections (e.g. `Collection<T>` from EF Core entities) to a different target type. See [Collection Type Mapping](#collection-type-mapping) below. |
 | `GenerateCopyConstructor`      | `bool`    | Generate a copy constructor that accepts another instance of the same facet type and copies all member values (default: false). See [Copy Constructor](#copy-constructor) below. |
 | `GenerateEquality`             | `bool`    | Generate value-based equality members (`Equals`, `GetHashCode`, `==`, `!=`) and implement `IEquatable<T>` (default: false). Ignored for records. See [Equality Generation](#equality-generation) below. |
 
@@ -707,6 +708,73 @@ public partial class UserDto : System.IEquatable<UserDto>
 
 - **Records**: Records already have value-based equality � `GenerateEquality` is automatically ignored
 - **Reference equality needed**: If you need identity-based comparison, don't enable this
+
+---
+
+## Collection Type Mapping
+
+By default, Facet preserves the source collection type when mapping nested facet collections. For example, if an EF Core entity uses `Collection<T>`, the generated facet property will also use `Collection<T>`. Use `CollectionTargetType` to override this for all collection properties on a facet.
+
+### Supported Types
+
+Any open generic collection type is accepted:
+
+| `CollectionTargetType`            | Generated property type        | Materialized via           |
+|-----------------------------------|-------------------------------|---------------------------|
+| `typeof(List<>)`                  | `List<TFacet>`                | `.ToList()`               |
+| `typeof(IList<>)`                 | `IList<TFacet>`               | `.ToList()`               |
+| `typeof(ICollection<>)`           | `ICollection<TFacet>`         | `.ToList()`               |
+| `typeof(IEnumerable<>)`           | `IEnumerable<TFacet>`         | lazy (no materialization) |
+| `typeof(IReadOnlyList<>)`         | `IReadOnlyList<TFacet>`       | `.ToList()`               |
+| `typeof(IReadOnlyCollection<>)`   | `IReadOnlyCollection<TFacet>` | `.ToList()`               |
+| `typeof(Collection<>)`            | `Collection<TFacet>`          | `new Collection<>(…)`     |
+
+### Facet-Level Override
+
+Remap all `Collection<T>` (or any source collection type) to `List<T>`:
+
+```csharp
+public class UnitEntity
+{
+    public int Id { get; set; }
+    public Collection<UnitItemEntity> Items { get; set; } = new();
+}
+
+[Facet(typeof(UnitEntity),
+    NestedFacets = [typeof(UnitItemDto)],
+    CollectionTargetType = typeof(List<>))]
+public partial class UnitDto { }
+
+// Generated: public List<UnitItemDto> Items { get; set; }
+```
+
+### Per-Property Override with `[MapFrom]`
+
+Use `AsCollection` on `[MapFrom]` to override a single property:
+
+```csharp
+[Facet(typeof(UnitEntity), NestedFacets = [typeof(UnitItemDto)])]
+public partial class UnitDto
+{
+    [MapFrom(nameof(UnitEntity.Items), AsCollection = typeof(List<>))]
+    public List<UnitItemDto> Items { get; set; } = new();
+}
+```
+
+### Round-Trip Support
+
+When `GenerateToSource = true`, `ToSource()` restores the **original source collection type** even when the facet uses a different type:
+
+```csharp
+[Facet(typeof(UnitEntity),
+    NestedFacets = [typeof(UnitItemDto)],
+    CollectionTargetType = typeof(List<>),
+    GenerateToSource = true)]
+public partial class UnitDto { }
+
+// facet.Items is List<UnitItemDto>
+// facet.ToSource().Items is Collection<UnitItemEntity> , original source type restored
+```
 
 ---
 

--- a/docs/15_MapFromAttribute.md
+++ b/docs/15_MapFromAttribute.md
@@ -121,6 +121,29 @@ Use `IncludeInProjection = false` for:
 - Properties requiring client-side evaluation
 - Complex expressions that EF Core doesn't support
 
+### AsCollection
+
+Overrides the collection type for a single mapped collection property. Accepts an open generic type such as `typeof(List<>)`. This is useful when the source uses `Collection<T>` (common in EF Core entities) but you want a `List<T>` in your DTO, without applying the override globally to all collection properties.
+
+```csharp
+public class UnitEntity
+{
+    public int Id { get; set; }
+    public Collection<UnitItemEntity> Items { get; set; } = new();
+    public Collection<UnitItemEntity> ArchivedItems { get; set; } = new();
+}
+
+[Facet(typeof(UnitEntity), NestedFacets = [typeof(UnitItemDto)])]
+public partial class UnitDto
+{
+    // Only Items is remapped to List<>; ArchivedItems keeps its source type
+    [MapFrom(nameof(UnitEntity.Items), AsCollection = typeof(List<>))]
+    public List<UnitItemDto> Items { get; set; } = new();
+}
+```
+
+For a facet-wide override of all collection properties, use `CollectionTargetType` on the `[Facet]` attribute instead. See [Collection Type Mapping](03_AttributeReference.md#collection-type-mapping).
+
 ## Examples
 
 ### Simple Property Rename

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -45,6 +45,19 @@ public sealed class FacetAttribute : Attribute
     public bool GenerateParameterlessConstructor { get; set; } = true;
 
     /// <summary>
+    /// Overrides the collection type used for all mapped collection properties on this facet.
+    /// Use an open generic type like <c>typeof(List&lt;&gt;)</c> to remap all source collections
+    /// (e.g., <see cref="System.Collections.ObjectModel.Collection{T}"/>) to a different target type.
+    /// </summary>
+    /// <remarks>
+    /// Supported types: <c>typeof(List&lt;&gt;)</c>, <c>typeof(IList&lt;&gt;)</c>,
+    /// <c>typeof(ICollection&lt;&gt;)</c>, <c>typeof(IEnumerable&lt;&gt;)</c>,
+    /// <c>typeof(IReadOnlyList&lt;&gt;)</c>, <c>typeof(IReadOnlyCollection&lt;&gt;)</c>,
+    /// <c>typeof(Collection&lt;&gt;)</c>.
+    /// </remarks>
+    public Type? CollectionTargetType { get; set; }
+
+    /// <summary>
     /// Optional type that provides custom reverse-mapping logic when converting the facet type back
     /// to the source type via <c>ToSource()</c>.
     /// Must implement <c>IFacetToSourceConfiguration&lt;TFacet, TSource&gt;</c> with a static

--- a/src/Facet.Attributes/MapFromAttribute.cs
+++ b/src/Facet.Attributes/MapFromAttribute.cs
@@ -104,6 +104,13 @@ public sealed class MapFromAttribute : Attribute
     public bool IncludeInProjection { get; set; } = true;
 
     /// <summary>
+    /// Overrides the collection type for this specific property.
+    /// Use an open generic type like <c>typeof(List&lt;&gt;)</c>.
+    /// When specified, the generated mapping expression will materialize to this collection type.
+    /// </summary>
+    public Type? AsCollection { get; set; }
+
+    /// <summary>
     /// Creates a new MapFromAttribute that maps from the specified source property or expression.
     /// </summary>
     /// <param name="source">The source property name or expression to map from.</param>

--- a/src/Facet/FacetMember.cs
+++ b/src/Facet/FacetMember.cs
@@ -20,6 +20,12 @@ internal sealed class FacetMember : IEquatable<FacetMember>
     public IReadOnlyList<string> AttributeNamespaces { get; }
     public bool IsCollection { get; }
     public string? CollectionWrapper { get; }
+    /// <summary>
+    /// The original source collection wrapper before any <c>CollectionTargetType</c> or <c>AsCollection</c>
+    /// override was applied. Used by <c>ToSource()</c> to produce the correct source collection type.
+    /// Null when no override was applied (in which case <see cref="CollectionWrapper"/> is used).
+    /// </summary>
+    public string? SourceCollectionWrapper { get; }
     public string? SourceMemberTypeName { get; }
     public bool IsNestedType { get; }
 
@@ -68,6 +74,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         IReadOnlyList<string>? attributes = null,
         bool isCollection = false,
         string? collectionWrapper = null,
+        string? sourceCollectionWrapper = null,
         string? sourceMemberTypeName = null,
         string? mapFromSource = null,
         bool mapFromReversible = false,
@@ -98,6 +105,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         AttributeNamespaces = attributeNamespaces ?? Array.Empty<string>();
         IsCollection = isCollection;
         CollectionWrapper = collectionWrapper;
+        SourceCollectionWrapper = sourceCollectionWrapper;
         SourceMemberTypeName = sourceMemberTypeName;
         MapFromSource = mapFromSource;
         MapFromReversible = mapFromReversible;
@@ -127,6 +135,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         NestedFacetSourceTypeName == other.NestedFacetSourceTypeName &&
         IsCollection == other.IsCollection &&
         CollectionWrapper == other.CollectionWrapper &&
+        SourceCollectionWrapper == other.SourceCollectionWrapper &&
         SourceMemberTypeName == other.SourceMemberTypeName &&
         MapFromSource == other.MapFromSource &&
         MapFromReversible == other.MapFromReversible &&
@@ -162,6 +171,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
             hash = hash * 31 + (NestedFacetSourceTypeName?.GetHashCode() ?? 0);
             hash = hash * 31 + IsCollection.GetHashCode();
             hash = hash * 31 + (CollectionWrapper?.GetHashCode() ?? 0);
+            hash = hash * 31 + (SourceCollectionWrapper?.GetHashCode() ?? 0);
             hash = hash * 31 + (SourceMemberTypeName?.GetHashCode() ?? 0);
             hash = hash * 31 + (MapFromSource?.GetHashCode() ?? 0);
             hash = hash * 31 + MapFromReversible.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/AttributeParser.cs
+++ b/src/Facet/Generators/FacetGenerators/AttributeParser.cs
@@ -236,6 +236,52 @@ internal static class AttributeParser
     }
 
     /// <summary>
+    /// Extracts the CollectionTargetType from the FacetAttribute and converts it to a collection wrapper constant string.
+    /// Returns null if not specified.
+    /// </summary>
+    public static string? ExtractCollectionTargetType(AttributeData attribute)
+    {
+        var arg = attribute.NamedArguments
+            .FirstOrDefault(kvp => kvp.Key == FacetConstants.AttributeNames.CollectionTargetType);
+
+        if (arg.Value.Value is INamedTypeSymbol typeSymbol)
+            return TypeToCollectionWrapper(typeSymbol);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the AsCollection type from a MapFromAttribute and converts it to a collection wrapper constant string.
+    /// Returns null if not specified.
+    /// </summary>
+    public static string? ExtractAsCollection(AttributeData attribute)
+    {
+        var arg = attribute.NamedArguments
+            .FirstOrDefault(kvp => kvp.Key == FacetConstants.AttributeNames.AsCollection);
+
+        if (arg.Value.Value is INamedTypeSymbol typeSymbol)
+            return TypeToCollectionWrapper(typeSymbol);
+
+        return null;
+    }
+
+    public static string? TypeToCollectionWrapper(INamedTypeSymbol typeSymbol)
+    {
+        var displayName = typeSymbol.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return displayName switch
+        {
+            "global::System.Collections.Generic.List<T>" => FacetConstants.CollectionWrappers.List,
+            "global::System.Collections.Generic.IList<T>" => FacetConstants.CollectionWrappers.IList,
+            "global::System.Collections.Generic.ICollection<T>" => FacetConstants.CollectionWrappers.ICollection,
+            "global::System.Collections.Generic.IEnumerable<T>" => FacetConstants.CollectionWrappers.IEnumerable,
+            "global::System.Collections.Generic.IReadOnlyList<T>" => FacetConstants.CollectionWrappers.IReadOnlyList,
+            "global::System.Collections.Generic.IReadOnlyCollection<T>" => FacetConstants.CollectionWrappers.IReadOnlyCollection,
+            "global::System.Collections.ObjectModel.Collection<T>" => FacetConstants.CollectionWrappers.Collection,
+            _ => null
+        };
+    }
+
+    /// <summary>
     /// Extracts the FlattenTo types from the FlattenTo parameter.
     /// Returns a list of fully qualified type names of flatten target types.
     /// </summary>

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -197,7 +197,7 @@ internal static class ExpressionBuilder
                 : $"{sourceCollection}.Select(x => new {elementTypeName}(x, __depth + 1, {updatedProcessed}))";
 
             // Convert back to the appropriate collection type
-            var collectionExpression = WrapCollectionProjection(projection, member.CollectionWrapper!);
+            var collectionExpression = WrapCollectionProjection(projection, member.CollectionWrapper!, elementTypeName);
 
             if (isNullable)
             {
@@ -225,7 +225,7 @@ internal static class ExpressionBuilder
                 : $"{sourceCollection}.Select(x => new {elementTypeName}(x))";
 
             // Convert back to the appropriate collection type
-            var collectionExpression = WrapCollectionProjection(projection, member.CollectionWrapper!);
+            var collectionExpression = WrapCollectionProjection(projection, member.CollectionWrapper!, elementTypeName);
 
             if (isNullable)
             {
@@ -304,8 +304,10 @@ internal static class ExpressionBuilder
         // Use LINQ Select to map each element back
         var projection = $"this.{member.Name}.Select(x => x.ToSource())";
 
-        // Convert back to the appropriate collection type
-        var collectionExpression = WrapCollectionProjection(projection, member.CollectionWrapper!);
+        // Use the original source collection wrapper (before any CollectionTargetType override)
+        // so that the generated expression produces the correct source type.
+        var toSourceWrapper = member.SourceCollectionWrapper ?? member.CollectionWrapper!;
+        var collectionExpression = WrapCollectionProjection(projection, toSourceWrapper, member.NestedFacetSourceTypeName);
 
         // Add null check for nullable collections
         if (facetTypeIsNullable)
@@ -328,7 +330,7 @@ internal static class ExpressionBuilder
         return $"this.{member.Name}.ToSource()";
     }
 
-    private static string WrapCollectionProjection(string projection, string collectionWrapper)
+    private static string WrapCollectionProjection(string projection, string collectionWrapper, string? elementTypeName = null)
     {
         return collectionWrapper switch
         {
@@ -339,6 +341,9 @@ internal static class ExpressionBuilder
             FacetConstants.CollectionWrappers.IReadOnlyCollection => $"{projection}.ToList()",
             FacetConstants.CollectionWrappers.IEnumerable => projection,
             FacetConstants.CollectionWrappers.Array => $"{projection}.ToArray()",
+            FacetConstants.CollectionWrappers.Collection when elementTypeName != null =>
+                $"new global::System.Collections.ObjectModel.Collection<{elementTypeName}>({projection}.ToList())",
+            FacetConstants.CollectionWrappers.Collection => $"{projection}.ToList()",
             _ => projection
         };
     }

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -84,6 +84,9 @@ internal static class ModelBuilder
         // Extract ToSourceConfiguration parameter
         var toSourceConfigurationTypeName = AttributeParser.ExtractToSourceConfigurationTypeName(attribute);
 
+        // Extract CollectionTargetType parameter
+        var collectionTargetType = AttributeParser.ExtractCollectionTargetType(attribute);
+
         // Extract nested facets parameter and build mapping from source type to child facet type
         var nestedFacetMappings = AttributeParser.ExtractNestedFacetMappings(attribute, context.SemanticModel.Compilation);
 
@@ -116,6 +119,7 @@ internal static class ModelBuilder
             mapWhenMappings,
             convertEnumsTo,
             baseClassMemberNames,
+            collectionTargetType,
             token);
 
         // Add expression-based members (from MapFrom with expressions)
@@ -243,10 +247,11 @@ internal static class ModelBuilder
         bool nullableProperties,
         bool copyAttributes,
         Dictionary<string, (string childFacetTypeName, string sourceTypeName)> nestedFacetMappings,
-        Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName)> mapFromMappings,
+        Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection)> mapFromMappings,
         Dictionary<string, (List<string> conditions, string? defaultValue, bool includeInProjection)> mapWhenMappings,
         string? convertEnumsTo,
         ImmutableArray<string> baseClassMemberNames,
+        string? collectionTargetType,
         CancellationToken token)
     {
         var members = new List<FacetMember>();
@@ -288,6 +293,7 @@ internal static class ModelBuilder
                     mapFromMappings,
                     mapWhenMappings,
                     convertEnumsTo,
+                    collectionTargetType,
                     members,
                     excludedRequiredMembers,
                     addedMembers);
@@ -320,9 +326,10 @@ internal static class ModelBuilder
         bool nullableProperties,
         bool copyAttributes,
         Dictionary<string, (string childFacetTypeName, string sourceTypeName)> nestedFacetMappings,
-        Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName)> mapFromMappings,
+        Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection)> mapFromMappings,
         Dictionary<string, (List<string> conditions, string? defaultValue, bool includeInProjection)> mapWhenMappings,
         string? convertEnumsTo,
+        string? collectionTargetType,
         List<FacetMember> members,
         List<FacetMember> excludedRequiredMembers,
         HashSet<string> addedMembers)
@@ -359,6 +366,7 @@ internal static class ModelBuilder
         string? nestedFacetSourceTypeName = null;
         bool isCollection = false;
         string? collectionWrapper = null;
+        string? sourceCollectionWrapper = null;
 
         // Detect if the property type is a nested type (has a containing type)
         // This is needed to generate 'using static' instead of 'using' for the containing type
@@ -387,13 +395,18 @@ internal static class ModelBuilder
             var elementTypeName = elementType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             if (nestedFacetMappings.TryGetValue(elementTypeName, out var nestedMapping))
             {
-                // Wrap the child facet type in the same collection type
-                var wrappedType = GeneratorUtilities.WrapInCollectionType(nestedMapping.childFacetTypeName, wrapper!);
+                // Apply CollectionTargetType override if set, otherwise preserve the source wrapper
+                var effectiveWrapper = collectionTargetType ?? wrapper!;
+                var sourceWrapper = (collectionTargetType != null && collectionTargetType != wrapper) ? wrapper : null;
+
+                // Wrap the child facet type in the target collection type
+                var wrappedType = GeneratorUtilities.WrapInCollectionType(nestedMapping.childFacetTypeName, effectiveWrapper);
                 // Preserve nullability if the collection itself was nullable
                 typeName = shouldTreatAsNullable ? wrappedType + "?" : wrappedType;
                 isNestedFacet = true;
                 isCollection = true;
-                collectionWrapper = wrapper;
+                collectionWrapper = effectiveWrapper;
+                sourceCollectionWrapper = sourceWrapper;
                 nestedFacetSourceTypeName = nestedMapping.sourceTypeName;
             }
         }
@@ -458,6 +471,7 @@ internal static class ModelBuilder
         var mapFromSource = hasMapFrom ? mapFromInfo.source : null;
         var mapFromReversible = hasMapFrom ? mapFromInfo.reversible : true;
         var mapFromIncludeInProjection = hasMapFrom ? mapFromInfo.includeInProjection : true;
+        var mapFromAsCollection = hasMapFrom ? mapFromInfo.asCollection : null;
         var sourcePropertyName = property.Name; // Always use the actual source property name
 
         // Get MapWhen conditions for this property (keyed by target property name)
@@ -477,6 +491,15 @@ internal static class ModelBuilder
             {
                 typeName = GeneratorUtilities.MakeNullable(typeName);
             }
+        }
+
+        // Apply AsCollection override from MapFrom attribute
+        if (mapFromAsCollection != null && isCollection)
+        {
+            var originalWrapper = collectionWrapper;
+            collectionWrapper = mapFromAsCollection;
+            if (originalWrapper != mapFromAsCollection)
+                sourceCollectionWrapper = originalWrapper;
         }
 
         // Enum conversion: if ConvertEnumsTo is set and this property is an enum type, convert it
@@ -535,6 +558,7 @@ internal static class ModelBuilder
             attributes,
             isCollection,
             collectionWrapper,
+            sourceCollectionWrapper,
             sourceMemberTypeName,
             mapFromSource,
             mapFromReversible,
@@ -673,6 +697,7 @@ internal static class ModelBuilder
             attributes,
             false, // Fields are not collections
             null,  // No collection wrapper for fields
+            null,  // sourceCollectionWrapper
             sourceMemberTypeName,
             null,  // mapFromSource
             false, // mapFromReversible
@@ -711,12 +736,12 @@ internal static class ModelBuilder
     /// Returns a dictionary mapping source property names to (targetName, source, reversible, includeInProjection, typeName).
     /// Also returns a list of expression-based members that should be added directly.
     /// </summary>
-private static Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName)> ExtractMapFromMappings(
+private static Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection)> ExtractMapFromMappings(
     INamedTypeSymbol targetSymbol,
     List<FacetMember> expressionMembers,
     bool nullableProperties)
 {
-    var mappings = new Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName)>();
+    var mappings = new Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection)>();
 
     // Get all members from the target type (user-declared properties)
     foreach (var member in targetSymbol.GetMembers())
@@ -774,6 +799,7 @@ private static Dictionary<string, (string targetName, string source, bool revers
                 // Get named arguments
                 var reversible = false;
                 var includeInProjection = true;
+                string? asCollection = null;
 
                 foreach (var namedArg in attr.NamedArguments)
                 {
@@ -784,6 +810,10 @@ private static Dictionary<string, (string targetName, string source, bool revers
                     else if (namedArg.Key == "IncludeInProjection" && namedArg.Value.Value is bool incProj)
                     {
                         includeInProjection = incProj;
+                    }
+                    else if (namedArg.Key == "AsCollection" && namedArg.Value.Value is INamedTypeSymbol asCollectionType)
+                    {
+                        asCollection = AttributeParser.TypeToCollectionWrapper(asCollectionType);
                     }
                 }
 
@@ -812,6 +842,7 @@ private static Dictionary<string, (string targetName, string source, bool revers
                         null,  // attributes
                         false, // isCollection
                         null,  // collectionWrapper
+                        null,  // sourceCollectionWrapper
                         null,  // sourceMemberTypeName
                         source, // mapFromSource
                         reversible,
@@ -822,7 +853,7 @@ private static Dictionary<string, (string targetName, string source, bool revers
                 else
                 {
                     // Simple property rename - map to source property
-                    mappings[source] = (property.Name, source, reversible, includeInProjection, typeName);
+                    mappings[source] = (property.Name, source, reversible, includeInProjection, typeName, asCollection);
                 }
             }
         }

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -396,6 +396,8 @@ internal static class ProjectionGenerator
             {
                 FacetConstants.CollectionWrappers.Array => $"{circularProjection}.ToArray()",
                 FacetConstants.CollectionWrappers.IEnumerable => circularProjection,
+                FacetConstants.CollectionWrappers.Collection =>
+                    $"new global::System.Collections.ObjectModel.Collection<{elementFacetTypeName}>({circularProjection}.ToList())",
                 _ => $"{circularProjection}.ToList()"
             };
         }
@@ -431,6 +433,8 @@ internal static class ProjectionGenerator
         {
             FacetConstants.CollectionWrappers.Array => $"{projection}.ToArray()",
             FacetConstants.CollectionWrappers.IEnumerable => projection,
+            FacetConstants.CollectionWrappers.Collection =>
+                $"new global::System.Collections.ObjectModel.Collection<{elementFacetTypeName}>({projection}.ToList())",
             _ => $"{projection}.ToList()"
         };
     }

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -78,6 +78,7 @@ internal static class FacetConstants
         public const string IReadOnlyList = "IReadOnlyList";
         public const string IReadOnlyCollection = "IReadOnlyCollection";
         public const string Array = "array";
+        public const string Collection = "Collection";
     }
 
     /// <summary>
@@ -110,5 +111,7 @@ internal static class FacetConstants
         public const string GenerateCopyConstructor = "GenerateCopyConstructor";
         public const string GenerateEquality = "GenerateEquality";
         public const string ToSourceConfiguration = "ToSourceConfiguration";
+        public const string CollectionTargetType = "CollectionTargetType";
+        public const string AsCollection = "AsCollection";
     }
 }

--- a/src/Facet/Generators/Shared/GeneratorUtilities.cs
+++ b/src/Facet/Generators/Shared/GeneratorUtilities.cs
@@ -290,7 +290,7 @@ internal static class GeneratorUtilities
 
     /// <summary>
     /// Attempts to extract the element type from a collection type.
-    /// Handles List&lt;T&gt;, ICollection&lt;T&gt;, IEnumerable&lt;T&gt;, IList&lt;T&gt;, IReadOnlyList&lt;T&gt;, IReadOnlyCollection&lt;T&gt;, and T[].
+    /// Handles List&lt;T&gt;, ICollection&lt;T&gt;, IEnumerable&lt;T&gt;, IList&lt;T&gt;, IReadOnlyList&lt;T&gt;, IReadOnlyCollection&lt;T&gt;, Collection&lt;T&gt;, and T[].
     /// </summary>
     /// <param name="typeSymbol">The type symbol to analyze.</param>
     /// <param name="elementType">The extracted element type symbol if successful.</param>
@@ -361,6 +361,14 @@ internal static class GeneratorUtilities
                 collectionWrapper = "IReadOnlyCollection";
                 return true;
             }
+
+            // Check for Collection<T> (System.Collections.ObjectModel)
+            if (typeDefinition == "global::System.Collections.ObjectModel.Collection<T>")
+            {
+                elementType = namedType.TypeArguments[0];
+                collectionWrapper = "Collection";
+                return true;
+            }
         }
 
         return false;
@@ -395,7 +403,7 @@ internal static class GeneratorUtilities
     /// Wraps an element type name in the appropriate collection type.
     /// </summary>
     /// <param name="elementTypeName">The fully qualified element type name.</param>
-    /// <param name="collectionWrapper">The collection wrapper type ("List", "ICollection", "IList", "IEnumerable", "IReadOnlyList", "IReadOnlyCollection", "array").</param>
+    /// <param name="collectionWrapper">The collection wrapper type ("List", "ICollection", "IList", "IEnumerable", "IReadOnlyList", "IReadOnlyCollection", "Collection", "array").</param>
     /// <returns>The fully qualified collection type name.</returns>
     public static string WrapInCollectionType(string elementTypeName, string collectionWrapper)
     {
@@ -407,6 +415,7 @@ internal static class GeneratorUtilities
             "IEnumerable" => $"global::System.Collections.Generic.IEnumerable<{elementTypeName}>",
             "IReadOnlyList" => $"global::System.Collections.Generic.IReadOnlyList<{elementTypeName}>",
             "IReadOnlyCollection" => $"global::System.Collections.Generic.IReadOnlyCollection<{elementTypeName}>",
+            "Collection" => $"global::System.Collections.ObjectModel.Collection<{elementTypeName}>",
             "array" => $"{elementTypeName}[]",
             _ => elementTypeName
         };

--- a/src/Facet/Generators/WrapperGenerators/WrapperModelBuilder.cs
+++ b/src/Facet/Generators/WrapperGenerators/WrapperModelBuilder.cs
@@ -183,6 +183,7 @@ internal static class WrapperModelBuilder
             attributes,
             false, // isCollection
             null,  // collectionWrapper
+            null,  // sourceCollectionWrapper
             GeneratorUtilities.GetTypeNameWithNullability(property.Type), // sourceMemberTypeName
             null,  // mapFromSource
             false, // mapFromReversible
@@ -248,7 +249,8 @@ internal static class WrapperModelBuilder
             nestedWrapperSourceTypeName,
             attributes,
             false, // isCollection
-            null,
+            null,  // collectionWrapper
+            null,  // sourceCollectionWrapper
             GeneratorUtilities.GetTypeNameWithNullability(field.Type),
             null,  // mapFromSource
             false, // mapFromReversible

--- a/test/Facet.Tests/UnitTests/Core/Facet/CollectionTargetTypeTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CollectionTargetTypeTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.ObjectModel;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+// Test entities with Collection<T> navigation properties (EF Core style)
+public class CollectionEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public Collection<CollectionItemEntity> Items { get; set; } = new();
+}
+
+public class CollectionItemEntity
+{
+    public int Id { get; set; }
+    public string Value { get; set; } = string.Empty;
+}
+
+// 1. Without override — Collection<T> should be recognized and mapped to Collection<T>
+[Facet(typeof(CollectionEntity), NestedFacets = [typeof(CollectionItemFacet)])]
+public partial class CollectionEntityFacet { }
+
+[Facet(typeof(CollectionItemEntity))]
+public partial class CollectionItemFacet { }
+
+// 2. With CollectionTargetType override — Collection<T> remapped to List<T>
+[Facet(typeof(CollectionEntity), NestedFacets = [typeof(CollectionItemWithOverrideFacet)], CollectionTargetType = typeof(List<>))]
+public partial class CollectionEntityWithOverrideFacet { }
+
+[Facet(typeof(CollectionItemEntity))]
+public partial class CollectionItemWithOverrideFacet { }
+
+// 3. With GenerateToSource — ToSource() should restore Collection<T>
+[Facet(typeof(CollectionEntity), NestedFacets = [typeof(CollectionItemWithToSourceFacet)], CollectionTargetType = typeof(List<>), GenerateToSource = true)]
+public partial class CollectionEntityWithToSourceFacet { }
+
+[Facet(typeof(CollectionItemEntity), GenerateToSource = true)]
+public partial class CollectionItemWithToSourceFacet { }
+
+public class CollectionTargetTypeTests
+{
+    [Fact]
+    public void Collection_ShouldBeRecognized_WithoutOverride()
+    {
+        // Arrange
+        var entity = new CollectionEntity
+        {
+            Id = 1,
+            Name = "Test",
+            Items = new Collection<CollectionItemEntity>
+            {
+                new() { Id = 10, Value = "A" },
+                new() { Id = 20, Value = "B" }
+            }
+        };
+
+        // Act
+        var facet = new CollectionEntityFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(1);
+        facet.Name.Should().Be("Test");
+        facet.Items.Should().NotBeNull();
+        facet.Items.Should().BeOfType<Collection<CollectionItemFacet>>();
+        facet.Items.Should().HaveCount(2);
+        facet.Items[0].Id.Should().Be(10);
+        facet.Items[0].Value.Should().Be("A");
+        facet.Items[1].Id.Should().Be(20);
+        facet.Items[1].Value.Should().Be("B");
+    }
+
+    [Fact]
+    public void CollectionTargetType_ShouldOverride_ToList()
+    {
+        // Arrange
+        var entity = new CollectionEntity
+        {
+            Id = 2,
+            Name = "Override",
+            Items = new Collection<CollectionItemEntity>
+            {
+                new() { Id = 30, Value = "C" }
+            }
+        };
+
+        // Act
+        var facet = new CollectionEntityWithOverrideFacet(entity);
+
+        // Assert
+        facet.Id.Should().Be(2);
+        facet.Items.Should().NotBeNull();
+        facet.Items.Should().BeOfType<List<CollectionItemWithOverrideFacet>>();
+        facet.Items.Should().HaveCount(1);
+        facet.Items[0].Id.Should().Be(30);
+        facet.Items[0].Value.Should().Be("C");
+    }
+
+    [Fact]
+    public void CollectionTargetType_ToSource_ShouldUseSourceWrapper()
+    {
+        // Arrange
+        var entity = new CollectionEntity
+        {
+            Id = 3,
+            Name = "ToSource",
+            Items = new Collection<CollectionItemEntity>
+            {
+                new() { Id = 40, Value = "D" }
+            }
+        };
+
+        // Act
+        var facet = new CollectionEntityWithToSourceFacet(entity);
+
+        // Items are List in facet (due to override)
+        facet.Items.Should().BeOfType<List<CollectionItemWithToSourceFacet>>();
+
+        // But ToSource() should restore them to Collection<T>
+        var source = facet.ToSource();
+
+        // Assert
+        source.Id.Should().Be(3);
+        source.Name.Should().Be("ToSource");
+        source.Items.Should().NotBeNull();
+        source.Items.Should().BeOfType<Collection<CollectionItemEntity>>();
+        source.Items.Should().HaveCount(1);
+        source.Items[0].Id.Should().Be(40);
+        source.Items[0].Value.Should().Be("D");
+    }
+}


### PR DESCRIPTION
Solution for, and closes #315 

EF Core entities commonly use `System.Collections.ObjectModel.Collection<T>` for navigation properties. When a facet is generated from such an entity the collection type is preserved as-is, meaning DTO properties end up typed as `Collection<T>` even when `List<T>` (or any other type) is preferred.

Additionally, `Collection<T>` was not recognised by the collection-detection pipeline at all, so properties of that type were silently skipped during mapping.

New features in this PR:

| Feature | Where | Effect |
|---|---|---|
| `CollectionTargetType = typeof(List<>)` | `[Facet]` attribute | Remaps **all** collection properties on the facet to the given type |
| `AsCollection = typeof(List<>)` | `[MapFrom]` attribute | Remaps a **single** collection property to the given type |
| `Collection<T>` recognition fix | Internal pipeline | `Collection<T>` is now detected and mapped correctly with no opt-in needed |

## Usage

### Facet-level override

```csharp
// Entity uses Collection<T> (EF Core default)
public class UnitEntity
{
    public Collection<UnitItemEntity> Items { get; set; } = new();
}

// DTO gets List<T> for all collection properties
[Facet(typeof(UnitEntity),
    NestedFacets = [typeof(UnitItemDto)],
    CollectionTargetType = typeof(List<>),
    GenerateToSource = true)]
public partial class UnitDto { }

// Generated:
//   public List<UnitItemDto> Items { get; set; }
//   ToSource() -> entity.Items = new Collection<UnitItemEntity>(this.Items.Select(...).ToList())
```

### Per-property override

```csharp
[Facet(typeof(UnitEntity), NestedFacets = [typeof(UnitItemDto)])]
public partial class UnitDto
{
    [MapFrom(nameof(UnitEntity.Items), AsCollection = typeof(List<>))]
    public List<UnitItemDto> Items { get; set; } = new();
}
```