### PR TITLE
feat: InheritDocs parameter

### DIFF
--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -159,6 +159,13 @@ public sealed class FacetAttribute : Attribute
     public bool CopyDocs { get; set; } = true;
 
     /// <summary>
+    /// When true and <see cref="CopyDocs"/> is also true, documentation is inherited from base classes
+    /// and interfaces when the member has no documentation of its own.
+    /// Default is true.
+    /// </summary>
+    public bool InheritDocs { get; set; } = true;
+
+    /// <summary>
     /// The maximum depth for nested facet recursion. When set to a positive value, the generator will
     /// limit how deep nested facets can be instantiated to prevent stack overflow with circular references.
     /// A value of 0 means unlimited depth (not recommended - can cause stack overflow).

--- a/src/Facet/Facet.props
+++ b/src/Facet/Facet.props
@@ -13,6 +13,8 @@
     <CompilerVisibleProperty Include="Facet_ChainToParameterlessConstructor" />
     <CompilerVisibleProperty Include="Facet_NullableProperties" />
     <CompilerVisibleProperty Include="Facet_CopyAttributes" />
+    <CompilerVisibleProperty Include="Facet_CopyDocs" />
+    <CompilerVisibleProperty Include="Facet_InheritDocs" />
     <CompilerVisibleProperty Include="Facet_UseFullName" />
     <CompilerVisibleProperty Include="Facet_GenerateCopyConstructor" />
     <CompilerVisibleProperty Include="Facet_GenerateEquality" />

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -103,6 +103,14 @@ internal static class CodeBuilder
         {
             MemberGenerator.GenerateMembers(sb, model, memberIndent);
         }
+        else
+        {
+            // Positional parameters can't carry doc comments; emit property body overrides for documented members.
+            var membersWithDocs = model.Members
+                .Where(static m => !string.IsNullOrWhiteSpace(m.XmlDocumentation) && !m.IsUserDeclared)
+                .ToList();
+            MemberGenerator.GenerateMembers(sb, model, memberIndent, membersWithDocs, usePropertyNameAsInitializer: true);
+        }
 
         // Generate parameterless constructor first if requested
         // This ensures third-party code that picks the first constructor will use the parameterless one

--- a/src/Facet/Generators/FacetGenerators/CodeGenerationHelpers.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeGenerationHelpers.cs
@@ -410,14 +410,57 @@ internal static class CodeGenerationHelpers
 
     /// <summary>
     /// Extracts and formats XML documentation from a symbol.
+    /// When <paramref name="inheritDocs"/> is true and the symbol has no documentation,
+    /// falls back to base classes and then interfaces to find inherited documentation.
     /// </summary>
-    public static string? ExtractXmlDocumentation(ISymbol symbol)
+    public static string? ExtractXmlDocumentation(ISymbol symbol, bool inheritDocs = false)
     {
         var documentationComment = symbol.GetDocumentationCommentXml();
-        if (string.IsNullOrWhiteSpace(documentationComment))
+        if (!string.IsNullOrWhiteSpace(documentationComment))
+            return FormatXmlDocumentation(documentationComment!);
+
+        if (!inheritDocs)
             return null;
 
-        return FormatXmlDocumentation(documentationComment!);
+        return ExtractXmlDocumentationFromHierarchy(symbol);
+    }
+
+    private static string? ExtractXmlDocumentationFromHierarchy(ISymbol symbol)
+    {
+        if (symbol is not (IPropertySymbol or IFieldSymbol))
+            return null;
+
+        var containingType = symbol.ContainingType;
+        if (containingType is null)
+            return null;
+
+        var baseType = containingType.BaseType;
+        while (baseType is not null)
+        {
+            if (baseType.SpecialType == SpecialType.System_Object)
+                break;
+            var match = baseType.GetMembers(symbol.Name).FirstOrDefault(m => m.Kind == symbol.Kind);
+            if (match is not null)
+            {
+                var doc = match.GetDocumentationCommentXml();
+                if (!string.IsNullOrWhiteSpace(doc))
+                    return FormatXmlDocumentation(doc!);
+            }
+            baseType = baseType.BaseType;
+        }
+
+        foreach (var iface in containingType.AllInterfaces)
+        {
+            var match = iface.GetMembers(symbol.Name).FirstOrDefault(m => m.Kind == symbol.Kind);
+            if (match is not null)
+            {
+                var doc = match.GetDocumentationCommentXml();
+                if (!string.IsNullOrWhiteSpace(doc))
+                    return FormatXmlDocumentation(doc!);
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Facet/Generators/FacetGenerators/MemberGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/MemberGenerator.cs
@@ -16,11 +16,17 @@ internal static class MemberGenerator
     /// <see cref="FacetTargetModel.Members"/>.  Used by the multi-source combined generator to emit
     /// the union of all source members.
     /// </param>
+    /// <param name="usePropertyNameAsInitializer">
+    /// When <see langword="true"/>, each generated property is initialized with <c>= PropertyName;</c>
+    /// instead of a type default. Required for positional record body overrides, where the initializer
+    /// reads from the matching positional parameter and satisfies CS8907 ("Parameter 'X' is unread").
+    /// </param>
     public static void GenerateMembers(
         StringBuilder sb,
         FacetTargetModel model,
         string memberIndent,
-        System.Collections.Generic.IReadOnlyList<FacetMember>? membersOverride = null)
+        System.Collections.Generic.IReadOnlyList<FacetMember>? membersOverride = null,
+        bool usePropertyNameAsInitializer = false)
     {
         // Create a HashSet for efficient lookup of base class member names
         var baseClassMembers = new System.Collections.Generic.HashSet<string>(model.BaseClassMemberNames);
@@ -52,7 +58,7 @@ internal static class MemberGenerator
 
             if (m.Kind == FacetMemberKind.Property)
             {
-                GenerateProperty(sb, m, memberIndent);
+                GenerateProperty(sb, m, memberIndent, usePropertyNameAsInitializer);
             }
             else
             {
@@ -61,7 +67,7 @@ internal static class MemberGenerator
         }
     }
 
-    private static void GenerateProperty(StringBuilder sb, FacetMember member, string indent)
+    private static void GenerateProperty(StringBuilder sb, FacetMember member, string indent, bool usePropertyNameAsInitializer = false)
     {
         var propDef = $"public {member.TypeName} {member.Name}";
 
@@ -75,7 +81,11 @@ internal static class MemberGenerator
         }
 
         // Add a default value or the "= default!" null-suppression for non-nullable reference types.
-        if (!string.IsNullOrEmpty(member.DefaultValue))
+        if (usePropertyNameAsInitializer)
+        {
+            propDef += $" = {member.Name};";
+        }
+        else if (!string.IsNullOrEmpty(member.DefaultValue))
         {
             propDef += $" = {member.DefaultValue};";
         }

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -105,6 +105,7 @@ internal static class ModelBuilder
         var nullableProperties = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.NullableProperties, globalDefaults.NullableProperties);
         var copyAttributes = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.CopyAttributes, globalDefaults.CopyAttributes);
         var copyDocs = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.CopyDocs, globalDefaults.CopyDocs);
+        var inheritDocs = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.InheritDocs, globalDefaults.InheritDocs);
         var maxDepth = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.MaxDepth, globalDefaults.MaxDepth);
         var preserveReferences = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveReferences, globalDefaults.PreserveReferences);
 
@@ -211,6 +212,7 @@ internal static class ModelBuilder
             nullableProperties,
             copyAttributes,
             copyDocs,
+            inheritDocs,
             nestedFacetMappings,
             mapFromMappings,
             mapWhenMappings,
@@ -350,6 +352,7 @@ internal static class ModelBuilder
         bool nullableProperties,
         bool copyAttributes,
         bool copyDocs,
+        bool inheritDocs,
         Dictionary<string, (string childFacetTypeName, string sourceTypeName)> nestedFacetMappings,
         Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection, bool isTargetRequired)> mapFromMappings,
         Dictionary<string, (List<string> conditions, string? defaultValue, bool includeInProjection)> mapWhenMappings,
@@ -394,6 +397,7 @@ internal static class ModelBuilder
                     nullableProperties,
                     copyAttributes,
                     copyDocs,
+                    inheritDocs,
                     nestedFacetMappings,
                     mapFromMappings,
                     mapWhenMappings,
@@ -413,6 +417,7 @@ internal static class ModelBuilder
                     nullableProperties,
                     copyAttributes,
                     copyDocs,
+                    inheritDocs,
                     members,
                     excludedRequiredMembers,
                     addedMembers);
@@ -432,6 +437,7 @@ internal static class ModelBuilder
         bool nullableProperties,
         bool copyAttributes,
         bool copyDocs,
+        bool inheritDocs,
         Dictionary<string, (string childFacetTypeName, string sourceTypeName)> nestedFacetMappings,
         Dictionary<string, (string targetName, string source, bool reversible, bool includeInProjection, string typeName, string? asCollection, bool isTargetRequired)> mapFromMappings,
         Dictionary<string, (List<string> conditions, string? defaultValue, bool includeInProjection)> mapWhenMappings,
@@ -441,7 +447,7 @@ internal static class ModelBuilder
         List<FacetMember> excludedRequiredMembers,
         HashSet<string> addedMembers)
     {
-        var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(property) : null;
+        var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(property, inheritDocs) : null;
 
         // Check if this source property has a MapFrom attribute pointing to it
         var hasMapFrom = mapFromMappings.TryGetValue(property.Name, out var mapFromInfo);
@@ -792,11 +798,12 @@ internal static class ModelBuilder
         bool nullableProperties,
         bool copyAttributes,
         bool copyDocs,
+        bool inheritDocs,
         List<FacetMember> members,
         List<FacetMember> excludedRequiredMembers,
         HashSet<string> addedMembers)
     {
-        var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(field) : null;
+        var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(field, inheritDocs) : null;
 
         if (!shouldIncludeMember)
         {

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -126,6 +126,7 @@ internal static class FacetConstants
         public const string NullableProperties = "NullableProperties";
         public const string CopyAttributes = "CopyAttributes";
         public const string CopyDocs = "CopyDocs";
+        public const string InheritDocs = "InheritDocs";
         public const string MaxDepth = "MaxDepth";
         public const string PreserveReferences = "PreserveReferences";
         public const string UseFullName = "UseFullName";

--- a/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
+++ b/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
@@ -64,6 +64,12 @@ internal sealed class GlobalConfigurationDefaults
     public bool CopyDocs { get; }
 
     /// <summary>
+    /// Default value for InheritDocs (default: true).
+    /// Can be overridden by setting the Facet_InheritDocs MSBuild property.
+    /// </summary>
+    public bool InheritDocs { get; }
+
+    /// <summary>
     /// Default value for UseFullName (default: false).
     /// Can be overridden by setting the Facet_UseFullName MSBuild property.
     /// </summary>
@@ -103,6 +109,7 @@ internal sealed class GlobalConfigurationDefaults
         bool nullableProperties,
         bool copyAttributes,
         bool copyDocs,
+        bool inheritDocs,
         bool useFullName,
         bool generateCopyConstructor,
         bool generateEquality,
@@ -118,6 +125,7 @@ internal sealed class GlobalConfigurationDefaults
         NullableProperties = nullableProperties;
         CopyAttributes = copyAttributes;
         CopyDocs = copyDocs;
+        InheritDocs = inheritDocs;
         UseFullName = useFullName;
         GenerateCopyConstructor = generateCopyConstructor;
         GenerateEquality = generateEquality;
@@ -141,6 +149,7 @@ internal sealed class GlobalConfigurationDefaults
             nullableProperties: GetBoolOption(globalOptions, "build_property.Facet_NullableProperties", defaultValue: false),
             copyAttributes: GetBoolOption(globalOptions, "build_property.Facet_CopyAttributes", defaultValue: false),
             copyDocs: GetBoolOption(globalOptions, "build_property.Facet_CopyDocs", defaultValue: true),
+            inheritDocs: GetBoolOption(globalOptions, "build_property.Facet_InheritDocs", defaultValue: true),
             useFullName: GetBoolOption(globalOptions, "build_property.Facet_UseFullName", defaultValue: false),
             generateCopyConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateCopyConstructor", defaultValue: false),
             generateEquality: GetBoolOption(globalOptions, "build_property.Facet_GenerateEquality", defaultValue: false),

--- a/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
@@ -84,6 +84,144 @@ public class CopyDocsTests
     }
 }
 
+public class InheritDocsTests
+{
+    // Reads the generator-emitted .g.cs file for a DTO type so tests can assert on doc content.
+    private static string LoadGeneratedSource(string typeFullName)
+    {
+        var projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        var path = Path.Combine(projectRoot, "obj", "Generated", "Facet", "Facet.Generators.FacetGenerator", $"{typeFullName}.g.cs");
+        try { return File.ReadAllText(path); }
+        catch (FileNotFoundException) { return string.Empty; }
+    }
+
+    [Fact]
+    public void Facet_ShouldInheritDocsFromInterface_WhenInheritDocsIsTrue()
+    {
+        var source = LoadGeneratedSource(typeof(DocumentedServiceDto).FullName!);
+        source.Should().NotBeEmpty("generated file should exist");
+        source.Should().Contain("The service title.");
+        source.Should().Contain("A description of the service.");
+    }
+
+    [Fact]
+    public void Facet_ShouldInheritDocsFromBaseClass_WhenOverridingPropertyHasNoDocs()
+    {
+        // ConcreteProduct.Name is an override with no doc comment; the doc lives on ProductBase.Name.
+        var source = LoadGeneratedSource(typeof(ConcreteProductDto).FullName!);
+        source.Should().NotBeEmpty("generated file should exist");
+        source.Should().Contain("The product name.");
+    }
+
+    [Fact]
+    public void Facet_ShouldNotInheritDocs_WhenInheritDocsIsFalse()
+    {
+        // Same override scenario but InheritDocs=false: Name should have no doc comment.
+        var source = LoadGeneratedSource(typeof(ConcreteProductNoInheritDto).FullName!);
+        source.Should().NotBeEmpty("generated file should exist");
+        source.Should().NotContain("The product name.");
+    }
+
+    [Fact]
+    public void Facet_ShouldUseOwnDocs_WhenMemberHasDirectDocComment()
+    {
+        // ConcreteProduct.Price has its own summary; it must appear in both DTOs
+        // regardless of InheritDocs, confirming direct docs are never suppressed.
+        var inheritSource = LoadGeneratedSource(typeof(ConcreteProductDto).FullName!);
+        var noInheritSource = LoadGeneratedSource(typeof(ConcreteProductNoInheritDto).FullName!);
+        inheritSource.Should().Contain("The selling price.");
+        noInheritSource.Should().Contain("The selling price.");
+    }
+
+    [Fact]
+    public void Facet_ShouldEmitDocCommentsOnPositionalRecordProperties_WhenDocsAreInherited()
+    {
+        // Positional records require property body overrides to carry doc comments.
+        // Without the usePropertyNameAsInitializer path in CodeBuilder, docs are silently dropped.
+        var source = LoadGeneratedSource(typeof(DocumentedPositionalDto).FullName!);
+        source.Should().NotBeEmpty("generated file should exist");
+        source.Should().Contain("The entity identifier.");
+        source.Should().Contain("The entity name.");
+    }
+}
+
+// Base class whose virtual property has documentation
+public class ProductBase
+{
+    /// <summary>
+    /// The product name.
+    /// </summary>
+    public virtual string Name { get; set; } = string.Empty;
+
+    public string Sku { get; set; } = string.Empty;
+}
+
+// Derived class that overrides Name without adding docs, and adds a documented Price property.
+// This is the key model for InheritDocs base-class tests: Name is re-declared (override) but
+// has no doc comment, so inheritance is required to surface the base-class summary.
+public class ConcreteProduct : ProductBase
+{
+    public override string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The selling price.
+    /// </summary>
+    public decimal Price { get; set; }
+}
+
+[Facet(typeof(ConcreteProduct), CopyDocs = true, InheritDocs = true)]
+public partial class ConcreteProductDto { }
+
+[Facet(typeof(ConcreteProduct), CopyDocs = true, InheritDocs = false)]
+public partial class ConcreteProductNoInheritDto { }
+
+// Interface whose members carry documentation
+public interface IDocumentedService
+{
+    /// <summary>
+    /// The service title.
+    /// </summary>
+    string Title { get; set; }
+
+    /// <summary>
+    /// A description of the service.
+    /// </summary>
+    string Description { get; set; }
+}
+
+// Concrete implementation with no doc comments on the properties
+public class DocumentedService : IDocumentedService
+{
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+[Facet(typeof(DocumentedService), CopyDocs = true, InheritDocs = true)]
+public partial class DocumentedServiceDto { }
+
+// Interface + concrete class for the positional record test
+public interface IDocumentedEntity
+{
+    /// <summary>
+    /// The entity identifier.
+    /// </summary>
+    int Id { get; }
+
+    /// <summary>
+    /// The entity name.
+    /// </summary>
+    string Name { get; }
+}
+
+public class DocumentedEntity : IDocumentedEntity
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+}
+
+[Facet(typeof(DocumentedEntity), CopyDocs = true)]
+public partial record DocumentedPositionalDto;
+
 // Source model with XML documentation
 public class UserWithDocs
 {


### PR DESCRIPTION
The first commit adds an 'InheritDocs' parameter to the FacetAttribute.

Specifically toggles whether or not to go up the inheritance hierarchy for a member looking for XML docs instead of the current behaviour which stops at the member itself.

The second commit is a fix for docs on positional constructors.

Fixes: https://github.com/Tim-Maes/Facet/issues/359