### PR TITLE
fix: CS1061 on multi source facet with GenerateToSource

### DIFF
--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -14,7 +14,7 @@ internal static class CodeBuilder
     /// <summary>
     /// Generates the complete source code for a facet type.
     /// </summary>
-    public static string Generate(FacetTargetModel model, Dictionary<string, FacetTargetModel> facetLookup)
+    public static string Generate(FacetTargetModel model, Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         var sb = new StringBuilder();
         GenerateFileHeader(sb);
@@ -138,7 +138,7 @@ internal static class CodeBuilder
         // Generate reverse mapping method (ToSource)
         if (model.GenerateToSource)
         {
-            ToSourceGenerator.Generate(sb, model);
+            ToSourceGenerator.Generate(sb, model, facetLookup);
         }
 
         // Generate FlattenTo methods
@@ -169,7 +169,7 @@ internal static class CodeBuilder
     /// </summary>
     public static string GenerateForGroup(
         IReadOnlyList<FacetTargetModel> models,
-        Dictionary<string, FacetTargetModel> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         if (models.Count == 1)
             return Generate(models[0], facetLookup);
@@ -191,7 +191,7 @@ internal static class CodeBuilder
     /// </summary>
     public static string GenerateCombined(
         IReadOnlyList<FacetTargetModel> models,
-        Dictionary<string, FacetTargetModel> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         var primaryModel = models[0];
         var sb = new StringBuilder();
@@ -328,7 +328,7 @@ internal static class CodeBuilder
             if (!model.GenerateToSource) continue;
 
             var toSourceName = GetToSourceMethodName(model, models);
-            ToSourceGenerator.Generate(sb, model, toSourceName);
+            ToSourceGenerator.Generate(sb, model, facetLookup, toSourceName);
         }
 
         // Per-source: FlattenTo

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -1,4 +1,5 @@
 using Facet.Generators.Shared;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Facet.Generators;
@@ -73,7 +74,9 @@ internal static class ExpressionBuilder
     /// For collection child facets, returns "this.PropertyName.Select(x => x.ToSource()).ToList()" with null checks if nullable.
     /// For regular members, returns "this.PropertyName" with nullable-to-non-nullable conversion if needed.
     /// </summary>
-    public static string GetToSourceValueExpression(FacetMember member)
+    /// <param name="facetLookup">Dictionary mapping facet type names to their model lists (for resolving multi-source nested facets).</param>
+    /// <param name="parentSourceTypeName">The source type name of the parent facet (used to determine which ToSource method to call for multi-source nested facets).</param>
+    public static string GetToSourceValueExpression(FacetMember member, Dictionary<string, List<FacetTargetModel>>? facetLookup = null, string? parentSourceTypeName = null)
     {
         // Check if the member type is nullable (ends with ?)
         bool facetTypeIsNullable = member.TypeName.Contains("?");
@@ -83,11 +86,11 @@ internal static class ExpressionBuilder
 
         if (member.IsNestedFacet && member.IsCollection)
         {
-            return BuildCollectionToSourceExpression(member, facetTypeIsNullable);
+            return BuildCollectionToSourceExpression(member, facetTypeIsNullable, facetLookup, parentSourceTypeName);
         }
         else if (member.IsNestedFacet)
         {
-            return BuildSingleToSourceExpression(member, facetTypeIsNullable);
+            return BuildSingleToSourceExpression(member, facetTypeIsNullable, facetLookup, parentSourceTypeName);
         }
 
         // Handle enum conversion (reverse: string/int back to enum)
@@ -300,10 +303,13 @@ internal static class ExpressionBuilder
         }
     }
 
-    private static string BuildCollectionToSourceExpression(FacetMember member, bool facetTypeIsNullable)
+    private static string BuildCollectionToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName)
     {
+        // Determine the correct ToSource method name for the nested facet
+        var toSourceMethodName = GetToSourceMethodName(member.TypeName, member.NestedFacetSourceTypeName, facetLookup, parentSourceTypeName);
+
         // Use LINQ Select to map each element back
-        var projection = $"this.{member.Name}.Select(x => x.ToSource())";
+        var projection = $"this.{member.Name}.Select(x => x.{toSourceMethodName}())";
 
         // Use the original source collection wrapper (before any CollectionTargetType override)
         // so that the generated expression produces the correct source type.
@@ -319,16 +325,19 @@ internal static class ExpressionBuilder
         return collectionExpression;
     }
 
-    private static string BuildSingleToSourceExpression(FacetMember member, bool facetTypeIsNullable)
+    private static string BuildSingleToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName)
     {
+        // Determine the correct ToSource method name for the nested facet
+        var toSourceMethodName = GetToSourceMethodName(member.TypeName, member.NestedFacetSourceTypeName, facetLookup, parentSourceTypeName);
+
         // Add null check for nullable nested facets
         if (facetTypeIsNullable)
         {
-            return $"this.{member.Name} != null ? this.{member.Name}.ToSource() : null";
+            return $"this.{member.Name} != null ? this.{member.Name}.{toSourceMethodName}() : null";
         }
 
         // Use the child facet's generated ToSource method
-        return $"this.{member.Name}.ToSource()";
+        return $"this.{member.Name}.{toSourceMethodName}()";
     }
 
     private static string WrapCollectionProjection(string projection, string collectionWrapper, string? elementTypeName = null)
@@ -466,6 +475,89 @@ internal static class ExpressionBuilder
             FacetConstants.CollectionWrappers.Collection => $"new global::System.Collections.ObjectModel.Collection<{elementType}>()",
             _ => $"new global::System.Collections.Generic.List<{elementType}>()"
         };
+    }
+
+    /// <summary>
+    /// Determines the correct ToSource method name for a nested facet, handling multi-source scenarios.
+    /// For single-source facets, returns "ToSource".
+    /// For multi-source facets, returns the source-specific method name like "ToUnitEntity".
+    /// </summary>
+    /// <param name="nestedFacetTypeName">The type name of the nested facet (may include nullable marker and generic arguments).</param>
+    /// <param name="nestedFacetSourceTypeName">The source type that the nested facet maps from.</param>
+    /// <param name="facetLookup">Dictionary mapping facet type names to their model lists.</param>
+    /// <param name="parentSourceTypeName">The source type name of the parent facet.</param>
+    /// <returns>The ToSource method name to call (e.g., "ToSource" or "ToUnitEntity").</returns>
+    private static string GetToSourceMethodName(
+        string nestedFacetTypeName,
+        string? nestedFacetSourceTypeName,
+        Dictionary<string, List<FacetTargetModel>>? facetLookup,
+        string? parentSourceTypeName)
+    {
+        // Default to "ToSource" if we don't have lookup information
+        if (facetLookup == null || nestedFacetSourceTypeName == null)
+            return "ToSource";
+
+        // Find the nested facet models in the lookup
+        var nestedFacetModels = FindNestedFacetModels(nestedFacetTypeName, facetLookup);
+        if (nestedFacetModels == null || nestedFacetModels.Count <= 1)
+        {
+            // Single-source facet: use the default "ToSource" method
+            return "ToSource";
+        }
+
+        // Multi-source facet: determine which ToSource method to call
+        // The method name is "To" + simple source type name
+        var sourceSimpleName = CodeGenerationHelpers.GetSimpleTypeName(nestedFacetSourceTypeName);
+        var angleBracket = sourceSimpleName.IndexOf('<');
+        if (angleBracket > 0)
+            sourceSimpleName = sourceSimpleName.Substring(0, angleBracket);
+
+        return "To" + sourceSimpleName;
+    }
+
+    /// <summary>
+    /// Finds the list of facet models for a given nested facet type name.
+    /// </summary>
+    private static List<FacetTargetModel>? FindNestedFacetModels(string typeName, Dictionary<string, List<FacetTargetModel>> facetLookup)
+    {
+        // Strip nullable marker and extract the non-nullable type name
+        var nonNullableTypeName = typeName.TrimEnd('?');
+
+        // For collection types, extract the element type
+        if (nonNullableTypeName.Contains('<'))
+        {
+            var elementType = ExtractElementTypeFromCollectionTypeName(nonNullableTypeName);
+            nonNullableTypeName = elementType;
+        }
+
+        // Strip "global::" prefix and extract simple name
+        var lookupName = nonNullableTypeName
+            .Replace(Shared.GeneratorUtilities.GlobalPrefix, "")
+            .Split('.', ':')
+            .Last();
+
+        // First try exact match with the lookup name
+        if (facetLookup.TryGetValue(lookupName, out var nestedFacetModels))
+        {
+            return nestedFacetModels;
+        }
+
+        // Try matching by simple name or full name
+        foreach (var kvp in facetLookup)
+        {
+            if (kvp.Value.Count > 0)
+            {
+                var model = kvp.Value[0];
+                if (kvp.Key == lookupName ||
+                    model.Name == lookupName ||
+                    kvp.Key.EndsWith("." + lookupName))
+                {
+                    return kvp.Value;
+                }
+            }
+        }
+
+        return null;
     }
 
     #endregion

--- a/src/Facet/Generators/FacetGenerators/FacetGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/FacetGenerator.cs
@@ -35,14 +35,12 @@ public sealed class FacetGenerator : IIncrementalGenerator
             spc.CancellationToken.ThrowIfCancellationRequested();
 
             // Build a lookup dictionary for nested facet resolution.
-            // When multiple models share the same FullName (multi-source scenario), only the first
-            // model is kept in the lookup; that is sufficient for nested-facet type resolution.
-            var facetLookup = new Dictionary<string, FacetTargetModel>();
-            foreach (var model in models)
-            {
-                if (model is not null && !facetLookup.ContainsKey(model.FullName))
-                    facetLookup[model.FullName] = model;
-            }
+            // Group all models by FullName to support multi-source facets (multiple [Facet] attributes on the same target).
+            // This allows nested facet resolution to determine the correct ToSource method name for multi-source scenarios.
+            var facetLookup = models
+                .Where(m => m is not null)
+                .GroupBy(m => m!.FullName)
+                .ToDictionary(g => g.Key, g => g.Select(m => m!).ToList());
 
             // Group models by target type FullName. Multiple models for the same target arise when
             // the target class carries more than one [Facet] attribute (different source types).

--- a/src/Facet/Generators/FacetGenerators/FlattenToGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/FlattenToGenerator.cs
@@ -13,7 +13,7 @@ internal static class FlattenToGenerator
     /// <summary>
     /// Generates FlattenTo methods for all configured flatten target types.
     /// </summary>
-    public static void Generate(StringBuilder sb, FacetTargetModel model, string indent, Dictionary<string, FacetTargetModel> facetLookup)
+    public static void Generate(StringBuilder sb, FacetTargetModel model, string indent, Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         if (model.FlattenToTypes.Length == 0) return;
 
@@ -24,7 +24,7 @@ internal static class FlattenToGenerator
         }
     }
 
-    private static void GenerateFlattenToMethod(StringBuilder sb, FacetTargetModel model, string flattenToType, string indent, Dictionary<string, FacetTargetModel> facetLookup)
+    private static void GenerateFlattenToMethod(StringBuilder sb, FacetTargetModel model, string flattenToType, string indent, Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         // Extract the simple name from the fully qualified type name
         var flattenToTypeName = ExtractSimpleName(flattenToType);
@@ -121,28 +121,28 @@ internal static class FlattenToGenerator
         sb.AppendLine($"{indent}}}");
     }
 
-    private static FacetTargetModel? FindFacetModel(string typeName, Dictionary<string, FacetTargetModel> facetLookup)
+    private static FacetTargetModel? FindFacetModel(string typeName, Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         if (string.IsNullOrEmpty(typeName)) return null;
 
         // Try the exact name first
-        if (facetLookup.TryGetValue(typeName, out var facet))
+        if (facetLookup.TryGetValue(typeName, out var facetModels) && facetModels.Count > 0)
         {
-            return facet;
+            return facetModels[0];
         }
 
         // Try just the simple name
         var simpleName = ExtractSimpleName(typeName);
-        if (facetLookup.TryGetValue(simpleName, out facet))
+        if (facetLookup.TryGetValue(simpleName, out facetModels) && facetModels.Count > 0)
         {
-            return facet;
+            return facetModels[0];
         }
 
         // Try without global:: prefix
         var withoutGlobal = typeName.Replace("global::", "");
-        if (facetLookup.TryGetValue(withoutGlobal, out facet))
+        if (facetLookup.TryGetValue(withoutGlobal, out facetModels) && facetModels.Count > 0)
         {
-            return facet;
+            return facetModels[0];
         }
 
         return null;
@@ -150,7 +150,7 @@ internal static class FlattenToGenerator
 
     private static void CollectLeafNames(
         FacetTargetModel facet,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         List<FacetMember> parentMembers,
         List<string> pathSegments,
         Dictionary<string, int> leafNameCounts,
@@ -215,7 +215,7 @@ internal static class FlattenToGenerator
     private static void CollectNestedProperties(
         StringBuilder sb,
         FacetTargetModel facet,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         List<FacetMember> parentMembers,
         string navigationPath,
         List<string> pathSegments,

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -22,7 +22,7 @@ internal static class ProjectionGenerator
         StringBuilder sb,
         FacetTargetModel model,
         string memberIndent,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         string? projectionPropertyName = null)
     {
         var propertyName = projectionPropertyName ?? "Projection";
@@ -57,7 +57,7 @@ internal static class ProjectionGenerator
         StringBuilder sb,
         FacetTargetModel model,
         string memberIndent,
-        Dictionary<string, FacetTargetModel> _,
+        Dictionary<string, List<FacetTargetModel>> _,
         string propertyName = "Projection")
     {
         var newModifier = model.BaseHidesFacetMembers ? "new " : "";
@@ -195,7 +195,7 @@ internal static class ProjectionGenerator
         StringBuilder sb,
         FacetTargetModel model,
         string baseIndent,
-        Dictionary<string, FacetTargetModel> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         var indent = baseIndent + "    ";
         
@@ -224,7 +224,7 @@ internal static class ProjectionGenerator
         StringBuilder sb,
         FacetTargetModel model,
         string indent,
-        Dictionary<string, FacetTargetModel> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         var visitedTypes = new HashSet<string> { model.Name };
         var includedMembers = model.Members.Where(m => m.MapFromIncludeInProjection).ToArray();
@@ -251,7 +251,7 @@ internal static class ProjectionGenerator
         StringBuilder sb,
         FacetTargetModel model,
         string indent,
-        Dictionary<string, FacetTargetModel> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         sb.AppendLine($"{indent}source => new {model.Name}");
         sb.AppendLine($"{indent}{{");
@@ -291,7 +291,7 @@ internal static class ProjectionGenerator
         FacetMember member,
         string sourceVariableName,
         string indent,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         HashSet<string> visitedTypes,
         int currentDepth = 0,
         int maxDepth = 0)
@@ -344,7 +344,7 @@ internal static class ProjectionGenerator
         FacetMember member,
         string sourceVariableName,
         bool isNullable,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         HashSet<string> visitedTypes,
         int currentDepth,
         int maxDepth)
@@ -386,7 +386,7 @@ internal static class ProjectionGenerator
         string sourceVariableName,
         bool isNullable,
         string indent,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         HashSet<string> visitedTypes,
         int currentDepth,
         int maxDepth)
@@ -470,7 +470,7 @@ internal static class ProjectionGenerator
         string sourceExpression,
         string facetTypeName,
         string indent,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         HashSet<string> visitedTypes,
         int currentDepth = 0,
         int maxDepth = 0)
@@ -503,7 +503,7 @@ internal static class ProjectionGenerator
         string elementFacetTypeName,
         string elementSourceTypeName,
         string collectionWrapper,
-        Dictionary<string, FacetTargetModel> facetLookup,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
         HashSet<string> visitedTypes,
         int currentDepth = 0,
         int maxDepth = 0)
@@ -583,7 +583,7 @@ internal static class ProjectionGenerator
         };
     }
 
-    private static FacetTargetModel? FindNestedFacetModel(string typeName, Dictionary<string, FacetTargetModel> facetLookup)
+    private static FacetTargetModel? FindNestedFacetModel(string typeName, Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
         // Strip "global::" prefix and extract simple name
         var lookupName = typeName
@@ -592,19 +592,25 @@ internal static class ProjectionGenerator
             .Last();
 
         // First try exact match with the lookup name
-        if (facetLookup.TryGetValue(lookupName, out var nestedFacetModel))
+        if (facetLookup.TryGetValue(lookupName, out var nestedFacetModels) && nestedFacetModels.Count > 0)
         {
-            return nestedFacetModel;
+            // For projection purposes, the first model is sufficient since all models with the same
+            // FullName share the same structure (union of all members)
+            return nestedFacetModels[0];
         }
 
         // Try matching by simple name or full name
         foreach (var kvp in facetLookup)
         {
-            if (kvp.Key == lookupName ||
-                kvp.Value.Name == lookupName ||
-                kvp.Key.EndsWith("." + lookupName))
+            if (kvp.Value.Count > 0)
             {
-                return kvp.Value;
+                var model = kvp.Value[0];
+                if (kvp.Key == lookupName ||
+                    model.Name == lookupName ||
+                    kvp.Key.EndsWith("." + lookupName))
+                {
+                    return model;
+                }
             }
         }
 

--- a/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
@@ -13,13 +13,16 @@ internal static class ToSourceGenerator
     /// <summary>
     /// Generates the ToSource and BackTo methods that convert the facet type back to the source type.
     /// </summary>
+    /// <param name="facetLookup">
+    /// Dictionary mapping facet type names to their model lists (for resolving multi-source nested facets).
+    /// </param>
     /// <param name="toSourceMethodName">
     /// The name to use for the generated method.
     /// When <see langword="null"/>, the default names <c>ToSource</c> and <c>BackTo</c> are used.
     /// When provided (for multi-source facets), only the specified method is generated without the
     /// deprecated <c>BackTo</c> alias.
     /// </param>
-    public static void Generate(StringBuilder sb, FacetTargetModel model, string? toSourceMethodName = null)
+    public static void Generate(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? toSourceMethodName = null)
     {
         var methodName = toSourceMethodName ?? "ToSource";
         var isCustomName = toSourceMethodName != null;
@@ -35,11 +38,11 @@ internal static class ToSourceGenerator
 
         if (model.SourceHasPositionalConstructor)
         {
-            GeneratePositionalToSource(sb, model);
+            GeneratePositionalToSource(sb, model, facetLookup);
         }
         else
         {
-            GenerateObjectInitializerToSource(sb, model);
+            GenerateObjectInitializerToSource(sb, model, facetLookup);
         }
 
         sb.AppendLine("    }");
@@ -57,12 +60,12 @@ internal static class ToSourceGenerator
         }
     }
 
-    private static void GeneratePositionalToSource(StringBuilder sb, FacetTargetModel model)
+    private static void GeneratePositionalToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup)
     {
         var constructorArgs = string.Join(", ",
             model.Members
                 .Where(m => m.MapFromReversible)
-                .Select(m => ExpressionBuilder.GetToSourceValueExpression(m)));
+                .Select(m => ExpressionBuilder.GetToSourceValueExpression(m, facetLookup, model.SourceTypeName)));
 
         if (model.ToSourceConfigurationTypeName != null)
         {
@@ -76,7 +79,7 @@ internal static class ToSourceGenerator
         }
     }
 
-    private static void GenerateObjectInitializerToSource(StringBuilder sb, FacetTargetModel model)
+    private static void GenerateObjectInitializerToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup)
     {
         var propertyAssignments = new List<string>();
 
@@ -85,7 +88,7 @@ internal static class ToSourceGenerator
             if (!member.MapFromReversible)
                 continue;
 
-            var toSourceValue = ExpressionBuilder.GetToSourceValueExpression(member);
+            var toSourceValue = ExpressionBuilder.GetToSourceValueExpression(member, facetLookup, model.SourceTypeName);
             propertyAssignments.Add($"            {member.SourcePropertyName} = {toSourceValue}");
         }
 

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -339,3 +339,25 @@ public partial class MultiSourceWithToSourceDto;
 [Facet(typeof(MultiSourceEntityA))]
 [Facet(typeof(MultiSourceEntityB))]
 public partial class MultiSourceUnionDto;
+
+/// <summary>
+/// Multi-source nested facet that can map from either UnitDto or UnitEntity.
+/// This is used as a nested property in OrderLineBaseUpsertDto.
+/// </summary>
+[Facet(typeof(UnitDto),
+       GenerateToSource = true,
+       Include = new[] { nameof(UnitDto.Name), nameof(UnitDto.ValidationResult) })]
+[Facet(typeof(UnitEntity),
+       GenerateToSource = true,
+       Include = new[] { nameof(UnitEntity.Name), nameof(UnitEntity.ValidationResult) })]
+public partial class UnitDropDownDto;
+
+/// <summary>
+/// Parent facet that uses UnitDropDownDto (a multi-source facet) as a nested property.
+/// Tests that ToSource() correctly calls the appropriate ToSource method on the nested facet.
+/// </summary>
+[Facet(typeof(OrderLineBaseEntity),
+       GenerateToSource = true,
+       Include = new[] { nameof(OrderLineBaseEntity.AssignedToUnit), nameof(OrderLineBaseEntity.Number) },
+       NestedFacets = new[] { typeof(UnitDropDownDto) })]
+public partial class OrderLineBaseUpsertDto;

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -473,3 +473,27 @@ public record MultiSourceEntityC
     public required string Name { get; init; }
 }
 
+/// <summary>Unit DTO - one of the sources for the multi-source nested facet.</summary>
+public class UnitDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ValidationResult { get; set; } = string.Empty;
+}
+
+/// <summary>Unit entity - another source for the multi-source nested facet.</summary>
+public class UnitEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ValidationResult { get; set; } = string.Empty;
+}
+
+/// <summary>Order line entity - contains a UnitEntity as a nested property.</summary>
+public class OrderLineBaseEntity
+{
+    public int Id { get; set; }
+    public string Number { get; set; } = string.Empty;
+    public UnitEntity? AssignedToUnit { get; set; }
+}
+

--- a/test/Facet.Tests/UnitTests/Core/Facet/MultiSourceMappingTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/MultiSourceMappingTests.cs
@@ -139,4 +139,82 @@ public class MultiSourceMappingTests
         dto.Name.Should().Be("Eight");
         dto.OnlyInB.Should().Be("bbb");
     }
+
+    [Fact]
+    public void NestedMultiSourceFacet_ToSource_ShouldCallCorrectSourceSpecificMethod()
+    {
+        // Arrange: Create a parent DTO with a nested multi-source facet
+        var orderLine = new OrderLineBaseEntity
+        {
+            Id = 1,
+            Number = "ORD-001",
+            AssignedToUnit = new UnitEntity
+            {
+                Id = 100,
+                Name = "Production Unit",
+                ValidationResult = "Valid"
+            }
+        };
+
+        var dto = new OrderLineBaseUpsertDto(orderLine);
+
+        // Verify the DTO was constructed correctly
+        dto.Number.Should().Be("ORD-001");
+        dto.AssignedToUnit.Should().NotBeNull();
+        dto.AssignedToUnit!.Name.Should().Be("Production Unit");
+        dto.AssignedToUnit.ValidationResult.Should().Be("Valid");
+
+        // Act: Call ToSource on the parent DTO
+        // This should internally call ToUnitEntity() on the nested multi-source facet
+        var result = dto.ToSource();
+
+        // Assert: Verify the parent entity was reconstructed correctly
+        result.Number.Should().Be("ORD-001");
+        result.AssignedToUnit.Should().NotBeNull();
+        result.AssignedToUnit!.Name.Should().Be("Production Unit");
+        result.AssignedToUnit.ValidationResult.Should().Be("Valid");
+    }
+
+    [Fact]
+    public void NestedMultiSourceFacet_WithNullNestedProperty_ShouldHandleCorrectly()
+    {
+        // Arrange: Create a parent DTO with null nested property
+        var dto = new OrderLineBaseUpsertDto
+        {
+            Number = "ORD-002",
+            AssignedToUnit = null
+        };
+
+        // Act: Call ToSource on the parent DTO with null nested property
+        var result = dto.ToSource();
+
+        // Assert: Verify null is preserved
+        result.Number.Should().Be("ORD-002");
+        result.AssignedToUnit.Should().BeNull();
+    }
+
+    [Fact]
+    public void MultiSourceNestedFacet_ShouldGenerateSourceSpecificToSourceMethods()
+    {
+        // Verify that UnitDropDownDto (multi-source facet) generates source-specific ToSource methods
+        var unitDropDown = new UnitDropDownDto
+        {
+            Name = "Test Unit",
+            ValidationResult = "Passed"
+        };
+
+        // Should have ToUnitDto() method
+        var unitDto = unitDropDown.ToUnitDto();
+        unitDto.Name.Should().Be("Test Unit");
+        unitDto.ValidationResult.Should().Be("Passed");
+
+        // Should have ToUnitEntity() method
+        var unitEntity = unitDropDown.ToUnitEntity();
+        unitEntity.Name.Should().Be("Test Unit");
+        unitEntity.ValidationResult.Should().Be("Passed");
+
+        var methods = typeof(UnitDropDownDto).GetMethods();
+        methods.Should().Contain(m => m.Name == "ToUnitDto");
+        methods.Should().Contain(m => m.Name == "ToUnitEntity");
+    }
 }


### PR DESCRIPTION
When using a multi-source facet (a class with multiple `[Facet]` attributes) as a nested property in a parent facet with `GenerateToSource = true`, the generated code failed to compile with error.

### Example

```csharp
[Facet(typeof(UnitDto), GenerateToSource = true, Include = [...])]
[Facet(typeof(UnitEntity), GenerateToSource = true, Include = [...])]
public partial class UnitDropDownDto;

// Parent facet using the multi-source nested facet
[Facet(typeof(OrderLineBaseEntity), GenerateToSource = true,
       Include = [...],
       NestedFacets = [typeof(UnitDropDownDto)])]
public partial class OrderLineBaseUpsertDto;
```

## This was broken:

```csharp
public OrderLineBaseEntity ToSource()
{
    return new OrderLineBaseEntity
    {
        AssignedToUnit = this.AssignedToUnit != null
            ? this.AssignedToUnit.ToSource() // -> failure
            : null
    };
}
```

The generator now:
1. Detects when a nested facet has multiple source mappings
2. Determines the correct source type based on the parent's source type
3. Calls the appropriate source-specific method (e.g., `.ToUnitEntity()`)

```csharp
public OrderLineBaseEntity ToSource()
{
    return new OrderLineBaseEntity
    {
        AssignedToUnit = this.AssignedToUnit != null
            ? this.AssignedToUnit.ToUnitEntity() // this is OK
            : null
    };
}
```

## Additional Notes

- The order of `[Facet]` attributes on multi-source classes no longer affects code generation behavior
- Works for both single nested facets and collections of nested facets
- Maintains backward compatibility with single-source facets

Asserted and replicated with new test models and unit tests

Closes #335 (again)