### PR TITLE
feat: CopyDocs parameter

### DIFF
--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -36,6 +36,7 @@ public partial class MyFacet { }
 | `PreserveRequiredProperties`   | `bool`    | Preserve required modifiers from source properties (default: true for records). |
 | `NullableProperties`           | `bool`    | Make all properties nullable in the generated facet (default: false). |
 | `CopyAttributes`               | `bool`    | Copy attributes from source type members to generated facet members (default: false). See [Attribute Copying](#attribute-copying) below. |
+| `CopyDocs`                     | `bool`    | Copy XML documentation comments from source type members to generated facet members (default: false). See [XML Documentation Copying](#xml-documentation-copying) below. |
 | `UseFullName`                  | `bool`    | Use full type name in generated file names to avoid collisions (default: false). |
 | `MaxDepth`                     | `int`     | Maximum depth for nested facet recursion to prevent stack overflow (default: 10). Set to 0 for unlimited (not recommended). See [Circular Reference Protection](#circular-reference-protection) below. |
 | `PreserveReferences`           | `bool`    | Enable runtime circular reference detection using object tracking (default: true). See [Circular Reference Protection](#circular-reference-protection) below. |
@@ -372,6 +373,104 @@ Both the parent and nested facets will have their attributes copied from their r
 ### Default Behavior
 
 By default, `CopyAttributes = false`, meaning no attributes are copied. This maintains backward compatibility and gives you explicit control over when attributes should be copied.
+
+## XML Documentation Copying
+
+The `CopyDocs` parameter allows you to copy XML documentation comments from the source type's members to the generated facet members. This is particularly useful when creating DTOs for API models that use tools like OpenAPI/Swagger, which can extract documentation from XML comments.
+
+### Usage
+
+```csharp
+public class User
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The user's first name.
+    /// </summary>
+    [Required]
+    [StringLength(50)]
+    public string FirstName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's email address. Must be a valid email format.
+    /// </summary>
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's age in years.
+    /// </summary>
+    [Range(0, 150)]
+    public int Age { get; set; }
+
+    public string Password { get; set; } = string.Empty;
+}
+
+[Facet(typeof(User), nameof(User.Password), CopyDocs = true)]
+public partial class UserDto;
+```
+
+The generated `UserDto` will include all the XML documentation comments:
+
+```csharp
+public partial class UserDto
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The user's first name.
+    /// </summary>
+    public string FirstName { get; set; }
+
+    /// <summary>
+    /// The user's email address. Must be a valid email format.
+    /// </summary>
+    public string Email { get; set; }
+
+    /// <summary>
+    /// The user's age in years.
+    /// </summary>
+    public int Age { get; set; }
+}
+```
+
+### Combining CopyDocs and CopyAttributes
+
+`CopyDocs` and `CopyAttributes` are independent options that can be used together:
+
+```csharp
+// Copy both attributes and XML documentation
+[Facet(typeof(User), nameof(User.Password), CopyAttributes = true, CopyDocs = true)]
+public partial class UserDto;
+
+// Copy only attributes
+[Facet(typeof(User), nameof(User.Password), CopyAttributes = true)]
+public partial class UserDto;
+
+// Copy only documentation
+[Facet(typeof(User), nameof(User.Password), CopyDocs = true)]
+public partial class UserDto;
+```
+
+### When to Use CopyDocs
+
+**Use `CopyDocs = true` when:**
+- Creating API DTOs for OpenAPI/Swagger documentation
+- Building DTOs that expose the same semantics as the domain models
+- Maintaining consistent documentation across layers
+- Generating client SDKs from your API that need inline documentation
+- Using XML documentation for UI tooltips or help text
+
+**Don't use it when:**
+- You want different documentation for your DTOs
+- Source model documentation includes internal implementation details
+- You prefer to define DTO-specific documentation
+
+### Default Behavior
+
+By default, `CopyDocs = false`, meaning no XML documentation is copied. This maintains backward compatibility and gives you explicit control over when documentation should be copied.
 
 ## Circular Reference Protection
 

--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -36,7 +36,7 @@ public partial class MyFacet { }
 | `PreserveRequiredProperties`   | `bool`    | Preserve required modifiers from source properties (default: true for records). |
 | `NullableProperties`           | `bool`    | Make all properties nullable in the generated facet (default: false). |
 | `CopyAttributes`               | `bool`    | Copy attributes from source type members to generated facet members (default: false). See [Attribute Copying](#attribute-copying) below. |
-| `CopyDocs`                     | `bool`    | Copy XML documentation comments from source type members to generated facet members (default: false). See [XML Documentation Copying](#xml-documentation-copying) below. |
+| `CopyDocs`                     | `bool`    | Copy XML documentation comments from source type members to generated facet members (default: true). See [XML Documentation Copying](#xml-documentation-copying) below. |
 | `UseFullName`                  | `bool`    | Use full type name in generated file names to avoid collisions (default: false). |
 | `MaxDepth`                     | `int`     | Maximum depth for nested facet recursion to prevent stack overflow (default: 10). Set to 0 for unlimited (not recommended). See [Circular Reference Protection](#circular-reference-protection) below. |
 | `PreserveReferences`           | `bool`    | Enable runtime circular reference detection using object tracking (default: true). See [Circular Reference Protection](#circular-reference-protection) below. |
@@ -470,7 +470,7 @@ public partial class UserDto;
 
 ### Default Behavior
 
-By default, `CopyDocs = false`, meaning no XML documentation is copied. This maintains backward compatibility and gives you explicit control over when documentation should be copied.
+By default, `CopyDocs = true`, meaning XML documentation is automatically copied from source types to DTOs. This is the most useful default for API DTOs and OpenAPI/Swagger scenarios. Set `CopyDocs = false` to disable copying if you want different documentation on your DTOs.
 
 ## Circular Reference Protection
 

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -154,9 +154,9 @@ public sealed class FacetAttribute : Attribute
     /// <summary>
     /// When true, copies XML documentation comments from the source type members to the generated facet members.
     /// This is useful for maintaining documentation in DTOs that are exposed through APIs like OpenAPI/Swagger.
-    /// Default is false.
+    /// Default is true.
     /// </summary>
-    public bool CopyDocs { get; set; } = false;
+    public bool CopyDocs { get; set; } = true;
 
     /// <summary>
     /// The maximum depth for nested facet recursion. When set to a positive value, the generator will

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -152,6 +152,13 @@ public sealed class FacetAttribute : Attribute
     public bool CopyAttributes { get; set; } = false;
 
     /// <summary>
+    /// When true, copies XML documentation comments from the source type members to the generated facet members.
+    /// This is useful for maintaining documentation in DTOs that are exposed through APIs like OpenAPI/Swagger.
+    /// Default is false.
+    /// </summary>
+    public bool CopyDocs { get; set; } = false;
+
+    /// <summary>
     /// The maximum depth for nested facet recursion. When set to a positive value, the generator will
     /// limit how deep nested facets can be instantiated to prevent stack overflow with circular references.
     /// A value of 0 means unlimited depth (not recommended - can cause stack overflow).

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -104,6 +104,7 @@ internal static class ModelBuilder
         var preserveRequired = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveRequiredProperties, preserveRequiredDefault);
         var nullableProperties = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.NullableProperties, globalDefaults.NullableProperties);
         var copyAttributes = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.CopyAttributes, globalDefaults.CopyAttributes);
+        var copyDocs = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.CopyDocs, globalDefaults.CopyDocs);
         var maxDepth = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.MaxDepth, globalDefaults.MaxDepth);
         var preserveReferences = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveReferences, globalDefaults.PreserveReferences);
 
@@ -209,6 +210,7 @@ internal static class ModelBuilder
             preserveRequired,
             nullableProperties,
             copyAttributes,
+            copyDocs,
             nestedFacetMappings,
             mapFromMappings,
             mapWhenMappings,
@@ -347,6 +349,7 @@ internal static class ModelBuilder
         bool preserveRequired,
         bool nullableProperties,
         bool copyAttributes,
+        bool copyDocs,
         Dictionary<string, (string childFacetTypeName, string sourceTypeName)> nestedFacetMappings,
         Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection, bool isTargetRequired)> mapFromMappings,
         Dictionary<string, (List<string> conditions, string? defaultValue, bool includeInProjection)> mapWhenMappings,
@@ -390,6 +393,7 @@ internal static class ModelBuilder
                     preserveRequired,
                     nullableProperties,
                     copyAttributes,
+                    copyDocs,
                     nestedFacetMappings,
                     mapFromMappings,
                     mapWhenMappings,
@@ -408,6 +412,7 @@ internal static class ModelBuilder
                     preserveRequired,
                     nullableProperties,
                     copyAttributes,
+                    copyDocs,
                     members,
                     excludedRequiredMembers,
                     addedMembers);
@@ -426,6 +431,7 @@ internal static class ModelBuilder
         bool preserveRequired,
         bool nullableProperties,
         bool copyAttributes,
+        bool copyDocs,
         Dictionary<string, (string childFacetTypeName, string sourceTypeName)> nestedFacetMappings,
         Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection, bool isTargetRequired)> mapFromMappings,
         Dictionary<string, (List<string> conditions, string? defaultValue, bool includeInProjection)> mapWhenMappings,
@@ -435,7 +441,7 @@ internal static class ModelBuilder
         List<FacetMember> excludedRequiredMembers,
         HashSet<string> addedMembers)
     {
-        var memberXmlDocumentation = CodeGenerationHelpers.ExtractXmlDocumentation(property);
+        var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(property) : null;
 
         // Check if this source property has a MapFrom attribute pointing to it
         var hasMapFrom = mapFromMappings.TryGetValue(property.Name, out var mapFromInfo);
@@ -785,11 +791,12 @@ internal static class ModelBuilder
         bool preserveRequired,
         bool nullableProperties,
         bool copyAttributes,
+        bool copyDocs,
         List<FacetMember> members,
         List<FacetMember> excludedRequiredMembers,
         HashSet<string> addedMembers)
     {
-        var memberXmlDocumentation = CodeGenerationHelpers.ExtractXmlDocumentation(field);
+        var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(field) : null;
 
         if (!shouldIncludeMember)
         {

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -125,6 +125,7 @@ internal static class FacetConstants
         public const string PreserveRequiredProperties = "PreserveRequiredProperties";
         public const string NullableProperties = "NullableProperties";
         public const string CopyAttributes = "CopyAttributes";
+        public const string CopyDocs = "CopyDocs";
         public const string MaxDepth = "MaxDepth";
         public const string PreserveReferences = "PreserveReferences";
         public const string UseFullName = "UseFullName";

--- a/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
+++ b/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
@@ -58,6 +58,12 @@ internal sealed class GlobalConfigurationDefaults
     public bool CopyAttributes { get; }
 
     /// <summary>
+    /// Default value for CopyDocs (default: false).
+    /// Can be overridden by setting the Facet_CopyDocs MSBuild property.
+    /// </summary>
+    public bool CopyDocs { get; }
+
+    /// <summary>
     /// Default value for UseFullName (default: false).
     /// Can be overridden by setting the Facet_UseFullName MSBuild property.
     /// </summary>
@@ -96,6 +102,7 @@ internal sealed class GlobalConfigurationDefaults
         bool chainToParameterlessConstructor,
         bool nullableProperties,
         bool copyAttributes,
+        bool copyDocs,
         bool useFullName,
         bool generateCopyConstructor,
         bool generateEquality,
@@ -110,6 +117,7 @@ internal sealed class GlobalConfigurationDefaults
         ChainToParameterlessConstructor = chainToParameterlessConstructor;
         NullableProperties = nullableProperties;
         CopyAttributes = copyAttributes;
+        CopyDocs = copyDocs;
         UseFullName = useFullName;
         GenerateCopyConstructor = generateCopyConstructor;
         GenerateEquality = generateEquality;
@@ -132,6 +140,7 @@ internal sealed class GlobalConfigurationDefaults
             chainToParameterlessConstructor: GetBoolOption(globalOptions, "build_property.Facet_ChainToParameterlessConstructor", defaultValue: false),
             nullableProperties: GetBoolOption(globalOptions, "build_property.Facet_NullableProperties", defaultValue: false),
             copyAttributes: GetBoolOption(globalOptions, "build_property.Facet_CopyAttributes", defaultValue: false),
+            copyDocs: GetBoolOption(globalOptions, "build_property.Facet_CopyDocs", defaultValue: false),
             useFullName: GetBoolOption(globalOptions, "build_property.Facet_UseFullName", defaultValue: false),
             generateCopyConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateCopyConstructor", defaultValue: false),
             generateEquality: GetBoolOption(globalOptions, "build_property.Facet_GenerateEquality", defaultValue: false),

--- a/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
+++ b/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
@@ -58,7 +58,7 @@ internal sealed class GlobalConfigurationDefaults
     public bool CopyAttributes { get; }
 
     /// <summary>
-    /// Default value for CopyDocs (default: false).
+    /// Default value for CopyDocs (default: true).
     /// Can be overridden by setting the Facet_CopyDocs MSBuild property.
     /// </summary>
     public bool CopyDocs { get; }
@@ -140,7 +140,7 @@ internal sealed class GlobalConfigurationDefaults
             chainToParameterlessConstructor: GetBoolOption(globalOptions, "build_property.Facet_ChainToParameterlessConstructor", defaultValue: false),
             nullableProperties: GetBoolOption(globalOptions, "build_property.Facet_NullableProperties", defaultValue: false),
             copyAttributes: GetBoolOption(globalOptions, "build_property.Facet_CopyAttributes", defaultValue: false),
-            copyDocs: GetBoolOption(globalOptions, "build_property.Facet_CopyDocs", defaultValue: false),
+            copyDocs: GetBoolOption(globalOptions, "build_property.Facet_CopyDocs", defaultValue: true),
             useFullName: GetBoolOption(globalOptions, "build_property.Facet_UseFullName", defaultValue: false),
             generateCopyConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateCopyConstructor", defaultValue: false),
             generateEquality: GetBoolOption(globalOptions, "build_property.Facet_GenerateEquality", defaultValue: false),

--- a/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
@@ -1,0 +1,207 @@
+using System.Reflection;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+public class CopyDocsTests
+{
+    [Fact]
+    public void Facet_ShouldCopyXmlDocs_WhenCopyDocsIsTrue()
+    {
+        // Arrange & Act
+        var firstNameProperty = typeof(UserWithDocsDto).GetProperty("FirstName");
+        var emailProperty = typeof(UserWithDocsDto).GetProperty("Email");
+        var ageProperty = typeof(UserWithDocsDto).GetProperty("Age");
+
+        // Assert - We can't directly access XML docs via reflection at runtime,
+        // but we can verify the generated code compiles and properties exist
+        firstNameProperty.Should().NotBeNull();
+        emailProperty.Should().NotBeNull();
+        ageProperty.Should().NotBeNull();
+
+        // The actual XML documentation copying is verified by the source generator tests
+        // and by inspecting the generated code
+    }
+
+    [Fact]
+    public void Facet_ShouldNotCopyXmlDocs_WhenCopyDocsIsFalse()
+    {
+        // Arrange & Act
+        var dtoType = typeof(UserWithDocsNoCopyDto);
+
+        // Assert - Properties should exist but without XML docs
+        var firstNameProperty = dtoType.GetProperty("FirstName");
+        var emailProperty = dtoType.GetProperty("Email");
+
+        firstNameProperty.Should().NotBeNull();
+        emailProperty.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Facet_ShouldCopyXmlDocs_WithNestedFacets()
+    {
+        // Arrange & Act
+        var orderDtoType = typeof(OrderWithDocsDto);
+        var customerProperty = orderDtoType.GetProperty("Customer");
+        var orderNumberProperty = orderDtoType.GetProperty("OrderNumber");
+        var totalAmountProperty = orderDtoType.GetProperty("TotalAmount");
+
+        // Assert
+        orderNumberProperty.Should().NotBeNull();
+        totalAmountProperty.Should().NotBeNull();
+        customerProperty.Should().NotBeNull();
+        customerProperty!.PropertyType.Should().Be(typeof(CustomerWithDocsDto));
+    }
+
+    [Fact]
+    public void Facet_ShouldCopyXmlDocs_OnNestedFacetProperties()
+    {
+        // Arrange & Act
+        var customerDtoType = typeof(CustomerWithDocsDto);
+        var emailProperty = customerDtoType.GetProperty("Email");
+        var fullNameProperty = customerDtoType.GetProperty("FullName");
+
+        // Assert - Properties exist (docs are in generated code)
+        emailProperty.Should().NotBeNull();
+        fullNameProperty.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Facet_CanCombine_CopyDocsAndCopyAttributes()
+    {
+        // Arrange & Act
+        var dtoType = typeof(UserWithDocsAndAttributesDto);
+        var firstNameProperty = dtoType.GetProperty("FirstName");
+        var emailProperty = dtoType.GetProperty("Email");
+
+        // Assert - Should have both attributes and docs
+        firstNameProperty.Should().NotBeNull();
+        firstNameProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>().Should().NotBeNull();
+        firstNameProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.StringLengthAttribute>().Should().NotBeNull();
+
+        emailProperty.Should().NotBeNull();
+        emailProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>().Should().NotBeNull();
+        emailProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.EmailAddressAttribute>().Should().NotBeNull();
+    }
+}
+
+// Source model with XML documentation
+public class UserWithDocs
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The user's first name.
+    /// </summary>
+    public string FirstName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's last name.
+    /// </summary>
+    public string LastName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's email address. Must be a valid email format.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's age in years.
+    /// </summary>
+    public int Age { get; set; }
+
+    /// <summary>
+    /// This should be excluded and not appear in DTO.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+}
+
+// DTO with CopyDocs = true
+[Facet(typeof(UserWithDocs), nameof(UserWithDocs.Password), nameof(UserWithDocs.LastName), CopyDocs = true)]
+public partial class UserWithDocsDto
+{
+}
+
+// DTO with CopyDocs = false (default)
+[Facet(typeof(UserWithDocs), nameof(UserWithDocs.Password), nameof(UserWithDocs.Age))]
+public partial class UserWithDocsNoCopyDto
+{
+}
+
+// Models for nested facet tests
+public class CustomerWithDocs
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The customer's full name.
+    /// </summary>
+    public string FullName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The customer's email address.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    public string? PhoneNumber { get; set; }
+}
+
+[Facet(typeof(CustomerWithDocs), nameof(CustomerWithDocs.PhoneNumber), CopyDocs = true)]
+public partial class CustomerWithDocsDto
+{
+}
+
+public class OrderWithDocs
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The unique order number.
+    /// </summary>
+    public string OrderNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The total amount for this order.
+    /// </summary>
+    public decimal TotalAmount { get; set; }
+
+    public DateTime OrderDate { get; set; }
+
+    /// <summary>
+    /// The customer who placed this order.
+    /// </summary>
+    public CustomerWithDocs Customer { get; set; } = null!;
+
+    public string? InternalNotes { get; set; }
+}
+
+[Facet(typeof(OrderWithDocs), nameof(OrderWithDocs.InternalNotes), CopyDocs = true, NestedFacets = [typeof(CustomerWithDocsDto)])]
+public partial class OrderWithDocsDto
+{
+}
+
+// Model combining both CopyDocs and CopyAttributes
+public class UserWithDocsAndAttributes
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The user's first name.
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Required]
+    [System.ComponentModel.DataAnnotations.StringLength(50)]
+    public string FirstName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's email address.
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Required]
+    [System.ComponentModel.DataAnnotations.EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+}
+
+[Facet(typeof(UserWithDocsAndAttributes), nameof(UserWithDocsAndAttributes.Password), CopyDocs = true, CopyAttributes = true)]
+public partial class UserWithDocsAndAttributesDto
+{
+}

--- a/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
@@ -121,8 +121,8 @@ public partial class UserWithDocsDto
 {
 }
 
-// DTO with CopyDocs = false (default)
-[Facet(typeof(UserWithDocs), nameof(UserWithDocs.Password), nameof(UserWithDocs.Age))]
+// DTO with CopyDocs = false (opt-out)
+[Facet(typeof(UserWithDocs), nameof(UserWithDocs.Password), nameof(UserWithDocs.Age), CopyDocs = false)]
 public partial class UserWithDocsNoCopyDto
 {
 }


### PR DESCRIPTION
Implements feature request #356 

- **`CopyDocs` property** on `[Facet]` attribute (opt-out, default: `true`)
- Works independently from `CopyAttributes`, can use together or separately
- Supports global configuration via MSBuild property: `Facet_CopyDocs`

Added unit tests

Closes #356
