### PR TITLE
fix: Projection with inherited Facet class doesn't populate properties

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -26,11 +26,17 @@ internal sealed class BaseFacetInfo
     /// </summary>
     public string? BaseConfigurationTypeName { get; }
 
-    public BaseFacetInfo(string baseTypeName, string baseSourceTypeName, string? baseConfigurationTypeName)
+    /// <summary>
+    /// The Include properties specified in the base Facet's [Facet] attribute.
+    /// </summary>
+    public ImmutableArray<string> IncludedMembers { get; }
+
+    public BaseFacetInfo(string baseTypeName, string baseSourceTypeName, string? baseConfigurationTypeName, ImmutableArray<string> includedMembers)
     {
         BaseTypeName = baseTypeName;
         BaseSourceTypeName = baseSourceTypeName;
         BaseConfigurationTypeName = baseConfigurationTypeName;
+        IncludedMembers = includedMembers;
     }
 }
 

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -160,6 +160,18 @@ internal static class ModelBuilder
         // Collect base class member names early, needed by ExtractMembers to auto-include
         var baseClassMemberNames = GetBaseClassMemberNames(targetSymbol);
 
+        // Get base Facet info early so we can merge Include properties from the base Facet
+        var baseFacetInfo = GetBaseFacetInfo(targetSymbol, context.SemanticModel.Compilation);
+
+        // If the target inherits from another Facet that has Include properties, merge them
+        if (baseFacetInfo != null && !baseFacetInfo.IncludedMembers.IsDefaultOrEmpty)
+        {
+            foreach (var baseIncludedMember in baseFacetInfo.IncludedMembers)
+            {
+                included.Add(baseIncludedMember);
+            }
+        }
+
         // Build members
         var (members, excludedRequiredMembers) = ExtractMembers(
             sourceType,
@@ -255,7 +267,6 @@ internal static class ModelBuilder
         var sourceTypeFullName = sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var baseHidesFacetMembers = BaseHidesFacetMembers(targetSymbol);
         var baseHidesFromSource = BaseHidesFromSource(targetSymbol, sourceTypeFullName);
-        var baseFacetInfo = GetBaseFacetInfo(targetSymbol, context.SemanticModel.Compilation);
 
         return new FacetTargetModel(
             targetSymbol.Name,
@@ -1136,7 +1147,10 @@ private static Dictionary<string, (string targetName, string source, bool revers
                             }
                         }
 
-                        return new BaseFacetInfo(baseTypeName, baseSourceTypeName, baseConfigurationTypeName);
+                        // Extract the Include properties from the base Facet's attribute
+                        var (baseIncludedMembers, _) = AttributeParser.ExtractIncludedMembers(facetAttr);
+
+                        return new BaseFacetInfo(baseTypeName, baseSourceTypeName, baseConfigurationTypeName, baseIncludedMembers.ToImmutableArray());
                     }
                 }
             }


### PR DESCRIPTION
When a Facet class inherited from another Facet class, the Include properties specified in the base Facet's [Facet] attribute were not being included in the derived Facet. Only the properties from the derived Facet's own Include attribute were being processed.

Another fix for #338 