### PR TITLE
feat: Projection mapping config

### DIFF
--- a/docs/04_CustomMapping.md
+++ b/docs/04_CustomMapping.md
@@ -10,6 +10,7 @@ Facet supports custom mapping logic for advanced scenarios via multiple interfac
 | `IFacetMapConfiguration<TSource, TTarget>` | Synchronous mapping | Fast, in-memory operations |
 | `IFacetMapConfigurationAsync<TSource, TTarget>` | Asynchronous mapping | I/O operations, database calls, API calls |
 | `IFacetMapConfigurationHybrid<TSource, TTarget>` | Combined sync/async | Optimal performance with mixed operations |
+| `IFacetProjectionMapConfiguration<TSource, TTarget>` | Expression-based projection mapping | Computed properties in EF Core `Projection` |
 
 ### Instance Mappers (With Dependency Injection Support)
 | Interface | Purpose | Use Case |
@@ -29,6 +30,12 @@ Facet supports custom mapping logic for advanced scenarios via multiple interfac
 - **Best for**: Complex scenarios requiring external services (databases, APIs, file systems)
 - **Benefits**: Full dependency injection support, easier testing, better separation of concerns
 - **Usage**: Pass mapper instances with injected dependencies
+
+### Projection Mappers (`IFacetProjectionMapConfiguration`)
+- **Best for**: Computed properties that must appear in EF Core `Select(DTO.Projection)` queries
+- **Benefits**: Custom bindings are inlined as `MemberInitExpression`, fully SQL-translatable, no `Invoke` nodes
+- **Limitations**: Expressions must be EF Core-translatable (property access, arithmetic, ternaries, no method calls, no DI)
+- **See also**: [Projection mapping section below](#projection-mapping-ifacetprojectionmapconfiguration)
 
 ## Facet.Mapping Extension Methods
 
@@ -556,5 +563,74 @@ public partial class UnitDto { ... }
 - **Thread Safety**: Each instance should handle its own thread-safety requirements for injected services
 - **Cancellation**: All async methods support `CancellationToken` for proper cancellation
 - **Error Handling**: Instance mappers can inject loggers and other services for better error handling
+
+---
+
+## Projection Mapping: IFacetProjectionMapConfiguration
+
+`IFacetMapConfiguration.Map()` is imperative code, EF Core cannot translate arbitrary method calls inside a `Select(DTO.Projection)` query to SQL. `IFacetProjectionMapConfiguration` solves this by letting you declare custom property mappings as **pure expression trees** that EF Core can translate.
+
+### When to use it
+
+Use `IFacetProjectionMapConfiguration` when:
+- You have a computed property (e.g. `FullName = FirstName + " " + LastName`) that must work in EF Core `Select` queries
+- Your `Map()` method sets some properties that are expressible as SQL and others that are not (DI-dependent); you want the SQL-translatable ones in the `Projection`
+
+### Division of responsibility
+
+| Interface | Runs in | Purpose |
+|---|---|---|
+| `IFacetMapConfiguration` — `Map()` | Constructors, `FromSource()` | Imperative logic, DI-dependent work, anything not SQL-translatable |
+| `IFacetProjectionMapConfiguration` - `ConfigureProjection()` | `Projection` build (once, lazy) | Expression-only mappings that EF Core can translate to SQL |
+
+### Example
+
+```csharp
+public class UserDto325MapConfig
+    : IFacetMapConfiguration<UserEntity, UserDto>,
+      IFacetProjectionMapConfiguration<UserEntity, UserDto>
+{
+    // Runs in constructors and FromSource(), can call services, do anything
+    public static void Map(UserEntity source, UserDto target)
+    {
+        target.FullName  = source.FirstName + " " + source.LastName;
+        target.AuditNote = AuditService.GetNote(source.Id); // DI-dependent, omitted from projection
+    }
+
+    // Runs once at app startup to build the Projection expression — expressions only
+    public static void ConfigureProjection(IFacetProjectionBuilder<UserEntity, UserDto> builder)
+    {
+        builder.Map(d => d.FullName, s => s.FirstName + " " + s.LastName);
+        // AuditNote intentionally omitted — cannot be expressed as a SQL-translatable expression
+    }
+}
+
+[Facet(typeof(UserEntity), Configuration = typeof(UserDto325MapConfig), GenerateProjection = true)]
+public partial class UserDto
+{
+    public string FullName   { get; set; } = string.Empty;
+    public string AuditNote  { get; set; } = string.Empty;
+}
+```
+
+When the generator detects that the `Configuration` type implements `IFacetProjectionMapConfiguration`, it switches the generated `Projection` property from a static expression literal to a **lazily-built expression tree**:
+
+```csharp
+// Generated code (simplified):
+private static Expression<Func<UserEntity, UserDto>>? _projection;
+
+public static Expression<Func<UserEntity, UserDto>> Projection
+    => LazyInitializer.EnsureInitialized(ref _projection, BuildProjection);
+```
+
+The `BuildProjection()` method assembles a `MemberInitExpression`, inlines the `ConfigureProjection` bindings via parameter substitution, and returns a pure expression tree — identical in structure to what EF Core already translates to SQL.
+
+### Limitations
+
+- Expressions in `ConfigureProjection` must be EF Core-translatable (property access, arithmetic, string concatenation, ternaries). Facet cannot validate this at compile time; EF Core will throw at runtime if they are not.
+- `ConfigureProjection` is called **once** during lazy initialisation, do not reference instance state or external services.
+- Properties omitted from `ConfigureProjection` but present in `Map()` will **not** appear in `Projection`. This is intentional.
+- Nested facet bindings in the lazy projection are not auto-generated; add them in `ConfigureProjection` if needed.
+- Thread safety is provided by `LazyInitializer.EnsureInitialized`.
 
 ---

--- a/src/Facet.Mapping/FacetProjectionBuilder.cs
+++ b/src/Facet.Mapping/FacetProjectionBuilder.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Facet.Mapping;
+
+/// <summary>
+/// Concrete implementation of <see cref="IFacetProjectionBuilder{TSource,TTarget}"/>.
+/// Collects user-declared expression bindings that are later inlined into the generated
+/// <c>Projection</c> expression by <c>BuildProjection()</c>.
+/// </summary>
+public sealed class FacetProjectionBuilder<TSource, TTarget>
+    : IFacetProjectionBuilder<TSource, TTarget>
+{
+    public List<(MemberInfo Member, LambdaExpression ValueExpression)> Mappings { get; } = new();
+
+    public IFacetProjectionBuilder<TSource, TTarget> Map<TValue>(
+        Expression<Func<TTarget, TValue>> targetMember,
+        Expression<Func<TSource, TValue>> valueExpression)
+    {
+        var member = ((MemberExpression)targetMember.Body).Member;
+        Mappings.Add((member, valueExpression));
+        return this;
+    }
+}

--- a/src/Facet.Mapping/IFacetProjectionBuilder.cs
+++ b/src/Facet.Mapping/IFacetProjectionBuilder.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Facet.Mapping;
+
+/// <summary>
+/// Builder interface used inside <see cref="IFacetProjectionMapConfiguration{TSource,TTarget}.ConfigureProjection"/>
+/// to declare property bindings that will be inlined into the generated <c>Projection</c> expression.
+/// </summary>
+/// <typeparam name="TSource">The source entity type.</typeparam>
+/// <typeparam name="TTarget">The target Facet-generated DTO type.</typeparam>
+public interface IFacetProjectionBuilder<TSource, TTarget>
+{
+    /// <summary>
+    /// Maps <paramref name="targetMember"/> on the target DTO to the value produced by
+    /// <paramref name="valueExpression"/> applied to the source entity.
+    /// If the property already has an auto-generated binding, this overwrites it.
+    /// </summary>
+    /// <typeparam name="TValue">The property value type.</typeparam>
+    /// <param name="targetMember">Expression selecting the target property (e.g. <c>d => d.FullName</c>).</param>
+    /// <param name="valueExpression">Expression that computes the value from the source (e.g. <c>s => s.FirstName + " " + s.LastName</c>).</param>
+    /// <returns>The builder, for fluent chaining.</returns>
+    IFacetProjectionBuilder<TSource, TTarget> Map<TValue>(
+        Expression<Func<TTarget, TValue>> targetMember,
+        Expression<Func<TSource, TValue>> valueExpression);
+}

--- a/src/Facet.Mapping/IFacetProjectionMapConfiguration.cs
+++ b/src/Facet.Mapping/IFacetProjectionMapConfiguration.cs
@@ -1,0 +1,36 @@
+namespace Facet.Mapping;
+
+/// <summary>
+/// Allows declaring custom property mappings that are inlined into the generated
+/// <c>Projection</c> expression, making them available to EF Core query translation.
+/// Implement this alongside <see cref="IFacetMapConfiguration{TSource,TTarget}"/> when
+/// some of your <c>Map()</c> logic can be expressed as simple LINQ expressions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Expressions passed to <see cref="IFacetProjectionBuilder{TSource,TTarget}.Map{TValue}"/>
+/// must be EF Core-translatable. If they are not, EF Core will throw at query execution time.
+/// </para>
+/// <para>
+/// <c>ConfigureProjection</c> is called once during lazy initialization. Do not reference
+/// instance state or external services.
+/// </para>
+/// <para>
+/// Properties omitted from <c>ConfigureProjection</c> but present in <c>Map()</c> will not
+/// appear in <c>Projection</c>. This is intentional — use <c>ConfigureProjection</c> only for
+/// SQL-translatable expressions.
+/// </para>
+/// </remarks>
+/// <typeparam name="TSource">The source entity type.</typeparam>
+/// <typeparam name="TTarget">The target Facet-generated DTO type.</typeparam>
+public interface IFacetProjectionMapConfiguration<TSource, TTarget>
+{
+    /// <summary>
+    /// Declare additional property bindings to include in the generated Projection.
+    /// Only use expressions that EF Core can translate to SQL (property access,
+    /// arithmetic, string concatenation, ternary operators, etc.).
+    /// Do NOT reference services or call arbitrary methods here.
+    /// </summary>
+    /// <param name="builder">The builder used to register expression bindings.</param>
+    static abstract void ConfigureProjection(IFacetProjectionBuilder<TSource, TTarget> builder);
+}

--- a/src/Facet.Mapping/ParameterReplacer.cs
+++ b/src/Facet.Mapping/ParameterReplacer.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+
+namespace Facet.Mapping;
+
+/// <summary>
+/// An <see cref="ExpressionVisitor"/> that substitutes every occurrence of one
+/// <see cref="ParameterExpression"/> with another.  Used by <c>BuildProjection()</c>
+/// to inline user-declared lambda bodies into the outer projection parameter so that
+/// the final expression tree contains no <c>Invoke</c> nodes — which EF Core cannot translate.
+/// </summary>
+public sealed class ParameterReplacer : ExpressionVisitor
+{
+    private readonly ParameterExpression _from, _to;
+
+    private ParameterReplacer(ParameterExpression from, ParameterExpression to)
+        => (_from, _to) = (from, to);
+
+    /// <summary>
+    /// Returns <paramref name="expr"/>.Body with every occurrence of its first parameter
+    /// replaced by <paramref name="newParam"/>.
+    /// </summary>
+    public static Expression Replace(LambdaExpression expr, ParameterExpression newParam)
+        => new ParameterReplacer(expr.Parameters[0], newParam).Visit(expr.Body)!;
+
+    protected override Expression VisitParameter(ParameterExpression node)
+        => node == _from ? _to : base.VisitParameter(node);
+}

--- a/src/Facet.Mapping/README.md
+++ b/src/Facet.Mapping/README.md
@@ -20,6 +20,11 @@ With **Facet.Mapping**, you can go further and define custom logic like combinin
 2. Define a static `Map` method.
 3. Point the `[Facet(...)]` attribute to the config class using `Configuration = typeof(...)`.
 
+### Projection Mapping (EF Core-compatible computed properties)
+1. Implement `IFacetProjectionMapConfiguration<TSource, TTarget>` alongside `IFacetMapConfiguration<TSource, TTarget>`.
+2. Define a static `ConfigureProjection` method that registers expression bindings via the builder.
+3. The generator detects the interface and switches `Projection` to a lazily-built `MemberInitExpression` — fully translatable by EF Core.
+
 ### Reverse Mapping (DTO → Entity)
 1. Implement the `IFacetToSourceConfiguration<TFacet, TSource>` interface.
 2. Define a static `Map(TFacet facet, TSource target)` method.
@@ -274,6 +279,43 @@ public partial class UnitDto
 ```
 
 The `Map` method is called **after** automatic property copying, so you only need to handle properties that require custom logic.
+
+### Projection Mapping (EF Core-compatible computed properties)
+
+`IFacetMapConfiguration.Map()` is imperative code — EF Core cannot translate it inside a `Select` query. `IFacetProjectionMapConfiguration` lets you declare the SQL-translatable subset as pure expression trees that are inlined into the generated `Projection` property.
+
+```csharp
+public class UserDtoMapConfig
+    : IFacetMapConfiguration<User, UserDto>,
+      IFacetProjectionMapConfiguration<User, UserDto>
+{
+    // Runs in constructors and FromSource() — can call services, do anything
+    public static void Map(User source, UserDto target)
+    {
+        target.FullName  = source.FirstName + " " + source.LastName;
+        target.AuditNote = AuditService.GetNote(source.Id); // DI-dependent, not in projection
+    }
+
+    // Runs once to build the Projection expression — SQL-translatable expressions only
+    public static void ConfigureProjection(IFacetProjectionBuilder<User, UserDto> builder)
+    {
+        builder.Map(d => d.FullName, s => s.FirstName + " " + s.LastName);
+    }
+}
+
+[Facet(typeof(User), Configuration = typeof(UserDtoMapConfig), GenerateProjection = true)]
+public partial class UserDto
+{
+    public string FullName   { get; set; } = string.Empty;
+    public string AuditNote  { get; set; } = string.Empty;
+}
+
+// Usage — FullName is computed directly in SQL; AuditNote is left at its default
+var dtos = await context.Users
+    .Where(u => u.IsActive)
+    .Select(UserDto.Projection)
+    .ToListAsync();
+```
 
 // Usage
 var userDto = await user.ToFacetHybridAsync(hybridMapperWithDI);

--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -65,6 +65,14 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     /// </summary>
     public bool BaseHidesFacetMembers { get; }
 
+    /// <summary>
+    /// When true, the <see cref="ConfigurationTypeName"/> type implements
+    /// <c>IFacetProjectionMapConfiguration&lt;TSource, TTarget&gt;</c>.
+    /// The generator will emit a lazily-built <c>Projection</c> that inlines the
+    /// <c>ConfigureProjection</c> bindings instead of a static expression literal.
+    /// </summary>
+    public bool HasProjectionMapConfiguration { get; }
+
     public FacetTargetModel(
         string name,
         string? @namespace,
@@ -99,7 +107,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         bool generateCopyConstructor = false,
         bool generateEquality = false,
         string? toSourceConfigurationTypeName = null,
-        bool baseHidesFacetMembers = false)
+        bool baseHidesFacetMembers = false,
+        bool hasProjectionMapConfiguration = false)
     {
         Name = name;
         Namespace = @namespace;
@@ -135,6 +144,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         GenerateEquality = generateEquality;
         ToSourceConfigurationTypeName = toSourceConfigurationTypeName;
         BaseHidesFacetMembers = baseHidesFacetMembers;
+        HasProjectionMapConfiguration = hasProjectionMapConfiguration;
     }
 
     public bool Equals(FacetTargetModel? other)
@@ -174,7 +184,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && GenerateCopyConstructor == other.GenerateCopyConstructor
             && GenerateEquality == other.GenerateEquality
             && ToSourceConfigurationTypeName == other.ToSourceConfigurationTypeName
-            && BaseHidesFacetMembers == other.BaseHidesFacetMembers;
+            && BaseHidesFacetMembers == other.BaseHidesFacetMembers
+            && HasProjectionMapConfiguration == other.HasProjectionMapConfiguration;
     }
 
     public override bool Equals(object? obj) => obj is FacetTargetModel other && Equals(other);
@@ -211,6 +222,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + GenerateEquality.GetHashCode();
             hash = hash * 31 + (ToSourceConfigurationTypeName?.GetHashCode() ?? 0);
             hash = hash * 31 + BaseHidesFacetMembers.GetHashCode();
+            hash = hash * 31 + HasProjectionMapConfiguration.GetHashCode();
             hash = hash * 31 + Members.Length.GetHashCode();
 
             foreach (var member in Members)

--- a/src/Facet/Generators/FacetGenerators/AttributeParser.cs
+++ b/src/Facet/Generators/FacetGenerators/AttributeParser.cs
@@ -166,6 +166,16 @@ internal static class AttributeParser
     }
 
     /// <summary>
+    /// Extracts the configuration type symbol from the attribute, or null if not set.
+    /// </summary>
+    public static INamedTypeSymbol? ExtractConfigurationTypeSymbol(AttributeData attribute)
+    {
+        var arg = attribute.NamedArguments
+            .FirstOrDefault(kvp => kvp.Key == FacetConstants.AttributeNames.Configuration);
+        return arg.Value.Value as INamedTypeSymbol;
+    }
+
+    /// <summary>
     /// Extracts the BeforeMapConfiguration type name from the attribute.
     /// </summary>
     public static string? ExtractBeforeMapConfigurationTypeName(AttributeData attribute)

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -84,6 +84,20 @@ internal static class ModelBuilder
         // Extract ToSourceConfiguration parameter
         var toSourceConfigurationTypeName = AttributeParser.ExtractToSourceConfigurationTypeName(attribute);
 
+        // Detect if the configuration type implements IFacetProjectionMapConfiguration<TSource, TTarget>
+        var configTypeSymbol = AttributeParser.ExtractConfigurationTypeSymbol(attribute);
+        var hasProjectionMapConfiguration = false;
+        if (configTypeSymbol != null)
+        {
+            var projectionConfigInterface = context.SemanticModel.Compilation
+                .GetTypeByMetadataName(FacetConstants.ProjectionMapConfigurationInterfaceFullName);
+            if (projectionConfigInterface != null)
+            {
+                hasProjectionMapConfiguration = configTypeSymbol.AllInterfaces.Any(i =>
+                    SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, projectionConfigInterface));
+            }
+        }
+
         // Extract CollectionTargetType parameter
         var collectionTargetType = AttributeParser.ExtractCollectionTargetType(attribute);
 
@@ -231,7 +245,8 @@ internal static class ModelBuilder
             generateCopyConstructor,
             generateEquality,
             toSourceConfigurationTypeName,
-            baseHidesFacetMembers);
+            baseHidesFacetMembers,
+            hasProjectionMapConfiguration);
     }
 
     #region Private Helper Methods

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -25,6 +25,11 @@ internal static class ProjectionGenerator
         {
             GenerateProjectionNotSupportedComment(sb, model, memberIndent);
         }
+        else if (model.HasProjectionMapConfiguration)
+        {
+            GenerateProjectionDocumentation(sb, model, memberIndent);
+            GenerateLazyProjection(sb, model, memberIndent, facetLookup);
+        }
         else
         {
             GenerateProjectionDocumentation(sb, model, memberIndent);
@@ -33,6 +38,112 @@ internal static class ProjectionGenerator
             // Generate object initializer projection for EF Core compatibility
             GenerateProjectionExpression(sb, model, memberIndent, facetLookup);
         }
+    }
+
+    /// <summary>
+    /// Generates a lazily-built projection that inlines ConfigureProjection bindings so that
+    /// EF Core can translate the result to SQL without encountering any Invoke nodes.
+    /// Emits: a backing field, a Projection property delegating to LazyInitializer, and a
+    /// BuildProjection() method that assembles a MemberInitExpression at runtime.
+    /// </summary>
+    private static void GenerateLazyProjection(
+        StringBuilder sb,
+        FacetTargetModel model,
+        string memberIndent,
+        Dictionary<string, FacetTargetModel> _)
+    {
+        var newModifier = model.BaseHidesFacetMembers ? "new " : "";
+        var src = model.SourceTypeName;
+        var tgt = model.Name;
+
+        // Backing field
+        sb.AppendLine($"{memberIndent}private static global::System.Linq.Expressions.Expression<global::System.Func<{src}, {tgt}>>? _projection;");
+        sb.AppendLine();
+
+        // Projection property
+        sb.AppendLine($"{memberIndent}public static {newModifier}global::System.Linq.Expressions.Expression<global::System.Func<{src}, {tgt}>> Projection");
+        sb.AppendLine($"{memberIndent}    => global::System.Threading.LazyInitializer.EnsureInitialized(ref _projection, BuildProjection);");
+        sb.AppendLine();
+
+        // BuildProjection() method
+        sb.AppendLine($"{memberIndent}private static global::System.Linq.Expressions.Expression<global::System.Func<{src}, {tgt}>> BuildProjection()");
+        sb.AppendLine($"{memberIndent}{{");
+
+        var bodyIndent = memberIndent + "    ";
+
+        // Source parameter
+        sb.AppendLine($"{bodyIndent}var __p = global::System.Linq.Expressions.Expression.Parameter(typeof({src}), \"source\");");
+        sb.AppendLine();
+
+        // Auto-generated bindings list
+        sb.AppendLine($"{bodyIndent}var __bindings = new global::System.Collections.Generic.List<global::System.Linq.Expressions.MemberBinding>");
+        sb.AppendLine($"{bodyIndent}{{");
+
+        var includedMembers = model.Members
+            .Where(m => m.MapFromIncludeInProjection && !m.IsNestedFacet)
+            .ToArray();
+
+        for (int i = 0; i < includedMembers.Length; i++)
+        {
+            var member = includedMembers[i];
+            var bindingExpr = GetMemberBindingExpression(member, "__p", tgt);
+            if (bindingExpr == null) continue;
+
+            var comma = i < includedMembers.Length - 1 ? "," : "";
+            sb.AppendLine($"{bodyIndent}    {bindingExpr}{comma}");
+        }
+
+        sb.AppendLine($"{bodyIndent}}};");
+        sb.AppendLine();
+
+        // Apply ConfigureProjection overrides
+        sb.AppendLine($"{bodyIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
+        sb.AppendLine($"{bodyIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
+        sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __builder.Mappings)");
+        sb.AppendLine($"{bodyIndent}{{");
+        sb.AppendLine($"{bodyIndent}    var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __p);");
+        sb.AppendLine($"{bodyIndent}    __bindings.RemoveAll(b => ((global::System.Linq.Expressions.MemberAssignment)b).Member.Name == __member.Name);");
+        sb.AppendLine($"{bodyIndent}    __bindings.Add(global::System.Linq.Expressions.Expression.Bind(__member, __body));");
+        sb.AppendLine($"{bodyIndent}}}");
+        sb.AppendLine();
+
+        // Build and return the final lambda
+        sb.AppendLine($"{bodyIndent}return global::System.Linq.Expressions.Expression.Lambda<global::System.Func<{src}, {tgt}>>(");
+        sb.AppendLine($"{bodyIndent}    global::System.Linq.Expressions.Expression.MemberInit(");
+        sb.AppendLine($"{bodyIndent}        global::System.Linq.Expressions.Expression.New(typeof({tgt})),");
+        sb.AppendLine($"{bodyIndent}        __bindings),");
+        sb.AppendLine($"{bodyIndent}    __p);");
+        sb.AppendLine($"{memberIndent}}}");
+    }
+
+    /// <summary>
+    /// Returns a <c>Expression.Bind(...)</c> call string for the given scalar member,
+    /// or null if the member cannot be expressed as a simple property access.
+    /// </summary>
+    private static string? GetMemberBindingExpression(
+        FacetMember member,
+        string paramName,
+        string targetTypeName)
+    {
+        // Skip members with computed expressions — user must declare them in ConfigureProjection
+        if (member.MapFromSource != null && ExpressionHelper.IsExpression(member.MapFromSource))
+            return null;
+
+        string valueExpr;
+        if (member.MapFromSource != null)
+        {
+            // Build chained Expression.Property calls for dotted paths like "Company.Name"
+            var parts = member.MapFromSource.Split('.');
+            valueExpr = $"global::System.Linq.Expressions.Expression.Property({paramName}, \"{parts[0]}\")";
+            for (int i = 1; i < parts.Length; i++)
+                valueExpr = $"global::System.Linq.Expressions.Expression.Property({valueExpr}, \"{parts[i]}\")";
+        }
+        else
+        {
+            valueExpr = $"global::System.Linq.Expressions.Expression.Property({paramName}, \"{member.SourcePropertyName}\")";
+        }
+
+        return $"global::System.Linq.Expressions.Expression.Bind(typeof({targetTypeName}).GetProperty(\"{member.Name}\")!, {valueExpr})";
     }
 
     private static void GenerateProjectionNotSupportedComment(StringBuilder sb, FacetTargetModel model, string memberIndent)

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -32,6 +32,12 @@ internal static class FacetConstants
     public const string FacetAttributeFullName = "Facet.FacetAttribute";
 
     /// <summary>
+    /// The metadata name of the IFacetProjectionMapConfiguration open generic interface.
+    /// Used by ModelBuilder to detect whether a configuration type opts into lazy projection building.
+    /// </summary>
+    public const string ProjectionMapConfigurationInterfaceFullName = "Facet.Mapping.IFacetProjectionMapConfiguration`2";
+
+    /// <summary>
     /// The fully qualified name of the WrapperAttribute.
     /// </summary>
     public const string WrapperAttributeFullName = "Facet.WrapperAttribute";

--- a/test/Facet.Tests/UnitTests/Core/Facet/ProjectionMapConfigTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ProjectionMapConfigTests.cs
@@ -1,0 +1,113 @@
+using System.Linq.Expressions;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+public class PersonEntity325
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+}
+
+public class PersonDto325MapConfig
+    : IFacetMapConfiguration<PersonEntity325, PersonDto325>,
+      IFacetProjectionMapConfiguration<PersonEntity325, PersonDto325>
+{
+    // Imperative mapping
+    public static void Map(PersonEntity325 source, PersonDto325 target)
+    {
+        target.FullName = source.FirstName + " " + source.LastName;
+        target.AuditNote = "SET_BY_SERVICE"; // simulates DI-dependent work
+    }
+
+    // Expression mapping
+    public static void ConfigureProjection(IFacetProjectionBuilder<PersonEntity325, PersonDto325> builder)
+    {
+        builder.Map(d => d.FullName, s => s.FirstName + " " + s.LastName);
+    }
+}
+
+[Facet(typeof(PersonEntity325), Configuration = typeof(PersonDto325MapConfig), GenerateProjection = true)]
+public partial class PersonDto325
+{
+    /// <summary>Computed by PersonDto325MapConfig.Map() and ConfigureProjection().</summary>
+    public string FullName { get; set; } = string.Empty;
+
+    /// <summary>Set only by Map() (DI-dependent); absent from Projection.</summary>
+    public string AuditNote { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Tests for IFacetProjectionMapConfiguration — lazy projection with inlined expression bindings.
+/// </summary>
+public class ProjectionMapConfigTests
+{
+    [Fact]
+    public void Constructor_ShouldSetBothMappedProperties()
+    {
+        var source = new PersonEntity325 { Id = 1, FirstName = "Jane", LastName = "Smith" };
+
+        var dto = new PersonDto325(source);
+
+        dto.Id.Should().Be(1);
+        dto.FullName.Should().Be("Jane Smith", "Map() should concatenate first + last name");
+        dto.AuditNote.Should().Be("SET_BY_SERVICE", "Map() should have set the DI-dependent property");
+    }
+
+    [Fact]
+    public void FromSource_ShouldSetBothMappedProperties()
+    {
+        var source = new PersonEntity325 { Id = 2, FirstName = "John", LastName = "Doe" };
+
+        var dto = PersonDto325.FromSource(source);
+
+        dto.FullName.Should().Be("John Doe");
+        dto.AuditNote.Should().Be("SET_BY_SERVICE");
+    }
+
+    [Fact]
+    public void Projection_ShouldIncludeComputedFullName()
+    {
+        var source = new PersonEntity325 { Id = 3, FirstName = "Alice", LastName = "Walker" };
+
+        var compiled = PersonDto325.Projection.Compile();
+        var dto = compiled(source);
+
+        dto.Id.Should().Be(3);
+        dto.FullName.Should().Be("Alice Walker",
+            "ConfigureProjection should inline the FullName expression into the Projection");
+    }
+
+    [Fact]
+    public void Projection_ShouldNotIncludeDiDependentProperty()
+    {
+        var source = new PersonEntity325 { Id = 4, FirstName = "Bob", LastName = "Builder" };
+
+        var compiled = PersonDto325.Projection.Compile();
+        var dto = compiled(source);
+
+        dto.AuditNote.Should().BeNullOrEmpty(
+            "AuditNote was intentionally omitted from ConfigureProjection and should not be set");
+    }
+
+    [Fact]
+    public void Projection_ShouldReturnPureMemberInitExpression()
+    {
+        // Verifies the expression tree contains no Invoke nodes
+        var expr = PersonDto325.Projection;
+
+        expr.Body.NodeType.Should().Be(ExpressionType.MemberInit,
+            "the Projection body must be a MemberInitExpression so EF Core can translate it");
+    }
+
+    [Fact]
+    public void Projection_ShouldBeLazyAndReturnSameInstance()
+    {
+        // LazyInitializer guarantees at-most-one build; same reference on repeated access.
+        var first = PersonDto325.Projection;
+        var second = PersonDto325.Projection;
+
+        first.Should().BeSameAs(second, "the lazy backing field should return the same expression instance");
+    }
+}
+


### PR DESCRIPTION
Implements `IFacetProjectionMapConfiguration<TSource, TTarget>` & closes #318.

When `Map()` sets computed properties, those values were silently absent from `DTO.Projection` because EF Core cannot translate imperative code to SQL. This PR adds an expression-based companion interface so the SQL-translatable subset of your mapping logic is inlined directly into the `Projection` expression tree.

## Problem

```csharp
// Map() runs in constructors, works fine
target.FullName = source.FirstName + " " + source.LastName;

// But Projection never called Map(), so FullName was always empty string when used with EF Core:
context.Users.Select(UserDto.Projection).ToList(); // FullName == ""
```

---

## Solution

Add `IFacetProjectionMapConfiguration<TSource, TTarget>` to your config class and declare the SQL-translatable bindings in `ConfigureProjection`:

```csharp
public class UserDtoMapConfig
    : IFacetMapConfiguration<UserEntity, UserDto>,
      IFacetProjectionMapConfiguration<UserEntity, UserDto>
{
    // Imperative, constructors / FromSource() only
    public static void Map(UserEntity source, UserDto target)
    {
        target.FullName  = source.FirstName + " " + source.LastName;
        target.AuditNote = AuditService.GetNote(source.Id); // DI-dependent, intentionally omitted below
    }

    // Expression-only,inlined into Projection
    public static void ConfigureProjection(IFacetProjectionBuilder<UserEntity, UserDto> builder)
    {
        builder.Map(d => d.FullName, s => s.FirstName + " " + s.LastName);
    }
}
```

When the generator detects the interface, it replaces the static `Projection` literal with a lazily-built `MemberInitExpression` so no `Invoke` nodes, fully EF Core-translatable.

## Behaviour

| Scenario | `Map()` | `ConfigureProjection()` | In `Projection`? |
|---|---|---|---|
| Computed scalar (`FullName`) | ✅ | ✅ | ✅ |
| DI-dependent (`AuditNote`) | ✅ | omitted | ❌ intentional |
| Auto-mapped scalar (`Id`) | ✅ (auto) | - | ✅ auto-generated binding |

## Limitations

- Expressions in `ConfigureProjection` must be EF Core-translatable. Facet cannot validate this at compile time.
- `ConfigureProjection` runs once at lazy init, no instance state or services.
- Nested facet bindings are not auto-generated in the lazy path; add them in `ConfigureProjection` if needed.