### PR TITLE
fix CS8601 and CS8602 warnings

### DIFF
--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -441,16 +441,30 @@ internal static class ExpressionBuilder
     }
 
     /// <summary>
-    /// Gets the appropriate default value for a collection type when depth is exceeded or null check fails.
+    /// Gets the appropriate default value for a collection type when depth is exceeded.
     /// For ImmutableArray (value type), returns default(ImmutableArray&lt;T&gt;).
-    /// For reference type collections, returns null!.
+    /// For other collections, returns an empty collection expression that matches the declared type.
     /// </summary>
     private static string GetCollectionDefaultValue(string collectionWrapper, string collectionTypeName)
     {
+        // Extract the element type from the collection type name for constructing empty collections
+        var elementType = ExtractElementTypeFromCollectionTypeName(collectionTypeName);
+
         return collectionWrapper switch
         {
             FacetConstants.CollectionWrappers.ImmutableArray => $"default({collectionTypeName})",
-            _ => "null!"
+            FacetConstants.CollectionWrappers.ImmutableList => $"global::System.Collections.Immutable.ImmutableList<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableHashSet => $"global::System.Collections.Immutable.ImmutableHashSet<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableSortedSet => $"global::System.Collections.Immutable.ImmutableSortedSet<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableQueue => $"global::System.Collections.Immutable.ImmutableQueue<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableStack => $"global::System.Collections.Immutable.ImmutableStack<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableList => $"global::System.Collections.Immutable.ImmutableList<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableSet => $"global::System.Collections.Immutable.ImmutableHashSet<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableQueue => $"global::System.Collections.Immutable.ImmutableQueue<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableStack => $"global::System.Collections.Immutable.ImmutableStack<{elementType}>.Empty",
+            FacetConstants.CollectionWrappers.Array => $"System.Array.Empty<{elementType}>()",
+            FacetConstants.CollectionWrappers.Collection => $"new global::System.Collections.ObjectModel.Collection<{elementType}>()",
+            _ => $"new global::System.Collections.Generic.List<{elementType}>()"
         };
     }
 

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -397,12 +397,11 @@ internal static class ModelBuilder
 
         if (!shouldTreatAsNullable && !property.Type.IsValueType)
         {
-            bool isExplicitlyNonNullable = property.Type.NullableAnnotation == NullableAnnotation.NotAnnotated &&
-                                            property.IsRequired;
-
-            if (!isExplicitlyNonNullable)
+            // NotAnnotated means the property is in a #nullable enable context and the
+            // type is explicitly declared as non-nullable. Respect the author's intent.
+            // None means nullable annotations are not enabled — treat as nullable for safety.
+            if (property.Type.NullableAnnotation != NullableAnnotation.NotAnnotated)
             {
-                // treat as potentially nullable for safety
                 shouldTreatAsNullable = true;
             }
         }

--- a/test/Facet.Tests/TestModels/FlattenTestModels.cs
+++ b/test/Facet.Tests/TestModels/FlattenTestModels.cs
@@ -265,7 +265,7 @@ public class DataEntity
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public ICollection<ExtendedEntity> Extended { get; set; } = new List<ExtendedEntity>();
+    public ICollection<ExtendedEntity>? Extended { get; set; }
 }
 
 public class ExtendedEntity

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -362,7 +362,8 @@ public partial class UserWithRequiredSettingsFacet
     public int ProcessedTicks => Settings.StopTick - Settings.StartTick;
 }
 
-// Test without required - should be nullable for safety
+// Test without required, in a #nullable enable context, the non-annotated property
+// is explicitly non-nullable and should be treated as such in the generated facet
 public class UserModelWithOptionalSettings
 {
     public int Id { get; set; }

--- a/test/Facet.Tests/UnitTests/Core/Facet/CircularReferenceTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CircularReferenceTests.cs
@@ -44,7 +44,8 @@ public class CircularReferenceTests
         bookFacet.Author.Name.Should().Be("John Doe");
 
         // At depth 2, Books is cut off to prevent going to level 3
-        bookFacet.Author.Books.Should().BeNull();
+        // Non-nullable collection properties get an empty collection instead of null
+        bookFacet.Author.Books.Should().BeEmpty();
     }
 
     [Fact]
@@ -78,7 +79,7 @@ public class CircularReferenceTests
         {
             book.Author.Should().NotBeNull();
             book.Author!.Name.Should().Be("Prolific Author");
-            book.Author.Books.Should().BeNull();
+            book.Author.Books.Should().BeEmpty();
         }
     }
 

--- a/test/Facet.Tests/UnitTests/Core/Facet/NestedFacetsWithCustomConfigurationTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/NestedFacetsWithCustomConfigurationTests.cs
@@ -23,8 +23,8 @@ public class CustomEmployeeSource
     public int Id { get; set; }
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
-    public CustomDepartmentSource Department { get; set; } = null!;
-    public CustomCompanySource Company { get; set; } = null!;
+    public CustomDepartmentSource? Department { get; set; }
+    public CustomCompanySource? Company { get; set; }
     public List<CustomEmployeeSource> DirectReports { get; set; } = new();
 }
 

--- a/test/Facet.Tests/UnitTests/Core/Facet/NullableForeignKeyTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/NullableForeignKeyTests.cs
@@ -1,19 +1,17 @@
 namespace Facet.Tests.UnitTests.Core.Facet;
 
-// Test entities that mimic EF Core entities with nullable foreign keys but non-nullable navigation properties
-// This is a common pattern where the FK is nullable but the navigation property is not marked with ?
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor
-
+// Test entities that mimic EF Core entities with nullable foreign keys
+// When the FK is nullable, the navigation property should also be nullable
 public class DataExampleEntity
 {
     public int Id { get; set; }
     public string Code { get; set; } = string.Empty;
 
     public int? StringResourceId { get; set; }
-    public virtual StringResourceEntity StringResource { get; set; }  // Non-nullable but can be null at runtime
+    public virtual StringResourceEntity? StringResource { get; set; }
 
     public int? ExtendedDataId { get; set; }
-    public virtual ExtendedDataEntity ExtendedData { get; set; }  // Non-nullable but can be null at runtime
+    public virtual ExtendedDataEntity? ExtendedData { get; set; }
 }
 
 public class StringResourceEntity
@@ -27,8 +25,6 @@ public class ExtendedDataEntity
     public int Id { get; set; }
     public string Metadata { get; set; } = string.Empty;
 }
-
-#pragma warning restore CS8618
 
 // Facet DTOs
 [Facet(typeof(StringResourceEntity))]


### PR DESCRIPTION
#332 fixes:

1. using static System.Collections.Immutable > Fixed `CollectStaticUsingTypes` in `CodeGenerationHelpers.cs` to extract the element type from generic brackets before determining the containing type.
2. Unnecessary new on FromSource > Split `BaseHidesFacetMembers` into two checks: one for Projection/ToSource/BackTo (hidden by name) and `BaseHidesFromSource`
3. Nullable annotation not respected > Fixed `ModelBuilder.cs` to treat `NullableAnnotation.NotAnnotated` as non-nullable regardless of required. Also fixed `GetCollectionDefaultValue` in `ExpressionBuilder.cs` to return empty collections instead of null! for non-nullable collection types at depth limits.