### PR TITLE
fix: multi level mapping with different configs

### DIFF
--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -32,7 +32,7 @@ internal static class ProjectionGenerator
         {
             GenerateProjectionNotSupportedComment(sb, model, memberIndent);
         }
-        else if (model.HasProjectionMapConfiguration)
+        else if (model.HasProjectionMapConfiguration || RequiresLazyProjection(model, facetLookup))
         {
             GenerateProjectionDocumentation(sb, model, memberIndent, propertyName);
             GenerateLazyProjection(sb, model, memberIndent, facetLookup, propertyName);
@@ -193,16 +193,19 @@ internal static class ProjectionGenerator
             sb.AppendLine();
         }
 
-        // Apply ConfigureProjection overrides from derived class
-        sb.AppendLine($"{bodyIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
-        sb.AppendLine($"{bodyIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
-        sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __builder.Mappings)");
-        sb.AppendLine($"{bodyIndent}{{");
-        sb.AppendLine($"{bodyIndent}    var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __p);");
-        sb.AppendLine($"{bodyIndent}    __bindings.RemoveAll(b => ((global::System.Linq.Expressions.MemberAssignment)b).Member.Name == __member.Name);");
-        sb.AppendLine($"{bodyIndent}    __bindings.Add(global::System.Linq.Expressions.Expression.Bind(__member, __body));");
-        sb.AppendLine($"{bodyIndent}}}");
-        sb.AppendLine();
+        // Apply ConfigureProjection overrides from derived class (only if this model has its own configuration)
+        if (model.ConfigurationTypeName != null)
+        {
+            sb.AppendLine($"{bodyIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
+            sb.AppendLine($"{bodyIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
+            sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __builder.Mappings)");
+            sb.AppendLine($"{bodyIndent}{{");
+            sb.AppendLine($"{bodyIndent}    var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __p);");
+            sb.AppendLine($"{bodyIndent}    __bindings.RemoveAll(b => ((global::System.Linq.Expressions.MemberAssignment)b).Member.Name == __member.Name);");
+            sb.AppendLine($"{bodyIndent}    __bindings.Add(global::System.Linq.Expressions.Expression.Bind(__member, __body));");
+            sb.AppendLine($"{bodyIndent}}}");
+            sb.AppendLine();
+        }
 
         // Build and return the final lambda
         sb.AppendLine($"{bodyIndent}return global::System.Linq.Expressions.Expression.Lambda<global::System.Func<{src}, {tgt}>>(");
@@ -913,6 +916,43 @@ internal static class ProjectionGenerator
             FacetConstants.CollectionWrappers.IImmutableStack => $"global::System.Collections.Immutable.ImmutableStack.CreateRange({projection})",
             _ => $"{projection}.ToList()"
         };
+    }
+
+    /// <summary>
+    /// Determines whether a model that doesn't itself have ConfigureProjection should still
+    /// use the lazy projection path because one or more of its transitively nested facets
+    /// requires runtime-composed projection (e.g. has ConfigureProjection or inherited base config).
+    /// </summary>
+    private static bool RequiresLazyProjection(
+        FacetTargetModel model,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
+        HashSet<string>? visited = null)
+    {
+        visited ??= new HashSet<string>();
+        if (!visited.Add(model.FullName))
+            return false;
+
+        var nestedFacetMembers = model.Members
+            .Where(m => m.MapFromIncludeInProjection && m.IsNestedFacet);
+
+        foreach (var member in nestedFacetMembers)
+        {
+            var nestedModel = FindNestedFacetModel(member.TypeName.TrimEnd('?'), facetLookup);
+            if (nestedModel == null)
+                continue;
+
+            if (nestedModel.HasProjectionMapConfiguration)
+                return true;
+
+            if (nestedModel.BaseFacetInfo?.BaseConfigurationTypeName != null)
+                return true;
+
+            // Recurse into the nested model's own nested facets
+            if (RequiresLazyProjection(nestedModel, facetLookup, visited))
+                return true;
+        }
+
+        return false;
     }
 
     private static FacetTargetModel? FindNestedFacetModel(string typeName, Dictionary<string, List<FacetTargetModel>> facetLookup)

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -76,6 +76,13 @@ internal static class ProjectionGenerator
             .ToArray();
         bool hasNestedFacets = nestedFacetMembers.Length > 0;
 
+        // Single-source: the facet target has exactly one [Facet] attribute.
+        // Only single-source lazy DTOs with nested facets get ProjectionFor/BuildProjectionExcluding,
+        // because multi-source DTOs use ProjectionFromX instead of Projection and don't have a
+        // stable "Projection" property that ProjectionFor can return.
+        bool isSingleSource = !facetLookup.TryGetValue(model.FullName, out var __modelSiblings)
+            || __modelSiblings.Count <= 1;
+
         // Backing field
         sb.AppendLine($"{memberIndent}private static global::System.Linq.Expressions.Expression<global::System.Func<{src}, {tgt}>>? {backingFieldName};");
         sb.AppendLine();
@@ -166,7 +173,8 @@ internal static class ProjectionGenerator
             var nestedIndent = bodyIndent + "    ";
             foreach (var member in nestedFacetMembers)
             {
-                GenerateNestedFacetBindingForLazyProjection(sb, member, tgt, nestedIndent, facetLookup);
+                GenerateNestedFacetBindingForLazyProjection(sb, member, tgt, nestedIndent, facetLookup,
+                    isSingleSource ? model.FullName : null);
             }
 
             sb.AppendLine($"{bodyIndent}}}");
@@ -214,6 +222,15 @@ internal static class ProjectionGenerator
         sb.AppendLine($"{bodyIndent}        __bindings),");
         sb.AppendLine($"{bodyIndent}    __p);");
         sb.AppendLine($"{memberIndent}}}");
+
+        // For single-source lazy DTOs with nested facets, generate ProjectionFor and BuildProjectionExcluding.
+        // These enable partial (non-fully-shallow) projections when a circular re-entry is detected,
+        // allowing second-level (and deeper) reverse navigation properties to be included.
+        if (hasNestedFacets && isSingleSource)
+        {
+            GenerateProjectionForMethod(sb, src, tgt, safeName, propertyName, memberIndent);
+            GenerateBuildProjectionExcluding(sb, model, memberIndent, facetLookup, nestedFacetMembers, src, tgt);
+        }
     }
 
     /// <summary>
@@ -226,17 +243,18 @@ internal static class ProjectionGenerator
         FacetMember member,
         string targetTypeName,
         string indent,
-        Dictionary<string, List<FacetTargetModel>> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
+        string? currentModelFullName = null)
     {
         var sourcePropName = member.SourcePropertyName;
 
         if (member.IsCollection)
         {
-            GenerateCollectionNestedFacetLazyBinding(sb, member, targetTypeName, indent, facetLookup);
+            GenerateCollectionNestedFacetLazyBinding(sb, member, targetTypeName, indent, facetLookup, currentModelFullName);
         }
         else
         {
-            GenerateSingleNestedFacetLazyBinding(sb, member, targetTypeName, indent, facetLookup);
+            GenerateSingleNestedFacetLazyBinding(sb, member, targetTypeName, indent, facetLookup, currentModelFullName);
         }
     }
 
@@ -248,7 +266,8 @@ internal static class ProjectionGenerator
         FacetMember member,
         string targetTypeName,
         string indent,
-        Dictionary<string, List<FacetTargetModel>> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
+        string? currentModelFullName = null)
     {
         var sourcePropName = member.SourcePropertyName;
         var nonNullableTypeName = member.TypeName.TrimEnd('?');
@@ -256,7 +275,7 @@ internal static class ProjectionGenerator
 
         // Resolve the Projection property name on the nested DTO
         var projectionPropertyAccess = ResolveNestedProjectionPropertyAccess(
-            nonNullableTypeName, member.NestedFacetSourceTypeName, facetLookup);
+            nonNullableTypeName, member.NestedFacetSourceTypeName, facetLookup, currentModelFullName);
 
         sb.AppendLine($"{indent}// Nested facet binding: {member.Name}");
         sb.AppendLine($"{indent}{{");
@@ -292,7 +311,8 @@ internal static class ProjectionGenerator
         FacetMember member,
         string targetTypeName,
         string indent,
-        Dictionary<string, List<FacetTargetModel>> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
+        string? currentModelFullName = null)
     {
         var sourcePropName = member.SourcePropertyName;
         var elementTypeName = ExpressionBuilder.ExtractElementTypeFromCollectionTypeName(member.TypeName);
@@ -307,7 +327,7 @@ internal static class ProjectionGenerator
 
         // Resolve the Projection property name on the nested DTO element type
         var projectionPropertyAccess = ResolveNestedProjectionPropertyAccess(
-            nonNullableElementType, sourceElementType, facetLookup);
+            nonNullableElementType, sourceElementType, facetLookup, currentModelFullName);
 
         // Determine the ToList/ToArray wrapper method
         var collectionWrapper = member.CollectionWrapper ?? "List";
@@ -390,13 +410,15 @@ internal static class ProjectionGenerator
 
     /// <summary>
     /// Resolves the fully qualified access to a nested Facet's Projection property.
-    /// Determines whether to use <c>Projection</c> or <c>ProjectionFrom{Source}</c> based on
-    /// whether the nested DTO is multi-source.
+    /// Determines whether to use <c>Projection</c>, <c>ProjectionFor(requester)</c>, or
+    /// <c>ProjectionFrom{Source}</c> based on whether the nested DTO is multi-source and
+    /// whether it participates in circular reference detection.
     /// </summary>
     private static string ResolveNestedProjectionPropertyAccess(
         string nestedDtoTypeName,
         string? nestedSourceTypeName,
-        Dictionary<string, List<FacetTargetModel>> facetLookup)
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
+        string? currentModelFullName = null)
     {
         // Strip "global::" prefix and extract simple name for lookup
         var lookupName = nestedDtoTypeName
@@ -406,10 +428,9 @@ internal static class ProjectionGenerator
 
         List<FacetTargetModel>? models = null;
 
-        // Try exact match
+        // Try exact match by FullName first, then by simple name
         if (!facetLookup.TryGetValue(lookupName, out models) || models == null || models.Count == 0)
         {
-            // Try matching by simple name in values
             foreach (var kvp in facetLookup)
             {
                 if (kvp.Value.Count > 0)
@@ -427,7 +448,14 @@ internal static class ProjectionGenerator
 
         if (models == null || models.Count <= 1)
         {
-            // Single-source: use "Projection"
+            // Single-source: use ProjectionFor when the nested DTO qualifies (lazy, has nested facets)
+            // so that it can provide a partial projection instead of fully-shallow on circular re-entry.
+            if (currentModelFullName != null && models?.Count >= 1 &&
+                NestedDtoHasProjectionFor(models[0], models, facetLookup))
+            {
+                return $"{nestedDtoTypeName}.ProjectionFor(\"{currentModelFullName}\")";
+            }
+
             return $"{nestedDtoTypeName}.Projection";
         }
 
@@ -1036,6 +1064,168 @@ internal static class ProjectionGenerator
         var defaultValue = member.MapWhenDefault ?? Shared.GeneratorUtilities.GetDefaultValueForType(member.TypeName);
 
         return $"{combinedCondition} ? {valueExpression} : {defaultValue}";
+    }
+
+    /// <summary>
+    /// Returns true if the given nested DTO model should have a <c>ProjectionFor</c> method generated,
+    /// meaning it is single-source, lazy (uses the lazy projection path), and has nested facets.
+    /// Only such DTOs will have the <c>ProjectionFor</c> method available at runtime.
+    /// </summary>
+    private static bool NestedDtoHasProjectionFor(
+        FacetTargetModel nestedModel,
+        List<FacetTargetModel> modelSiblings,
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
+    {
+        // Must be single-source
+        if (modelSiblings.Count > 1) return false;
+
+        // Must have nested facets (ProjectionFor is only generated when hasNestedFacets == true)
+        if (!nestedModel.Members.Any(m => m.MapFromIncludeInProjection && m.IsNestedFacet))
+            return false;
+
+        // Must be lazy (uses GenerateLazyProjection path)
+        if (nestedModel.HasProjectionMapConfiguration) return true;
+        if (nestedModel.BaseFacetInfo?.BaseConfigurationTypeName != null) return true;
+        return RequiresLazyProjection(nestedModel, facetLookup);
+    }
+
+    /// <summary>
+    /// Generates the <c>ProjectionFor(string __requesterType)</c> method for a lazy single-source DTO.
+    /// When the DTO is currently on the build stack (re-entrant), delegates to
+    /// <c>BuildProjectionExcluding(__requesterType)</c> instead of returning the cached projection.
+    /// This allows second-level reverse navigation properties to be included in circular projections.
+    /// </summary>
+    private static void GenerateProjectionForMethod(
+        StringBuilder sb,
+        string src,
+        string tgt,
+        string safeName,
+        string propertyName,
+        string memberIndent)
+    {
+        sb.AppendLine();
+        sb.AppendLine($"{memberIndent}internal static global::System.Linq.Expressions.Expression<global::System.Func<{src}, {tgt}>> ProjectionFor(string __requesterType)");
+        sb.AppendLine($"{memberIndent}{{");
+        sb.AppendLine($"{memberIndent}    // If this DTO is currently being built (re-entrant), return a partial projection");
+        sb.AppendLine($"{memberIndent}    // that excludes the requester type to break the cycle while including other nested facets.");
+        sb.AppendLine($"{memberIndent}    if (__projectionBuildStack != null && __projectionBuildStack.Contains(\"{tgt}:{safeName}\"))");
+        sb.AppendLine($"{memberIndent}        return BuildProjectionExcluding(__requesterType);");
+        sb.AppendLine($"{memberIndent}    return {propertyName};");
+        sb.AppendLine($"{memberIndent}}}");
+    }
+
+    /// <summary>
+    /// Generates the <c>BuildProjectionExcluding(string __excludeType)</c> method for a lazy single-source DTO.
+    /// This is like <c>BuildProjection(true)</c> but each nested facet binding is guarded with
+    /// <c>if (__excludeType != nestedModel.FullName)</c> so the caller can break a specific cycle
+    /// while still populating all other nested facets.
+    /// The result is NOT cached (no Volatile.Write) since it is cycle-dependent.
+    /// </summary>
+    private static void GenerateBuildProjectionExcluding(
+        StringBuilder sb,
+        FacetTargetModel model,
+        string memberIndent,
+        Dictionary<string, List<FacetTargetModel>> facetLookup,
+        FacetMember[] nestedFacetMembers,
+        string src,
+        string tgt)
+    {
+        sb.AppendLine();
+        sb.AppendLine($"{memberIndent}private static global::System.Linq.Expressions.Expression<global::System.Func<{src}, {tgt}>> BuildProjectionExcluding(string __excludeType)");
+        sb.AppendLine($"{memberIndent}{{");
+
+        var bodyIndent = memberIndent + "    ";
+
+        sb.AppendLine($"{bodyIndent}var __p = global::System.Linq.Expressions.Expression.Parameter(typeof({src}), \"source\");");
+        sb.AppendLine();
+
+        // Scalar bindings (identical to BuildProjection)
+        sb.AppendLine($"{bodyIndent}var __bindings = new global::System.Collections.Generic.List<global::System.Linq.Expressions.MemberBinding>");
+        sb.AppendLine($"{bodyIndent}{{");
+
+        var includedMembers = model.Members
+            .Where(m => m.MapFromIncludeInProjection && !m.IsNestedFacet)
+            .ToArray();
+
+        for (int i = 0; i < includedMembers.Length; i++)
+        {
+            var member = includedMembers[i];
+            var bindingExpr = GetMemberBindingExpression(member, "__p", tgt);
+            if (bindingExpr == null) continue;
+            var comma = i < includedMembers.Length - 1 ? "," : "";
+            sb.AppendLine($"{bodyIndent}    {bindingExpr}{comma}");
+        }
+
+        sb.AppendLine($"{bodyIndent}}};");
+        sb.AppendLine();
+
+        // Nested facet bindings, each guarded by an exclusion check
+        var nestedIndent = bodyIndent + "    ";
+        foreach (var member in nestedFacetMembers)
+        {
+            // Determine the FullName of the nested model to use as the exclusion key
+            string exclusionKey;
+            if (member.IsCollection)
+            {
+                var elementTypeName = ExpressionBuilder.ExtractElementTypeFromCollectionTypeName(member.TypeName);
+                var nestedModel = FindNestedFacetModel(elementTypeName.TrimEnd('?'), facetLookup);
+                exclusionKey = nestedModel?.FullName ?? elementTypeName.TrimEnd('?');
+            }
+            else
+            {
+                var nonNullableTypeName = member.TypeName.TrimEnd('?');
+                var nestedModel = FindNestedFacetModel(nonNullableTypeName, facetLookup);
+                exclusionKey = nestedModel?.FullName ?? nonNullableTypeName;
+            }
+
+            sb.AppendLine($"{bodyIndent}if (__excludeType != \"{exclusionKey}\")");
+            sb.AppendLine($"{bodyIndent}{{");
+            // Pass model.FullName as currentModelFullName so nested bindings also use ProjectionFor
+            GenerateNestedFacetBindingForLazyProjection(sb, member, tgt, nestedIndent, facetLookup, model.FullName);
+            sb.AppendLine($"{bodyIndent}}}");
+            sb.AppendLine();
+        }
+
+        // Apply base Facet ConfigureProjection if present (same as BuildProjection)
+        if (model.BaseFacetInfo?.BaseConfigurationTypeName != null)
+        {
+            sb.AppendLine($"{bodyIndent}// Apply base Facet projection mappings");
+            sb.AppendLine($"{bodyIndent}var __baseBuilder = new global::Facet.Mapping.FacetProjectionBuilder<{model.BaseFacetInfo.BaseSourceTypeName}, {model.BaseFacetInfo.BaseTypeName}>();");
+            sb.AppendLine($"{bodyIndent}{model.BaseFacetInfo.BaseConfigurationTypeName}.ConfigureProjection(__baseBuilder);");
+            sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __baseBuilder.Mappings)");
+            sb.AppendLine($"{bodyIndent}{{");
+            sb.AppendLine($"{bodyIndent}    var __derivedMember = typeof({tgt}).GetProperty(__member.Name);");
+            sb.AppendLine($"{bodyIndent}    if (__derivedMember != null)");
+            sb.AppendLine($"{bodyIndent}    {{");
+            sb.AppendLine($"{bodyIndent}        var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __p);");
+            sb.AppendLine($"{bodyIndent}        __bindings.RemoveAll(b => ((global::System.Linq.Expressions.MemberAssignment)b).Member.Name == __derivedMember.Name);");
+            sb.AppendLine($"{bodyIndent}        __bindings.Add(global::System.Linq.Expressions.Expression.Bind(__derivedMember, __body));");
+            sb.AppendLine($"{bodyIndent}    }}");
+            sb.AppendLine($"{bodyIndent}}}");
+            sb.AppendLine();
+        }
+
+        // Apply own ConfigureProjection if present (same as BuildProjection)
+        if (model.ConfigurationTypeName != null)
+        {
+            sb.AppendLine($"{bodyIndent}var __builder = new global::Facet.Mapping.FacetProjectionBuilder<{src}, {tgt}>();");
+            sb.AppendLine($"{bodyIndent}global::{model.ConfigurationTypeName}.ConfigureProjection(__builder);");
+            sb.AppendLine($"{bodyIndent}foreach (var (__member, __expr) in __builder.Mappings)");
+            sb.AppendLine($"{bodyIndent}{{");
+            sb.AppendLine($"{bodyIndent}    var __body = global::Facet.Mapping.ParameterReplacer.Replace(__expr, __p);");
+            sb.AppendLine($"{bodyIndent}    __bindings.RemoveAll(b => ((global::System.Linq.Expressions.MemberAssignment)b).Member.Name == __member.Name);");
+            sb.AppendLine($"{bodyIndent}    __bindings.Add(global::System.Linq.Expressions.Expression.Bind(__member, __body));");
+            sb.AppendLine($"{bodyIndent}}}");
+            sb.AppendLine();
+        }
+
+        // Return without caching (result is cycle-context-dependent)
+        sb.AppendLine($"{bodyIndent}return global::System.Linq.Expressions.Expression.Lambda<global::System.Func<{src}, {tgt}>>(");
+        sb.AppendLine($"{bodyIndent}    global::System.Linq.Expressions.Expression.MemberInit(");
+        sb.AppendLine($"{bodyIndent}        global::System.Linq.Expressions.Expression.New(typeof({tgt})),");
+        sb.AppendLine($"{bodyIndent}        __bindings),");
+        sb.AppendLine($"{bodyIndent}    __p);");
+        sb.AppendLine($"{memberIndent}}}");
     }
 
 }

--- a/test/Facet.Tests/UnitTests/Core/Facet/ProjectionAbstractionsAndMultiSourceRegressionTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ProjectionAbstractionsAndMultiSourceRegressionTests.cs
@@ -1,0 +1,151 @@
+using Facet.Mapping;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+public interface ICustomerContract352
+{
+    int Id { get; set; }
+    string Name { get; set; }
+    string Email { get; set; }
+}
+
+public class CustomerEntity352 : ICustomerContract352
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}
+
+[Facet(typeof(ICustomerContract352),
+    Configuration = typeof(CustomerContractFacet352Config),
+    Include = new[] { nameof(ICustomerContract352.Id), nameof(ICustomerContract352.Name), nameof(ICustomerContract352.Email) })]
+[Facet(typeof(CustomerEntity352),
+    Include = new[] { nameof(CustomerEntity352.Id), nameof(CustomerEntity352.Name), nameof(CustomerEntity352.Email) })]
+public partial class CustomerFacet352
+{
+}
+
+public class CustomerContractFacet352Config
+    : IFacetProjectionMapConfiguration<ICustomerContract352, CustomerFacet352>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<ICustomerContract352, CustomerFacet352> builder)
+    {
+        builder.Map(d => d.Name, s => s.Name + " (contract)");
+    }
+}
+
+public class DispatchEntity352
+{
+    public int Id { get; set; }
+    public ICustomerContract352? Customer { get; set; }
+}
+
+[Facet(typeof(DispatchEntity352),
+    Include = new[] { nameof(DispatchEntity352.Id), nameof(DispatchEntity352.Customer) },
+    NestedFacets = new[] { typeof(CustomerFacet352) })]
+public partial class DispatchDto352
+{
+}
+
+[Facet(typeof(DispatchEntity352),
+    Configuration = typeof(DispatchDto352LazyConfig),
+    Include = new[] { nameof(DispatchEntity352.Id), nameof(DispatchEntity352.Customer) },
+    NestedFacets = new[] { typeof(CustomerFacet352) })]
+public partial class DispatchDto352Lazy
+{
+}
+
+public class DispatchDto352LazyConfig
+    : IFacetProjectionMapConfiguration<DispatchEntity352, DispatchDto352Lazy>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<DispatchEntity352, DispatchDto352Lazy> builder)
+    {
+        builder.Map(d => d.Id, s => s.Id + 1000);
+    }
+}
+
+public class BaseOrderEntity352
+{
+    public int Id { get; set; }
+    public DispatchEntity352? Dispatch { get; set; }
+}
+
+public class DerivedOrderEntity352 : BaseOrderEntity352
+{
+    public string OrderNumber { get; set; } = string.Empty;
+}
+
+[Facet(typeof(BaseOrderEntity352),
+    Include = new[] { nameof(BaseOrderEntity352.Id), nameof(BaseOrderEntity352.Dispatch) },
+    NestedFacets = new[] { typeof(DispatchDto352) })]
+public partial class BaseOrderDto352
+{
+}
+
+[Facet(typeof(DerivedOrderEntity352),
+    Include = new[] { nameof(DerivedOrderEntity352.OrderNumber) })]
+public partial class DerivedOrderDto352 : BaseOrderDto352
+{
+}
+
+public class ProjectionAbstractionsAndMultiSourceRegressionTests
+{
+    [Fact]
+    public void Projection_InterfaceNestedFacet_InlinePath_ShouldUseInterfaceSpecificProjection()
+    {
+        var source = new DispatchEntity352
+        {
+            Id = 1,
+            Customer = new CustomerEntity352 { Id = 10, Name = "Alice", Email = "alice@example.com" }
+        };
+
+        var dto = DispatchDto352.Projection.Compile()(source);
+
+        dto.Id.Should().Be(1);
+        dto.Customer.Should().NotBeNull();
+        dto.Customer!.Name.Should().Be("Alice (contract)");
+        dto.Customer.Email.Should().Be("alice@example.com");
+    }
+
+    [Fact]
+    public void Projection_InterfaceNestedFacet_WithLazyParentProjection_ShouldKeepNestedConfiguration()
+    {
+        var source = new DispatchEntity352
+        {
+            Id = 7,
+            Customer = new CustomerEntity352 { Id = 77, Name = "Bob", Email = "bob@example.com" }
+        };
+
+        var dto = DispatchDto352Lazy.Projection.Compile()(source);
+
+        dto.Id.Should().Be(1007);
+        dto.Customer.Should().NotBeNull();
+        dto.Customer!.Name.Should().Be("Bob (contract)");
+    }
+
+    [Fact]
+    public void Projection_InheritedFacet_WithAbstractNestedFacet_ShouldProjectNestedConfiguration()
+    {
+        var source = new DerivedOrderEntity352
+        {
+            Id = 2,
+            OrderNumber = "ORD-352",
+            Dispatch = new DispatchEntity352
+            {
+                Id = 20,
+                Customer = new CustomerEntity352 { Id = 30, Name = "Carol", Email = "carol@example.com" }
+            }
+        };
+
+        var dto = DerivedOrderDto352.Projection.Compile()(source);
+
+        dto.Id.Should().Be(2);
+        dto.OrderNumber.Should().Be("ORD-352");
+        dto.Dispatch.Should().NotBeNull();
+        dto.Dispatch!.Customer.Should().NotBeNull();
+        dto.Dispatch.Customer!.Name.Should().Be("Carol (contract)");
+    }
+
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/ProjectionAbstractionsAndMultiSourceRegressionTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ProjectionAbstractionsAndMultiSourceRegressionTests.cs
@@ -149,3 +149,307 @@ public class ProjectionAbstractionsAndMultiSourceRegressionTests
     }
 
 }
+
+public interface IContactContract353
+{
+    int Id { get; set; }
+    string Name { get; set; }
+}
+
+public class ContactEntity353 : IContactContract353
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[Facet(typeof(IContactContract353),
+    Configuration = typeof(ContactFacet353InterfaceConfig),
+    Include = new[] { nameof(IContactContract353.Id), nameof(IContactContract353.Name) })]
+[Facet(typeof(ContactEntity353),
+    Include = new[] { nameof(ContactEntity353.Id), nameof(ContactEntity353.Name) })]
+public partial class ContactFacet353
+{
+}
+
+public class ContactFacet353InterfaceConfig
+    : IFacetProjectionMapConfiguration<IContactContract353, ContactFacet353>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<IContactContract353, ContactFacet353> builder)
+    {
+        builder.Map(d => d.Name, s => s.Name + " (iface)");
+    }
+}
+
+public class Level5Entity353
+{
+    public int Id { get; set; }
+    public IContactContract353? Contact { get; set; }
+}
+
+public class Level5ConcreteEntity353
+{
+    public int Id { get; set; }
+    public ContactEntity353? Contact { get; set; }
+}
+
+public class Level4Entity353
+{
+    public int Id { get; set; }
+    public Level5Entity353? Level5 { get; set; }
+}
+
+public class Level3Entity353
+{
+    public int Id { get; set; }
+    public Level4Entity353? Level4 { get; set; }
+}
+
+public class Level2Entity353
+{
+    public int Id { get; set; }
+    public Level3Entity353? Level3 { get; set; }
+}
+
+public class Level1Entity353
+{
+    public int Id { get; set; }
+    public Level2Entity353? Level2 { get; set; }
+}
+
+[Facet(typeof(Level5Entity353),
+    Include = new[] { nameof(Level5Entity353.Id), nameof(Level5Entity353.Contact) },
+    NestedFacets = new[] { typeof(ContactFacet353) })]
+public partial class Level5Dto353
+{
+}
+
+[Facet(typeof(Level5ConcreteEntity353),
+    Include = new[] { nameof(Level5ConcreteEntity353.Id), nameof(Level5ConcreteEntity353.Contact) },
+    NestedFacets = new[] { typeof(ContactFacet353) })]
+public partial class Level5ConcreteDto353
+{
+}
+
+[Facet(typeof(Level4Entity353),
+    Include = new[] { nameof(Level4Entity353.Id), nameof(Level4Entity353.Level5) },
+    NestedFacets = new[] { typeof(Level5Dto353) })]
+public partial class Level4Dto353
+{
+}
+
+[Facet(typeof(Level3Entity353),
+    Configuration = typeof(Level3Dto353Config),
+    Include = new[] { nameof(Level3Entity353.Id), nameof(Level3Entity353.Level4) },
+    NestedFacets = new[] { typeof(Level4Dto353) })]
+public partial class Level3Dto353
+{
+}
+
+public class Level3Dto353Config
+    : IFacetProjectionMapConfiguration<Level3Entity353, Level3Dto353>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<Level3Entity353, Level3Dto353> builder)
+    {
+        builder.Map(d => d.Id, s => s.Id + 30);
+    }
+}
+
+[Facet(typeof(Level2Entity353),
+    Include = new[] { nameof(Level2Entity353.Id), nameof(Level2Entity353.Level3) },
+    NestedFacets = new[] { typeof(Level3Dto353) })]
+public partial class Level2Dto353
+{
+}
+
+[Facet(typeof(Level1Entity353),
+    Include = new[] { nameof(Level1Entity353.Id), nameof(Level1Entity353.Level2) },
+    NestedFacets = new[] { typeof(Level2Dto353) })]
+public partial class Level1Dto353
+{
+}
+
+[Facet(typeof(Level1Entity353),
+    Configuration = typeof(Level1Dto353LazyConfig),
+    Include = new[] { nameof(Level1Entity353.Id), nameof(Level1Entity353.Level2) },
+    NestedFacets = new[] { typeof(Level2Dto353) })]
+public partial class Level1Dto353Lazy
+{
+}
+
+public class Level1Dto353LazyConfig
+    : IFacetProjectionMapConfiguration<Level1Entity353, Level1Dto353Lazy>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<Level1Entity353, Level1Dto353Lazy> builder)
+    {
+        builder.Map(d => d.Id, s => s.Id + 1000);
+    }
+}
+
+public class BaseRootEntity353
+{
+    public int Id { get; set; }
+    public Level2Entity353? Level2 { get; set; }
+}
+
+public class DerivedRootEntity353 : BaseRootEntity353
+{
+    public string Code { get; set; } = string.Empty;
+}
+
+[Facet(typeof(BaseRootEntity353),
+    Include = new[] { nameof(BaseRootEntity353.Id), nameof(BaseRootEntity353.Level2) },
+    NestedFacets = new[] { typeof(Level2Dto353) })]
+public partial class BaseRootDto353
+{
+}
+
+[Facet(typeof(DerivedRootEntity353),
+    Include = new[] { nameof(DerivedRootEntity353.Code) })]
+public partial class DerivedRootDto353 : BaseRootDto353
+{
+}
+
+public class FiveLevelProjectionRegressionTests
+{
+    private static Level2Entity353 CreateLevel2Tree(int baseId, string contactName) =>
+        new()
+        {
+            Id = baseId + 2,
+            Level3 = new Level3Entity353
+            {
+                Id = baseId + 3,
+                Level4 = new Level4Entity353
+                {
+                    Id = baseId + 4,
+                    Level5 = new Level5Entity353
+                    {
+                        Id = baseId + 5,
+                        Contact = new ContactEntity353
+                        {
+                            Id = baseId + 6,
+                            Name = contactName
+                        }
+                    }
+                }
+            }
+        };
+
+    [Fact]
+    public void Projection_FiveLevels_Inline_ShouldMapAllLevels()
+    {
+        var source = new Level1Entity353
+        {
+            Id = 1,
+            Level2 = CreateLevel2Tree(1, "Alpha")
+        };
+
+        var dto = Level1Dto353.Projection.Compile()(source);
+
+        dto.Id.Should().Be(1);
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Id.Should().Be(3);
+        dto.Level2.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Id.Should().Be(34);
+        dto.Level2.Level3.Level4.Should().NotBeNull();
+        dto.Level2.Level3.Level4!.Id.Should().Be(5);
+        dto.Level2.Level3.Level4.Level5.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5!.Id.Should().Be(6);
+        dto.Level2.Level3.Level4.Level5.Contact.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5.Contact!.Name.Should().Be("Alpha (iface)");
+    }
+
+    [Fact]
+    public void Projection_FiveLevels_LazyRoot_ShouldMapAllLevels()
+    {
+        var source = new Level1Entity353
+        {
+            Id = 2,
+            Level2 = CreateLevel2Tree(10, "Bravo")
+        };
+
+        var dto = Level1Dto353Lazy.Projection.Compile()(source);
+
+        dto.Id.Should().Be(1002);
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Id.Should().Be(43);
+        dto.Level2.Level3.Level4.Should().NotBeNull();
+        dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5.Contact!.Name.Should().Be("Bravo (iface)");
+    }
+
+    [Fact]
+    public void Projection_FiveLevels_InheritedRoot_ShouldMapAllLevels()
+    {
+        var source = new DerivedRootEntity353
+        {
+            Id = 8,
+            Code = "DER-8",
+            Level2 = CreateLevel2Tree(20, "Charlie")
+        };
+
+        var dto = DerivedRootDto353.Projection.Compile()(source);
+
+        dto.Id.Should().Be(8);
+        dto.Code.Should().Be("DER-8");
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Level4.Should().NotBeNull();
+        dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5.Contact!.Name.Should().Be("Charlie (iface)");
+    }
+
+    [Fact]
+    public void Projection_FiveLevels_MultiSourceNestedFacet_ShouldSelectMatchingProjectionByNestedSourceType()
+    {
+        var interfaceSource = new Level5Entity353
+        {
+            Id = 100,
+            Contact = new ContactEntity353 { Id = 101, Name = "Delta" }
+        };
+        var concreteSource = new Level5ConcreteEntity353
+        {
+            Id = 200,
+            Contact = new ContactEntity353 { Id = 201, Name = "Echo" }
+        };
+
+        var interfaceDto = Level5Dto353.Projection.Compile()(interfaceSource);
+        var concreteDto = Level5ConcreteDto353.Projection.Compile()(concreteSource);
+
+        interfaceDto.Contact.Should().NotBeNull();
+        interfaceDto.Contact!.Name.Should().Be("Delta (iface)");
+
+        concreteDto.Contact.Should().NotBeNull();
+        concreteDto.Contact!.Name.Should().Be("Echo");
+    }
+
+    [Fact]
+    public void Projection_FiveLevels_WithNullIntermediateNode_ShouldKeepNestedNodeNull()
+    {
+        var source = new Level1Entity353
+        {
+            Id = 5,
+            Level2 = new Level2Entity353
+            {
+                Id = 50,
+                Level3 = new Level3Entity353
+                {
+                    Id = 60,
+                    Level4 = null
+                }
+            }
+        };
+
+        var dto = Level1Dto353.Projection.Compile()(source);
+
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Id.Should().Be(90);
+        dto.Level2.Level3.Level4.Should().BeNull();
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/ThreeLevelNestedProjectionTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ThreeLevelNestedProjectionTests.cs
@@ -1,0 +1,658 @@
+using System.Linq.Expressions;
+using Facet.Mapping;
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+public class OrderEntity350
+{
+    public int Id { get; set; }
+    public string OrderNumber { get; set; } = string.Empty;
+    public OrderLineDispatchEntity350? Dispatch { get; set; }
+}
+
+public class OrderLineDispatchEntity350
+{
+    public int Id { get; set; }
+    public DateTime DispatchDate { get; set; }
+    public CustomerEntity350? Customer { get; set; }
+}
+
+public class CustomerEntity350
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}
+
+[Facet(typeof(CustomerEntity350),
+    Include = new[] { "Id", "Name", "Email" })]
+public partial class CustomerDto350
+{
+}
+
+[Facet(typeof(OrderLineDispatchEntity350),
+    Include = new[] { "Id", "DispatchDate", "Customer" },
+    NestedFacets = new[] { typeof(CustomerDto350) })]
+public partial class OrderLineDispatchDto350
+{
+}
+
+[Facet(typeof(OrderEntity350),
+    Include = new[] { "Id", "OrderNumber", "Dispatch" },
+    NestedFacets = new[] { typeof(OrderLineDispatchDto350) })]
+public partial class OrderDto350
+{
+}
+
+[Facet(typeof(CustomerEntity350),
+    Configuration = typeof(CustomerDto350LazyConfig),
+    Include = new[] { "Id", "Name", "Email" })]
+public partial class CustomerDto350Lazy
+{
+}
+
+public class CustomerDto350LazyConfig
+    : IFacetProjectionMapConfiguration<CustomerEntity350, CustomerDto350Lazy>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<CustomerEntity350, CustomerDto350Lazy> builder)
+    {
+        builder.Map(d => d.Name, s => s.Name.ToUpper());
+    }
+}
+
+[Facet(typeof(OrderLineDispatchEntity350),
+    Configuration = typeof(DispatchDto350LazyConfig),
+    Include = new[] { "Id", "DispatchDate", "Customer" },
+    NestedFacets = new[] { typeof(CustomerDto350Lazy) })]
+public partial class DispatchDto350Lazy
+{
+}
+
+public class DispatchDto350LazyConfig
+    : IFacetProjectionMapConfiguration<OrderLineDispatchEntity350, DispatchDto350Lazy>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<OrderLineDispatchEntity350, DispatchDto350Lazy> builder)
+    {
+        // just a dummy mapping
+    }
+}
+
+[Facet(typeof(OrderEntity350),
+    Configuration = typeof(OrderDto350LazyConfig),
+    Include = new[] { "Id", "OrderNumber", "Dispatch" },
+    NestedFacets = new[] { typeof(DispatchDto350Lazy) })]
+public partial class OrderDto350Lazy
+{
+}
+
+public class OrderDto350LazyConfig
+    : IFacetProjectionMapConfiguration<OrderEntity350, OrderDto350Lazy>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<OrderEntity350, OrderDto350Lazy> builder)
+    {
+        // just a dummy mapping
+    }
+}
+
+public class BaseOrderEntity350
+{
+    public int Id { get; set; }
+    public string Number { get; set; } = string.Empty;
+}
+
+public class DerivedOrderEntity350 : BaseOrderEntity350
+{
+    public OrderLineDispatchEntity350? Dispatch { get; set; }
+}
+
+[Facet(typeof(BaseOrderEntity350),
+    Include = new[] { "Id", "Number" })]
+public partial class BaseOrderDto350
+{
+}
+
+[Facet(typeof(DerivedOrderEntity350),
+    Include = new[] { "Dispatch" },
+    NestedFacets = new[] { typeof(OrderLineDispatchDto350) })]
+public partial class DerivedOrderDto350 : BaseOrderDto350
+{
+}
+
+[Facet(typeof(BaseOrderEntity350),
+    Configuration = typeof(BaseOrderDto350LzCfg),
+    Include = new[] { "Id", "Number" })]
+public partial class BaseOrderDto350Lz
+{
+}
+
+public class BaseOrderDto350LzCfg
+    : IFacetProjectionMapConfiguration<BaseOrderEntity350, BaseOrderDto350Lz>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<BaseOrderEntity350, BaseOrderDto350Lz> builder)
+    {
+        builder.Map(d => d.Number, s => "ORD-" + s.Number);
+    }
+}
+
+[Facet(typeof(DerivedOrderEntity350),
+    Configuration = typeof(DerivedOrderDto350LzCfg),
+    Include = new[] { "Dispatch" },
+    NestedFacets = new[] { typeof(OrderLineDispatchDto350) })]
+public partial class DerivedOrderDto350Lz : BaseOrderDto350Lz
+{
+}
+
+public class DerivedOrderDto350LzCfg
+    : IFacetProjectionMapConfiguration<DerivedOrderEntity350, DerivedOrderDto350Lz>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<DerivedOrderEntity350, DerivedOrderDto350Lz> builder)
+    {
+    }
+}
+
+public class AssignedToUnit350
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class OrderHeader350
+{
+    public int Id { get; set; }
+    public string Number { get; set; } = string.Empty;
+}
+
+public class DispatchEntity351
+{
+    public int Id { get; set; }
+    public DateTime DispatchDate { get; set; }
+    public AssignedToUnit350? AssignedToUnit { get; set; }
+    public OrderHeader350? OrderHeader { get; set; }
+    public CustomerEntity350? Customer { get; set; }
+}
+
+public class ProductEntity351
+{
+    public int Id { get; set; }
+    public string ProductName { get; set; } = string.Empty;
+    public DispatchEntity351? Dispatch { get; set; }
+}
+
+[Facet(typeof(CustomerEntity350),
+    Include = new[] { "Id", "Name", "Email" })]
+public partial class CustomerDto351
+{
+}
+
+[Facet(typeof(DispatchEntity351),
+    Configuration = typeof(DispatchDto351Config),
+    Include = new[] { "Id", "DispatchDate", "Customer" },
+    NestedFacets = new[] { typeof(CustomerDto351) })]
+public partial class DispatchDto351
+{
+    public string? AssignedToUnitName { get; set; }
+    public string? OrderHeaderNumber { get; set; }
+}
+
+public class DispatchDto351Config
+    : IFacetProjectionMapConfiguration<DispatchEntity351, DispatchDto351>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<DispatchEntity351, DispatchDto351> builder)
+    {
+        // Manually map deep paths
+        builder.Map(d => d.AssignedToUnitName, s => s.AssignedToUnit != null ? s.AssignedToUnit.Name : null);
+        builder.Map(d => d.OrderHeaderNumber, s => s.OrderHeader != null ? s.OrderHeader.Number : null);
+        // Customer is intentionally NOT mapped here — should be auto-projected as nested facet
+    }
+}
+
+[Facet(typeof(ProductEntity351),
+    Include = new[] { "Id", "ProductName", "Dispatch" },
+    NestedFacets = new[] { typeof(DispatchDto351) })]
+public partial class ProductDto351
+{
+}
+
+[Facet(typeof(ProductEntity351),
+    Configuration = typeof(ProductDto351LzConfig),
+    Include = new[] { "Id", "ProductName", "Dispatch" },
+    NestedFacets = new[] { typeof(DispatchDto351) })]
+public partial class ProductDto351Lz
+{
+}
+
+public class ProductDto351LzConfig
+    : IFacetProjectionMapConfiguration<ProductEntity351, ProductDto351Lz>
+{
+    public static void ConfigureProjection(
+        IFacetProjectionBuilder<ProductEntity351, ProductDto351Lz> builder)
+    {
+        // nothing extra — just triggers the lazy path
+    }
+}
+
+public class OrderEntityNonNull350
+{
+    public int Id { get; set; }
+    public string OrderNumber { get; set; } = string.Empty;
+    public OrderLineDispatchEntityNonNull350 Dispatch { get; set; } = new();
+}
+
+public class OrderLineDispatchEntityNonNull350
+{
+    public int Id { get; set; }
+    public DateTime DispatchDate { get; set; }
+    public CustomerEntity350 Customer { get; set; } = new();
+}
+
+[Facet(typeof(OrderLineDispatchEntityNonNull350),
+    Include = new[] { "Id", "DispatchDate", "Customer" },
+    NestedFacets = new[] { typeof(CustomerDto350) })]
+public partial class DispatchDtoNonNull350
+{
+}
+
+[Facet(typeof(OrderEntityNonNull350),
+    Include = new[] { "Id", "OrderNumber", "Dispatch" },
+    NestedFacets = new[] { typeof(DispatchDtoNonNull350) })]
+public partial class OrderDtoNonNull350
+{
+}
+
+public class ThreeLevelNestedProjectionTests
+{
+    private OrderEntity350 CreateTestEntity() => new()
+    {
+        Id = 1,
+        OrderNumber = "ORD-001",
+        Dispatch = new OrderLineDispatchEntity350
+        {
+            Id = 2,
+            DispatchDate = new DateTime(2024, 6, 15),
+            Customer = new CustomerEntity350
+            {
+                Id = 3,
+                Name = "John Doe",
+                Email = "john@example.com"
+            }
+        }
+    };
+
+    [Fact]
+    public void Projection_InlinePath_ThreeLevelsDeep_ShouldPopulateAllLevels()
+    {
+        // Arrange
+        var entity = CreateTestEntity();
+
+        // Act
+        var projection = OrderDto350.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1
+        dto.Id.Should().Be(1);
+        dto.OrderNumber.Should().Be("ORD-001");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level (Dispatch) should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+        dto.Dispatch.DispatchDate.Should().Be(new DateTime(2024, 6, 15));
+
+        // Assert - Level 3 (the critical one)
+        dto.Dispatch.Customer.Should().NotBeNull("Third level (Customer) MUST be populated");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("John Doe");
+        dto.Dispatch.Customer.Email.Should().Be("john@example.com");
+    }
+
+    [Fact]
+    public void Projection_InlinePath_ThreeLevelsDeep_WithNullSecondLevel_ShouldReturnNull()
+    {
+        // Arrange
+        var entity = new OrderEntity350
+        {
+            Id = 1,
+            OrderNumber = "ORD-002",
+            Dispatch = null
+        };
+
+        // Act
+        var projection = OrderDto350.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert
+        dto.Id.Should().Be(1);
+        dto.Dispatch.Should().BeNull("Dispatch is null in source");
+    }
+
+    [Fact]
+    public void Projection_InlinePath_ThreeLevelsDeep_WithNullThirdLevel_ShouldReturnNull()
+    {
+        // Arrange
+        var entity = new OrderEntity350
+        {
+            Id = 1,
+            OrderNumber = "ORD-003",
+            Dispatch = new OrderLineDispatchEntity350
+            {
+                Id = 2,
+                DispatchDate = new DateTime(2024, 6, 15),
+                Customer = null
+            }
+        };
+
+        // Act
+        var projection = OrderDto350.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert
+        dto.Dispatch.Should().NotBeNull();
+        dto.Dispatch!.Customer.Should().BeNull("Customer is null in source");
+    }
+
+    [Fact]
+    public void Projection_InlinePath_ThreeLevelsDeep_ViaQueryable_ShouldPopulateAll()
+    {
+        // Arrange
+        var entities = new[] { CreateTestEntity() }.AsQueryable();
+
+        // Act
+        var dtos = entities.Select(OrderDto350.Projection).ToList();
+
+        // Assert
+        dtos.Should().HaveCount(1);
+        var dto = dtos[0];
+        dto.Dispatch.Should().NotBeNull();
+        dto.Dispatch!.Customer.Should().NotBeNull("Third level should be populated via Queryable");
+        dto.Dispatch.Customer!.Name.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public void Projection_LazyPath_ThreeLevelsDeep_ShouldPopulateAllLevels()
+    {
+        // Arrange
+        var entity = CreateTestEntity();
+
+        // Act
+        var projection = OrderDto350Lazy.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1
+        dto.Id.Should().Be(1);
+        dto.OrderNumber.Should().Be("ORD-001");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level (Dispatch) should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+        dto.Dispatch.DispatchDate.Should().Be(new DateTime(2024, 6, 15));
+
+        // Assert - Level 3 (the critical one)
+        dto.Dispatch.Customer.Should().NotBeNull("Third level (Customer) MUST be populated via lazy projection");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("JOHN DOE", "Name should be uppercased via ConfigureProjection");
+        dto.Dispatch.Customer.Email.Should().Be("john@example.com");
+    }
+
+    [Fact]
+    public void Projection_LazyPath_ThreeLevelsDeep_ViaQueryable_ShouldPopulateAll()
+    {
+        // Arrange
+        var entities = new[] { CreateTestEntity() }.AsQueryable();
+
+        // Act
+        var dtos = entities.Select(OrderDto350Lazy.Projection).ToList();
+
+        // Assert
+        dtos.Should().HaveCount(1);
+        var dto = dtos[0];
+        dto.Dispatch.Should().NotBeNull();
+        dto.Dispatch!.Customer.Should().NotBeNull("Third level should be populated via lazy Queryable");
+        dto.Dispatch.Customer!.Name.Should().Be("JOHN DOE");
+    }
+
+    [Fact]
+    public void Constructor_ThreeLevelsDeep_ShouldPopulateAllLevels()
+    {
+        // Arrange
+        var entity = CreateTestEntity();
+
+        // Act
+        var dto = new OrderDto350(entity);
+
+        // Assert - Level 1
+        dto.Id.Should().Be(1);
+        dto.OrderNumber.Should().Be("ORD-001");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+
+        // Assert - Level 3
+        dto.Dispatch.Customer.Should().NotBeNull("Third level MUST be populated via constructor");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("John Doe");
+    }
+
+    private ProductEntity351 CreateProduct351Entity() => new()
+    {
+        Id = 1,
+        ProductName = "Widget",
+        Dispatch = new DispatchEntity351
+        {
+            Id = 2,
+            DispatchDate = new DateTime(2024, 6, 15),
+            AssignedToUnit = new AssignedToUnit350 { Id = 10, Name = "Unit Alpha" },
+            OrderHeader = new OrderHeader350 { Id = 20, Number = "HDR-001" },
+            Customer = new CustomerEntity350
+            {
+                Id = 3,
+                Name = "John Doe",
+                Email = "john@example.com"
+            }
+        }
+    };
+
+    [Fact]
+    public void Projection_ManualDeepMaps_PlusNestedFacet_InlinePath_ShouldPopulateAll()
+    {
+        // Arrange — Level 1 uses inline path, Level 2 has ConfigureProjection (lazy)
+        var entity = CreateProduct351Entity();
+
+        // Act
+        var projection = ProductDto351.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1
+        dto.Id.Should().Be(1);
+        dto.ProductName.Should().Be("Widget");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level (Dispatch) should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+
+        // Assert - Manually mapped deep properties SHOULD work
+        dto.Dispatch.AssignedToUnitName.Should().Be("Unit Alpha",
+            "Manually mapped property via ConfigureProjection should work");
+        dto.Dispatch.OrderHeaderNumber.Should().Be("HDR-001",
+            "Manually mapped property via ConfigureProjection should work");
+
+        // Assert - Level 3 nested facet NOT manually mapped - THIS IS THE BUG AREA
+        dto.Dispatch.Customer.Should().NotBeNull(
+            "Third level nested facet (Customer) NOT in ConfigureProjection MUST still be populated");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("John Doe");
+        dto.Dispatch.Customer.Email.Should().Be("john@example.com");
+    }
+
+    [Fact]
+    public void Projection_ManualDeepMaps_PlusNestedFacet_LazyPath_ShouldPopulateAll()
+    {
+        // Arrange — Level 1 ALSO uses lazy path (ConfigureProjection)
+        var entity = CreateProduct351Entity();
+
+        // Act
+        var projection = ProductDto351Lz.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1
+        dto.Id.Should().Be(1);
+        dto.ProductName.Should().Be("Widget");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level (Dispatch) should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+
+        // Assert - Manually mapped deep properties
+        dto.Dispatch.AssignedToUnitName.Should().Be("Unit Alpha");
+        dto.Dispatch.OrderHeaderNumber.Should().Be("HDR-001");
+
+        // Assert - Level 3 nested facet
+        dto.Dispatch.Customer.Should().NotBeNull(
+            "Third level nested facet MUST be populated even through lazy path chain");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public void Projection_ManualDeepMaps_PlusNestedFacet_ViaQueryable_ShouldPopulateAll()
+    {
+        // Arrange
+        var entities = new[] { CreateProduct351Entity() }.AsQueryable();
+
+        // Act
+        var dtos = entities.Select(ProductDto351.Projection).ToList();
+
+        // Assert
+        var dto = dtos[0];
+        dto.Dispatch.Should().NotBeNull();
+        dto.Dispatch!.AssignedToUnitName.Should().Be("Unit Alpha");
+        dto.Dispatch.Customer.Should().NotBeNull("Third level via Queryable MUST be populated");
+        dto.Dispatch.Customer!.Name.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public void Projection_InheritedFacet_ThreeLevelsDeep_ShouldPopulateAllLevels()
+    {
+        // Arrange
+        var entity = new DerivedOrderEntity350
+        {
+            Id = 1,
+            Number = "ORD-001",
+            Dispatch = new OrderLineDispatchEntity350
+            {
+                Id = 2,
+                DispatchDate = new DateTime(2024, 6, 15),
+                Customer = new CustomerEntity350
+                {
+                    Id = 3,
+                    Name = "John Doe",
+                    Email = "john@example.com"
+                }
+            }
+        };
+
+        // Act
+        var projection = DerivedOrderDto350.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1 (inherited from base)
+        dto.Id.Should().Be(1);
+        dto.Number.Should().Be("ORD-001");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level (Dispatch) should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+        dto.Dispatch.DispatchDate.Should().Be(new DateTime(2024, 6, 15));
+
+        // Assert - Level 3 (the critical one)
+        dto.Dispatch.Customer.Should().NotBeNull("Third level (Customer) MUST be populated with inherited facet");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("John Doe");
+        dto.Dispatch.Customer.Email.Should().Be("john@example.com");
+    }
+
+    [Fact]
+    public void Projection_InheritedFacet_WithConfigureProjection_ThreeLevelsDeep_ShouldPopulateAllLevels()
+    {
+        // Arrange
+        var entity = new DerivedOrderEntity350
+        {
+            Id = 1,
+            Number = "ORD-001",
+            Dispatch = new OrderLineDispatchEntity350
+            {
+                Id = 2,
+                DispatchDate = new DateTime(2024, 6, 15),
+                Customer = new CustomerEntity350
+                {
+                    Id = 3,
+                    Name = "John Doe",
+                    Email = "john@example.com"
+                }
+            }
+        };
+
+        // Act
+        var projection = DerivedOrderDto350Lz.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1 (inherited, with ConfigureProjection mapping)
+        dto.Id.Should().Be(1);
+        dto.Number.Should().Be("ORD-ORD-001", "Number should be mapped from base ConfigureProjection");
+
+        // Assert - Level 2
+        dto.Dispatch.Should().NotBeNull("Second level (Dispatch) should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+
+        // Assert - Level 3
+        dto.Dispatch.Customer.Should().NotBeNull("Third level (Customer) MUST be populated with inherited+lazy");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public void Projection_NonNullableNested_ThreeLevelsDeep_ShouldPopulateAllLevels()
+    {
+        // Arrange
+        var entity = new OrderEntityNonNull350
+        {
+            Id = 1,
+            OrderNumber = "ORD-001",
+            Dispatch = new OrderLineDispatchEntityNonNull350
+            {
+                Id = 2,
+                DispatchDate = new DateTime(2024, 6, 15),
+                Customer = new CustomerEntity350
+                {
+                    Id = 3,
+                    Name = "Jane Smith",
+                    Email = "jane@example.com"
+                }
+            }
+        };
+
+        // Act
+        var projection = OrderDtoNonNull350.Projection.Compile();
+        var dto = projection(entity);
+
+        // Assert - Level 1
+        dto.Id.Should().Be(1);
+        dto.OrderNumber.Should().Be("ORD-001");
+
+        // Assert - Level 2 (non-nullable)
+        dto.Dispatch.Should().NotBeNull("Non-nullable Dispatch should be populated");
+        dto.Dispatch!.Id.Should().Be(2);
+
+        // Assert - Level 3 (non-nullable, critical)
+        dto.Dispatch.Customer.Should().NotBeNull("Non-nullable third level MUST be populated");
+        dto.Dispatch.Customer!.Id.Should().Be(3);
+        dto.Dispatch.Customer.Name.Should().Be("Jane Smith");
+        dto.Dispatch.Customer.Email.Should().Be("jane@example.com");
+    }
+}

--- a/test/Facet.Tests/UnitTests/Extensions/EFCore/DeepProjectionEfCoreQueryRegressionTests.cs
+++ b/test/Facet.Tests/UnitTests/Extensions/EFCore/DeepProjectionEfCoreQueryRegressionTests.cs
@@ -39,6 +39,7 @@ public class DeepProjectionEfCoreQueryRegressionTests : IDisposable
         dto.Level2.Should().NotBeNull();
         dto.Level2!.Level3.Should().NotBeNull();
         dto.Level2.Level3!.Id.Should().Be(43);
+        dto.Level2.Level3.Level2.Should().NotBeNull();
         dto.Level2.Level3.Level4.Should().NotBeNull();
         dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
         dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
@@ -61,6 +62,7 @@ public class DeepProjectionEfCoreQueryRegressionTests : IDisposable
         dto.Id.Should().Be(1002);
         dto.Level2.Should().NotBeNull();
         dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3.Level2.Should().NotBeNull();
         dto.Level2.Level3!.Level4.Should().NotBeNull();
         dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
         dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
@@ -90,6 +92,8 @@ public class DeepProjectionEfCoreQueryRegressionTests : IDisposable
         dto.Code.Should().Be("DER-10");
         dto.Level2.Should().NotBeNull();
         dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3.Level2.Should().NotBeNull();
+        dto.Level2.Level3.Level2.Select(x => x.Level1).FirstOrDefault().Should().NotBeNull();
         dto.Level2.Level3!.Level4.Should().NotBeNull();
         dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
         dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
@@ -210,6 +214,8 @@ public class Level4Entity354
 public class Level3Entity354
 {
     public int Id { get; set; }
+    public virtual ICollection<Level2Entity354> Level2 { get; set; } = new List<Level2Entity354>();
+    public int Level2Id { get; set; }
     public int? Level4Id { get; set; }
     public Level4Entity354? Level4 { get; set; }
 }
@@ -217,6 +223,8 @@ public class Level3Entity354
 public class Level2Entity354
 {
     public int Id { get; set; }
+    public virtual ICollection<Level1Entity354> Level1 { get; set; } = new List<Level1Entity354>();
+    public int Level1Id { get; set; }
     public int? Level3Id { get; set; }
     public Level3Entity354? Level3 { get; set; }
 }
@@ -244,8 +252,8 @@ public partial class Level4Dto354
 
 [Facet(typeof(Level3Entity354),
     Configuration = typeof(Level3Dto354Config),
-    Include = new[] { nameof(Level3Entity354.Id), nameof(Level3Entity354.Level4) },
-    NestedFacets = new[] { typeof(Level4Dto354) })]
+    Include = new[] { nameof(Level3Entity354.Id), nameof(Level3Entity354.Level2), nameof(Level3Entity354.Level4) },
+    NestedFacets = new[] { typeof(Level2Dto354), typeof(Level4Dto354) })]
 public partial class Level3Dto354
 {
 }
@@ -260,8 +268,8 @@ public class Level3Dto354Config
 }
 
 [Facet(typeof(Level2Entity354),
-    Include = new[] { nameof(Level2Entity354.Id), nameof(Level2Entity354.Level3) },
-    NestedFacets = new[] { typeof(Level3Dto354) })]
+    Include = new[] { nameof(Level2Entity354.Id), nameof(Level2Entity354.Level1), nameof(Level2Entity354.Level3) },
+    NestedFacets = new[] { typeof(Level1Dto354), typeof(Level3Dto354) })]
 public partial class Level2Dto354
 {
 }
@@ -342,12 +350,12 @@ public class DeepProjectionDbContext354 : DbContext
 
         modelBuilder.Entity<Level1Entity354>()
             .HasOne(x => x.Level2)
-            .WithMany()
+            .WithMany(x => x.Level1)
             .HasForeignKey(x => x.Level2Id);
 
         modelBuilder.Entity<Level2Entity354>()
             .HasOne(x => x.Level3)
-            .WithMany()
+            .WithMany(x => x.Level2)
             .HasForeignKey(x => x.Level3Id);
 
         modelBuilder.Entity<Level3Entity354>()

--- a/test/Facet.Tests/UnitTests/Extensions/EFCore/DeepProjectionEfCoreQueryRegressionTests.cs
+++ b/test/Facet.Tests/UnitTests/Extensions/EFCore/DeepProjectionEfCoreQueryRegressionTests.cs
@@ -1,0 +1,373 @@
+using Facet.Mapping;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Facet.Tests.UnitTests.Extensions.EFCore;
+
+public class DeepProjectionEfCoreQueryRegressionTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DeepProjectionDbContext354 _context;
+
+    public DeepProjectionEfCoreQueryRegressionTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<DeepProjectionDbContext354>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new DeepProjectionDbContext354(options);
+        _context.Database.EnsureCreated();
+    }
+
+    [Fact]
+    public async Task QueryProjection_FiveLevels_Inline_ShouldMapConfiguredNestedMembers()
+    {
+        var root = CreateInlineRoot(1, "Inline");
+        _context.Level1Entities.Add(root);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var dto = await _context.Level1Entities
+            .Where(x => x.Id == 1)
+            .Select(Level1Dto354.Projection)
+            .SingleAsync();
+
+        dto.Id.Should().Be(1);
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Id.Should().Be(43);
+        dto.Level2.Level3.Level4.Should().NotBeNull();
+        dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5.Contact!.Name.Should().Be("Inline (abstract)");
+    }
+
+    [Fact]
+    public async Task QueryProjection_FiveLevels_LazyRoot_ShouldKeepNestedProjectionConfiguration()
+    {
+        var root = CreateInlineRoot(2, "Lazy");
+        _context.Level1Entities.Add(root);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var dto = await _context.Level1Entities
+            .Where(x => x.Id == 2)
+            .Select(Level1Dto354Lazy.Projection)
+            .SingleAsync();
+
+        dto.Id.Should().Be(1002);
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Level4.Should().NotBeNull();
+        dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5.Contact!.Name.Should().Be("Lazy (abstract)");
+    }
+
+    [Fact]
+    public async Task QueryProjection_FiveLevels_InheritedRoot_ShouldProjectNestedChain()
+    {
+        var derived = new DerivedRootEntity354
+        {
+            Id = 10,
+            Code = "DER-10",
+            Level2 = CreateLevel2Chain(100, "Inherited")
+        };
+
+        _context.DerivedRootEntities.Add(derived);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var dto = await _context.DerivedRootEntities
+            .Where(x => x.Id == 10)
+            .Select(DerivedRootDto354.Projection)
+            .SingleAsync();
+
+        dto.Id.Should().Be(10);
+        dto.Code.Should().Be("DER-10");
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Level4.Should().NotBeNull();
+        dto.Level2.Level3.Level4!.Level5.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5!.Contact.Should().NotBeNull();
+        dto.Level2.Level3.Level4.Level5.Contact!.Name.Should().Be("Inherited (abstract)");
+    }
+
+    [Fact]
+    public async Task QueryProjection_FiveLevels_NullIntermediateNode_ShouldRemainNull()
+    {
+        var root = new Level1Entity354
+        {
+            Id = 20,
+            Level2 = new Level2Entity354
+            {
+                Id = 21,
+                Level3 = new Level3Entity354
+                {
+                    Id = 22,
+                    Level4 = null
+                }
+            }
+        };
+
+        _context.Level1Entities.Add(root);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var dto = await _context.Level1Entities
+            .Where(x => x.Id == 20)
+            .Select(Level1Dto354.Projection)
+            .SingleAsync();
+
+        dto.Level2.Should().NotBeNull();
+        dto.Level2!.Level3.Should().NotBeNull();
+        dto.Level2.Level3!.Id.Should().Be(52);
+        dto.Level2.Level3.Level4.Should().BeNull();
+    }
+
+    private static Level1Entity354 CreateInlineRoot(int id, string contactName) =>
+        new()
+        {
+            Id = id,
+            Level2 = CreateLevel2Chain(id * 10, contactName)
+        };
+
+    private static Level2Entity354 CreateLevel2Chain(int baseId, string contactName) =>
+        new()
+        {
+            Id = baseId + 2,
+            Level3 = new Level3Entity354
+            {
+                Id = baseId + 3,
+                Level4 = new Level4Entity354
+                {
+                    Id = baseId + 4,
+                    Level5 = new Level5Entity354
+                    {
+                        Id = baseId + 5,
+                        Contact = new ConcreteContact354
+                        {
+                            Id = baseId + 6,
+                            Name = contactName
+                        }
+                    }
+                }
+            }
+        };
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+}
+
+public abstract class AbstractContact354
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class ConcreteContact354 : AbstractContact354
+{
+}
+
+[Facet(typeof(AbstractContact354),
+    Configuration = typeof(AbstractContact354Config),
+    Include = new[] { nameof(AbstractContact354.Id), nameof(AbstractContact354.Name) })]
+[Facet(typeof(ConcreteContact354),
+    Include = new[] { nameof(ConcreteContact354.Id), nameof(ConcreteContact354.Name) })]
+public partial class ContactFacet354
+{
+}
+
+public class AbstractContact354Config
+    : IFacetProjectionMapConfiguration<AbstractContact354, ContactFacet354>
+{
+    public static void ConfigureProjection(IFacetProjectionBuilder<AbstractContact354, ContactFacet354> builder)
+    {
+        builder.Map(d => d.Name, s => s.Name + " (abstract)");
+    }
+}
+
+public class Level5Entity354
+{
+    public int Id { get; set; }
+    public int? ContactId { get; set; }
+    public AbstractContact354? Contact { get; set; }
+}
+
+public class Level4Entity354
+{
+    public int Id { get; set; }
+    public int? Level5Id { get; set; }
+    public Level5Entity354? Level5 { get; set; }
+}
+
+public class Level3Entity354
+{
+    public int Id { get; set; }
+    public int? Level4Id { get; set; }
+    public Level4Entity354? Level4 { get; set; }
+}
+
+public class Level2Entity354
+{
+    public int Id { get; set; }
+    public int? Level3Id { get; set; }
+    public Level3Entity354? Level3 { get; set; }
+}
+
+public class Level1Entity354
+{
+    public int Id { get; set; }
+    public int? Level2Id { get; set; }
+    public Level2Entity354? Level2 { get; set; }
+}
+
+[Facet(typeof(Level5Entity354),
+    Include = new[] { nameof(Level5Entity354.Id), nameof(Level5Entity354.Contact) },
+    NestedFacets = new[] { typeof(ContactFacet354) })]
+public partial class Level5Dto354
+{
+}
+
+[Facet(typeof(Level4Entity354),
+    Include = new[] { nameof(Level4Entity354.Id), nameof(Level4Entity354.Level5) },
+    NestedFacets = new[] { typeof(Level5Dto354) })]
+public partial class Level4Dto354
+{
+}
+
+[Facet(typeof(Level3Entity354),
+    Configuration = typeof(Level3Dto354Config),
+    Include = new[] { nameof(Level3Entity354.Id), nameof(Level3Entity354.Level4) },
+    NestedFacets = new[] { typeof(Level4Dto354) })]
+public partial class Level3Dto354
+{
+}
+
+public class Level3Dto354Config
+    : IFacetProjectionMapConfiguration<Level3Entity354, Level3Dto354>
+{
+    public static void ConfigureProjection(IFacetProjectionBuilder<Level3Entity354, Level3Dto354> builder)
+    {
+        builder.Map(d => d.Id, s => s.Id + 30);
+    }
+}
+
+[Facet(typeof(Level2Entity354),
+    Include = new[] { nameof(Level2Entity354.Id), nameof(Level2Entity354.Level3) },
+    NestedFacets = new[] { typeof(Level3Dto354) })]
+public partial class Level2Dto354
+{
+}
+
+[Facet(typeof(Level1Entity354),
+    Include = new[] { nameof(Level1Entity354.Id), nameof(Level1Entity354.Level2) },
+    NestedFacets = new[] { typeof(Level2Dto354) })]
+public partial class Level1Dto354
+{
+}
+
+[Facet(typeof(Level1Entity354),
+    Configuration = typeof(Level1Dto354LazyConfig),
+    Include = new[] { nameof(Level1Entity354.Id), nameof(Level1Entity354.Level2) },
+    NestedFacets = new[] { typeof(Level2Dto354) })]
+public partial class Level1Dto354Lazy
+{
+}
+
+public class Level1Dto354LazyConfig
+    : IFacetProjectionMapConfiguration<Level1Entity354, Level1Dto354Lazy>
+{
+    public static void ConfigureProjection(IFacetProjectionBuilder<Level1Entity354, Level1Dto354Lazy> builder)
+    {
+        builder.Map(d => d.Id, s => s.Id + 1000);
+    }
+}
+
+public class BaseRootEntity354
+{
+    public int Id { get; set; }
+    public int? Level2Id { get; set; }
+    public Level2Entity354? Level2 { get; set; }
+}
+
+public class DerivedRootEntity354 : BaseRootEntity354
+{
+    public string Code { get; set; } = string.Empty;
+}
+
+[Facet(typeof(BaseRootEntity354),
+    Include = new[] { nameof(BaseRootEntity354.Id), nameof(BaseRootEntity354.Level2) },
+    NestedFacets = new[] { typeof(Level2Dto354) })]
+public partial class BaseRootDto354
+{
+}
+
+[Facet(typeof(DerivedRootEntity354),
+    Include = new[] { nameof(DerivedRootEntity354.Code) })]
+public partial class DerivedRootDto354 : BaseRootDto354
+{
+}
+
+public class DeepProjectionDbContext354 : DbContext
+{
+    public DeepProjectionDbContext354(DbContextOptions<DeepProjectionDbContext354> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Level1Entity354> Level1Entities => Set<Level1Entity354>();
+    public DbSet<DerivedRootEntity354> DerivedRootEntities => Set<DerivedRootEntity354>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<AbstractContact354>()
+            .HasDiscriminator<string>("ContactType")
+            .HasValue<ConcreteContact354>("Concrete");
+
+        modelBuilder.Entity<Level1Entity354>().HasKey(x => x.Id);
+        modelBuilder.Entity<Level2Entity354>().HasKey(x => x.Id);
+        modelBuilder.Entity<Level3Entity354>().HasKey(x => x.Id);
+        modelBuilder.Entity<Level4Entity354>().HasKey(x => x.Id);
+        modelBuilder.Entity<Level5Entity354>().HasKey(x => x.Id);
+        modelBuilder.Entity<BaseRootEntity354>().HasKey(x => x.Id);
+
+        modelBuilder.Entity<Level1Entity354>()
+            .HasOne(x => x.Level2)
+            .WithMany()
+            .HasForeignKey(x => x.Level2Id);
+
+        modelBuilder.Entity<Level2Entity354>()
+            .HasOne(x => x.Level3)
+            .WithMany()
+            .HasForeignKey(x => x.Level3Id);
+
+        modelBuilder.Entity<Level3Entity354>()
+            .HasOne(x => x.Level4)
+            .WithMany()
+            .HasForeignKey(x => x.Level4Id);
+
+        modelBuilder.Entity<Level4Entity354>()
+            .HasOne(x => x.Level5)
+            .WithMany()
+            .HasForeignKey(x => x.Level5Id);
+
+        modelBuilder.Entity<Level5Entity354>()
+            .HasOne(x => x.Contact)
+            .WithMany()
+            .HasForeignKey(x => x.ContactId);
+
+        modelBuilder.Entity<BaseRootEntity354>()
+            .HasOne(x => x.Level2)
+            .WithMany()
+            .HasForeignKey(x => x.Level2Id);
+    }
+}


### PR DESCRIPTION
When a parent DTO used the inline projection path and inlined a nested facet that had ConfigureProjection, the inline expansion only emitted auto-detected source members, ConfigureProjection mappings were completely lost