### PR TITLE
fix: Inherited Facet Projection Mappings Not Applied

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -6,6 +6,34 @@ using System.Linq;
 
 namespace Facet;
 
+/// <summary>
+/// Information about a base Facet class that the current Facet inherits from.
+/// </summary>
+internal sealed class BaseFacetInfo
+{
+    /// <summary>
+    /// The fully qualified name of the base Facet class.
+    /// </summary>
+    public string BaseTypeName { get; }
+
+    /// <summary>
+    /// The fully qualified name of the base Facet's source type.
+    /// </summary>
+    public string BaseSourceTypeName { get; }
+
+    /// <summary>
+    /// The configuration type name for the base Facet (if it has ConfigureProjection).
+    /// </summary>
+    public string? BaseConfigurationTypeName { get; }
+
+    public BaseFacetInfo(string baseTypeName, string baseSourceTypeName, string? baseConfigurationTypeName)
+    {
+        BaseTypeName = baseTypeName;
+        BaseSourceTypeName = baseSourceTypeName;
+        BaseConfigurationTypeName = baseConfigurationTypeName;
+    }
+}
+
 internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
 {
     public string Name { get; }
@@ -90,6 +118,11 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     /// </summary>
     public bool HasMapConfiguration { get; }
 
+    /// <summary>
+    /// Information about the base Facet class, if the target inherits from another Facet.
+    /// </summary>
+    public BaseFacetInfo? BaseFacetInfo { get; }
+
     public FacetTargetModel(
         string name,
         string? @namespace,
@@ -127,7 +160,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         bool baseHidesFacetMembers = false,
         bool hasProjectionMapConfiguration = false,
         bool baseHidesFromSource = false,
-        bool hasMapConfiguration = false)
+        bool hasMapConfiguration = false,
+        BaseFacetInfo? baseFacetInfo = null)
     {
         Name = name;
         Namespace = @namespace;
@@ -166,6 +200,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         HasProjectionMapConfiguration = hasProjectionMapConfiguration;
         HasMapConfiguration = hasMapConfiguration;
         BaseHidesFromSource = baseHidesFromSource;
+        BaseFacetInfo = baseFacetInfo;
     }
 
     public bool Equals(FacetTargetModel? other)

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -414,13 +414,33 @@ internal static class CodeBuilder
 
         var innerIndent = bodyIndent + "    ";
 
-        sb.AppendLine($"{innerIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
-        sb.AppendLine($"{innerIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
-        sb.AppendLine();
         sb.AppendLine($"{innerIndent}var __sourceParam = global::System.Linq.Expressions.Expression.Parameter(typeof({src}), \"source\");");
         sb.AppendLine($"{innerIndent}var __targetParam = global::System.Linq.Expressions.Expression.Parameter(typeof({tgt}), \"target\");");
         sb.AppendLine($"{innerIndent}var __assignments = new global::System.Collections.Generic.List<global::System.Linq.Expressions.Expression>();");
         sb.AppendLine();
+
+        // Apply base Facet ConfigureProjection if present
+        if (model.BaseFacetInfo?.BaseConfigurationTypeName != null)
+        {
+            sb.AppendLine($"{innerIndent}// Apply base Facet projection mappings");
+            sb.AppendLine($"{innerIndent}var __baseBuilder = new global::Facet.Mapping.FacetProjectionBuilder<{model.BaseFacetInfo.BaseSourceTypeName}, {model.BaseFacetInfo.BaseTypeName}>();");
+            sb.AppendLine($"{innerIndent}{model.BaseFacetInfo.BaseConfigurationTypeName}.ConfigureProjection(__baseBuilder);");
+            sb.AppendLine($"{innerIndent}foreach (var (__member, __expr) in __baseBuilder.Mappings)");
+            sb.AppendLine($"{innerIndent}{{");
+            sb.AppendLine($"{innerIndent}    var __derivedMember = typeof({tgt}).GetProperty(__member.Name);");
+            sb.AppendLine($"{innerIndent}    if (__derivedMember != null)");
+            sb.AppendLine($"{innerIndent}    {{");
+            sb.AppendLine($"{innerIndent}        var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __sourceParam);");
+            sb.AppendLine($"{innerIndent}        __assignments.Add(global::System.Linq.Expressions.Expression.Assign(");
+            sb.AppendLine($"{innerIndent}            global::System.Linq.Expressions.Expression.MakeMemberAccess(__targetParam, __derivedMember), __body));");
+            sb.AppendLine($"{innerIndent}    }}");
+            sb.AppendLine($"{innerIndent}}}");
+            sb.AppendLine();
+        }
+
+        // Apply derived ConfigureProjection
+        sb.AppendLine($"{innerIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
+        sb.AppendLine($"{innerIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
         sb.AppendLine($"{innerIndent}foreach (var (__member, __expr) in __builder.Mappings)");
         sb.AppendLine($"{innerIndent}{{");
         sb.AppendLine($"{innerIndent}    var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __sourceParam);");

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -255,6 +255,7 @@ internal static class ModelBuilder
         var sourceTypeFullName = sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var baseHidesFacetMembers = BaseHidesFacetMembers(targetSymbol);
         var baseHidesFromSource = BaseHidesFromSource(targetSymbol, sourceTypeFullName);
+        var baseFacetInfo = GetBaseFacetInfo(targetSymbol, context.SemanticModel.Compilation);
 
         return new FacetTargetModel(
             targetSymbol.Name,
@@ -293,7 +294,8 @@ internal static class ModelBuilder
             baseHidesFacetMembers,
             hasProjectionMapConfiguration,
             baseHidesFromSource,
-            hasMapConfiguration);
+            hasMapConfiguration,
+            baseFacetInfo);
     }
 
     #region Private Helper Methods
@@ -1083,6 +1085,66 @@ private static Dictionary<string, (string targetName, string source, bool revers
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Gets information about the base Facet class if the target inherits from another Facet.
+    /// Returns null if the base class is not a Facet.
+    /// </summary>
+    private static BaseFacetInfo? GetBaseFacetInfo(INamedTypeSymbol targetSymbol, Compilation compilation)
+    {
+        var baseType = targetSymbol.BaseType;
+        while (baseType != null && baseType.SpecialType != SpecialType.System_Object)
+        {
+            // Check if the base class has the [Facet] attribute
+            var facetAttr = baseType.GetAttributes().FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == FacetConstants.FacetAttributeFullName);
+
+            if (facetAttr != null)
+            {
+                // Extract the source type from the [Facet] attribute
+                if (facetAttr.ConstructorArguments.Length > 0)
+                {
+                    var baseSourceType = facetAttr.ConstructorArguments[0].Value as INamedTypeSymbol;
+                    if (baseSourceType != null)
+                    {
+                        var baseTypeName = baseType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                        var baseSourceTypeName = baseSourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+                        // Extract the Configuration type if specified
+                        string? baseConfigurationTypeName = null;
+                        var configArg = facetAttr.NamedArguments.FirstOrDefault(arg => arg.Key == "Configuration");
+                        if (!configArg.Equals(default(KeyValuePair<string, TypedConstant>)))
+                        {
+                            var configType = configArg.Value.Value as INamedTypeSymbol;
+                            if (configType != null)
+                            {
+                                // Check if it implements IFacetProjectionMapConfiguration
+                                var projectionMapConfigInterface = compilation.GetTypeByMetadataName(
+                                    "Facet.Mapping.IFacetProjectionMapConfiguration`2");
+
+                                if (projectionMapConfigInterface != null)
+                                {
+                                    var implementsProjectionConfig = configType.AllInterfaces.Any(i =>
+                                        SymbolEqualityComparer.Default.Equals(i.ConstructedFrom, projectionMapConfigInterface));
+
+                                    if (implementsProjectionConfig)
+                                    {
+                                        baseConfigurationTypeName = configType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                                    }
+                                }
+                            }
+                        }
+
+                        return new BaseFacetInfo(baseTypeName, baseSourceTypeName, baseConfigurationTypeName);
+                    }
+                }
+            }
+
+            baseType = baseType.BaseType;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -109,7 +109,27 @@ internal static class ProjectionGenerator
         sb.AppendLine($"{bodyIndent}}};");
         sb.AppendLine();
 
-        // Apply ConfigureProjection overrides
+        // Apply base Facet ConfigureProjection if present
+        if (model.BaseFacetInfo?.BaseConfigurationTypeName != null)
+        {
+            sb.AppendLine($"{bodyIndent}// Apply base Facet projection mappings");
+            sb.AppendLine($"{bodyIndent}var __baseBuilder = new global::Facet.Mapping.FacetProjectionBuilder<{model.BaseFacetInfo.BaseSourceTypeName}, {model.BaseFacetInfo.BaseTypeName}>();");
+            sb.AppendLine($"{bodyIndent}{model.BaseFacetInfo.BaseConfigurationTypeName}.ConfigureProjection(__baseBuilder);");
+            sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __baseBuilder.Mappings)");
+            sb.AppendLine($"{bodyIndent}{{");
+            sb.AppendLine($"{bodyIndent}    // Get the corresponding member in the derived type");
+            sb.AppendLine($"{bodyIndent}    var __derivedMember = typeof({tgt}).GetProperty(__member.Name);");
+            sb.AppendLine($"{bodyIndent}    if (__derivedMember != null)");
+            sb.AppendLine($"{bodyIndent}    {{");
+            sb.AppendLine($"{bodyIndent}        var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __p);");
+            sb.AppendLine($"{bodyIndent}        __bindings.RemoveAll(b => ((global::System.Linq.Expressions.MemberAssignment)b).Member.Name == __derivedMember.Name);");
+            sb.AppendLine($"{bodyIndent}        __bindings.Add(global::System.Linq.Expressions.Expression.Bind(__derivedMember, __body));");
+            sb.AppendLine($"{bodyIndent}    }}");
+            sb.AppendLine($"{bodyIndent}}}");
+            sb.AppendLine();
+        }
+
+        // Apply ConfigureProjection overrides from derived class
         sb.AppendLine($"{bodyIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
         sb.AppendLine($"{bodyIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
         sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __builder.Mappings)");

--- a/test/Facet.Tests/UnitTests/Core/Facet/InheritedFacetProjectionTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/InheritedFacetProjectionTests.cs
@@ -1,0 +1,153 @@
+using System.Linq.Expressions;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>Base entity.</summary>
+public class OrderLineBaseEntity338
+{
+    public int Id { get; set; }
+    public string Number { get; set; } = string.Empty;
+    public DateTime ExpectedStartTime { get; set; }
+}
+
+/// <summary>Derived entity that adds dispatch-specific properties.</summary>
+public class OrderLineDispatchEntity338 : OrderLineBaseEntity338
+{
+    public DateTime DeliveryTime { get; set; }
+    public DateTime ShipmentTime { get; set; }
+}
+
+public class ModifiedByBaseDto338
+{
+    public int Id { get; set; }
+}
+
+[Facet(typeof(OrderLineBaseEntity338),
+       Configuration = typeof(OrderLineBaseDto338MapConfig),
+       Include = new[]
+       {
+           nameof(OrderLineBaseEntity338.Number),
+           nameof(OrderLineBaseEntity338.ExpectedStartTime)
+       })]
+public partial class OrderLineBaseDto338 : ModifiedByBaseDto338
+{
+}
+
+public class OrderLineBaseDto338MapConfig
+    : IFacetProjectionMapConfiguration<OrderLineBaseEntity338, OrderLineBaseDto338>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<OrderLineBaseEntity338, OrderLineBaseDto338> builder)
+    {
+        // Map base properties (these should appear in derived projection too)
+        builder.Map(d => d.Number, s => "ORD-" + s.Number);
+        builder.Map(d => d.ExpectedStartTime, s => s.ExpectedStartTime.AddHours(1));
+    }
+}
+
+[Facet(typeof(OrderLineDispatchEntity338),
+       Configuration = typeof(OrderLineDispatchDto338MapConfig),
+       Include = new[]
+       {
+           nameof(OrderLineDispatchEntity338.DeliveryTime),
+           nameof(OrderLineDispatchEntity338.ShipmentTime)
+       })]
+public partial class OrderLineDispatchDto338 : OrderLineBaseDto338
+{
+}
+
+public class OrderLineDispatchDto338MapConfig
+    : IFacetProjectionMapConfiguration<OrderLineDispatchEntity338, OrderLineDispatchDto338>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<OrderLineDispatchEntity338, OrderLineDispatchDto338> builder)
+    {
+        // Map dispatch-specific properties
+        builder.Map(d => d.DeliveryTime, s => s.DeliveryTime.AddHours(2));
+        builder.Map(d => d.ShipmentTime, s => s.ShipmentTime.AddHours(3));
+    }
+}
+
+public class InheritedFacetProjectionTests
+{
+    [Fact]
+    public void Projection_WithInheritedFacetBase_ShouldMapAllProperties()
+    {
+        // Arrange
+        var baseTime = new DateTime(2024, 1, 1, 10, 0, 0);
+        var entity = new OrderLineDispatchEntity338
+        {
+            Id = 1,
+            Number = "123",
+            ExpectedStartTime = baseTime,
+            DeliveryTime = baseTime.AddDays(1),
+            ShipmentTime = baseTime.AddDays(2)
+        };
+
+        // Act - Use projection
+        var projection = OrderLineDispatchDto338.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Properties from derived class should be mapped
+        dto.DeliveryTime.Should().Be(baseTime.AddDays(1).AddHours(2),
+            "DeliveryTime should be mapped with +2 hours from ConfigureProjection");
+        dto.ShipmentTime.Should().Be(baseTime.AddDays(2).AddHours(3),
+            "ShipmentTime should be mapped with +3 hours from ConfigureProjection");
+
+        // Assert - Properties from base FACET class should ALSO be mapped
+        dto.Number.Should().Be("ORD-123",
+            "Number should be mapped from base facet's ConfigureProjection with 'ORD-' prefix");
+        dto.ExpectedStartTime.Should().Be(baseTime.AddHours(1),
+            "ExpectedStartTime should be mapped from base facet's ConfigureProjection with +1 hour");
+
+        // Assert - Property from non-facet base should be mapped
+        dto.Id.Should().Be(1, "Id from non-facet base should be mapped");
+    }
+
+    [Fact]
+    public void Constructor_WithInheritedFacetBase_ShouldMapAllProperties()
+    {
+        // Arrange
+        var baseTime = new DateTime(2024, 1, 1, 10, 0, 0);
+        var entity = new OrderLineDispatchEntity338
+        {
+            Id = 2,
+            Number = "456",
+            ExpectedStartTime = baseTime,
+            DeliveryTime = baseTime.AddDays(1),
+            ShipmentTime = baseTime.AddDays(2)
+        };
+
+        // Act - Use constructor
+        var dto = new OrderLineDispatchDto338(entity);
+
+        // Assert - All properties should be mapped (constructor uses ConfigureMap)
+        dto.Id.Should().Be(2);
+        dto.Number.Should().Be("ORD-456");
+        dto.ExpectedStartTime.Should().Be(baseTime.AddHours(1));
+        dto.DeliveryTime.Should().Be(baseTime.AddDays(1).AddHours(2));
+        dto.ShipmentTime.Should().Be(baseTime.AddDays(2).AddHours(3));
+    }
+
+    [Fact]
+    public void BaseProjection_ShouldMapBaseProperties()
+    {
+        // Arrange
+        var baseTime = new DateTime(2024, 1, 1, 10, 0, 0);
+        var entity = new OrderLineBaseEntity338
+        {
+            Id = 3,
+            Number = "789",
+            ExpectedStartTime = baseTime
+        };
+
+        // Act - Use base projection directly
+        var projection = OrderLineBaseDto338.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert
+        dto.Id.Should().Be(3);
+        dto.Number.Should().Be("ORD-789");
+        dto.ExpectedStartTime.Should().Be(baseTime.AddHours(1));
+    }
+}


### PR DESCRIPTION
Fixes #338

When a Facet class inherited from another Facet class with custom `ConfigureProjection` mappings, the base Facet's projection mappings were not being applied to the derived Facet's projections. This caused properties mapped in the base configuration to be missing or incorrectly mapped in derived projections.

## Root Cause

The projection generator only invoked the derived class's `ConfigureProjection` method, completely ignoring any base Facet's custom projection mappings defined via `IFacetProjectionMapConfiguration`.

--

Modified the source generator to detect and apply base Facet projection mappings:

1. **Added `BaseFacetInfo` class** to track base Facet metadata (base type, source type, and configuration type)

2. **Enhanced `ModelBuilder.GetBaseFacetInfo()`** to detect when a Facet inherits from another Facet and extract its configuration type

3. **Updated projection generation** (`ProjectionGenerator.cs` and `CodeBuilder.cs`) to:
   - First call the base Facet's `ConfigureProjection` method
   - Apply base mappings to derived type properties with matching names
   - Then call the derived Facet's `ConfigureProjection` to allow overrides