### PR TITLE
fix: MaxDepth with ToSource

### DIFF
--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -39,6 +39,7 @@ public partial class MyFacet { }
 | `CopyDocs`                     | `bool`    | Copy XML documentation comments from source type members to generated facet members (default: true). See [XML Documentation Copying](#xml-documentation-copying) below. |
 | `UseFullName`                  | `bool`    | Use full type name in generated file names to avoid collisions (default: false). |
 | `MaxDepth`                     | `int`     | Maximum depth for nested facet recursion to prevent stack overflow (default: 10). Set to 0 for unlimited (not recommended). See [Circular Reference Protection](#circular-reference-protection) below. |
+| `MaxDepthToSource`             | `int`     | Maximum depth for `ToSource()` reverse mapping, independent of `MaxDepth`. Default is 0 (no limit, same as existing behavior). Set to a positive value to limit how many levels `ToSource()` maps back. See [MaxDepthToSource](#maxdepthtosource) below. |
 | `PreserveReferences`           | `bool`    | Enable runtime circular reference detection using object tracking (default: true). See [Circular Reference Protection](#circular-reference-protection) below. |
 | `SourceSignature`              | `string?` | Hash signature to track source entity changes. Emits FAC022 warning when source structure changes. See [Source Signature Change Tracking](16_SourceSignature.md). |
 | `ConvertEnumsTo`               | `Type?`   | When set, all enum properties are converted to the specified type (`typeof(string)` or `typeof(int)`) in the generated facet. Default is null (enums retain their original types). See [Enum Conversion](20_ConvertEnumsTo.md). |
@@ -502,6 +503,52 @@ public partial record SimpleTypeDto;
 - **Level 2**: Second level nested objects (e.g., Product)
 - **Level 3**: Third level nested objects (e.g., Category)
 - Properties that would exceed MaxDepth are set to `null` (with default MaxDepth = 10, this covers most real-world scenarios)
+
+### MaxDepthToSource
+
+Controls how many levels deep `ToSource()` maps nested objects back to the source entity. This is independent of `MaxDepth`, which only controls the forward source-to-DTO direction.
+
+**Default:** `0` (no limit - preserves existing behavior)
+
+**Use case:** Backends with separation of duties often only want the top-level entity updated via `ToSource()`, without cascading saves into child entities. Setting `MaxDepthToSource = 1` maps only the root object and leaves all nested entity references as `null` (or empty collections).
+
+```csharp
+// ToFacet (source -> DTO) goes up to 5 levels deep.
+// ToSource (DTO -> entity) only maps the top-level object.
+[Facet(typeof(Order), GenerateToSource = true,
+       MaxDepth = 5, MaxDepthToSource = 1,
+       NestedFacets = [typeof(LineItemDto)])]
+public partial class OrderDto;
+```
+
+**How MaxDepthToSource Works:**
+
+When `MaxDepthToSource > 0`, Facet generates two overloads of `ToSource()`:
+
+- `public ToSource()` - the public entry point, calls `ToSource(0)`
+- `internal ToSource(int __depth)` - carries the depth counter through nested calls
+
+At the root level `__depth = 0`, so children at depth 0 are still mapped (the guard is `__depth < MaxDepthToSource`). Once the limit is reached, nested entity references become `null` and collections become empty.
+
+```csharp
+// Only the root Order entity properties are set; LineItems is empty.
+[Facet(typeof(Order), GenerateToSource = true,
+       MaxDepthToSource = 1,
+       NestedFacets = [typeof(LineItemDto)])]
+public partial class OrderDto;
+
+var entity = dto.ToSource(); // entity.LineItems is []
+```
+
+```csharp
+// Both Order and its LineItems are mapped; LineItem.Product is null.
+[Facet(typeof(Order), GenerateToSource = true,
+       MaxDepthToSource = 2,
+       NestedFacets = [typeof(LineItemDto)])]
+public partial class OrderDto;
+```
+
+`MaxDepthToSource` only applies to facets that have `GenerateToSource = true`. Child facets that do not set `MaxDepthToSource` are called via their normal `ToSource()` and are not depth-limited.
 
 ### PreserveReferences
 

--- a/docs/04_CustomMapping.md
+++ b/docs/04_CustomMapping.md
@@ -661,7 +661,17 @@ The `BuildProjection()` method assembles a `MemberInitExpression`, inlines the `
 - Expressions in `ConfigureProjection` must be EF Core-translatable (property access, arithmetic, string concatenation, ternaries). Facet cannot validate this at compile time; EF Core will throw at runtime if they are not.
 - `ConfigureProjection` is called **once** during lazy initialisation, do not reference instance state or external services.
 - Properties omitted from `ConfigureProjection` but present in `Map()` will **not** appear in `Projection`. This is intentional.
-- Nested facet bindings in the lazy projection are not auto-generated; add them in `ConfigureProjection` if needed.
+- Nested facet bindings in the lazy projection are not auto-generated; add them in `ConfigureProjection` if needed. When mapping a child facet that shares the same source entity, pass the child's static `Projection` property directly instead of calling `source.ToFacet<T>()`. `ToFacet<T>()` is a runtime method call that EF Core cannot translate; the `Projection` expression is what gets inlined and translated:
+
+```csharp
+// WRONG - source.ToFacet<T>() is not EF Core-translatable and will produce null properties
+builder.Map(t => t.OrderLineDto, s => s.ToFacet<OrderLineDto>());
+
+// CORRECT - pass the child Projection directly; Facet inlines it as an expression
+builder.Map(t => t.OrderLineDto, OrderLineDto.Projection);
+```
+
+For in-memory (non-EF Core) use, add a partial constructor that calls `new ChildFacet(source)` for each property.
 - Thread safety is provided by `LazyInitializer.EnsureInitialized`.
 
 ---

--- a/docs/21_GlobalConfigurationDefaults.md
+++ b/docs/21_GlobalConfigurationDefaults.md
@@ -26,6 +26,7 @@ The following properties can be configured globally for the `[Facet]` attribute:
 | `GenerateCopyConstructor` | `false` | `Facet_GenerateCopyConstructor` |
 | `GenerateEquality` | `false` | `Facet_GenerateEquality` |
 | `MaxDepth` | `10` | `Facet_MaxDepth` |
+| `MaxDepthToSource` | `0` | `Facet_MaxDepthToSource` |
 | `PreserveReferences` | `true` | `Facet_PreserveReferences` |
 
 ## How to Configure

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -172,8 +172,47 @@ public sealed class FacetAttribute : Attribute
     /// A value of 1 allows one level of nesting, 2 allows two levels, etc.
     /// Default is 10, which handles most real-world scenarios including deep non-circular nesting.
     /// Set to 0 to disable (use with caution), or increase if you need deeper nesting.
+    /// <para>
+    /// This setting affects the constructor (source-to-DTO) and EF Core projection directions.
+    /// To independently control the DTO-to-source direction, use <see cref="MaxDepthToSource"/>.
+    /// </para>
     /// </summary>
     public int MaxDepth { get; set; } = 10;
+
+    /// <summary>
+    /// Controls the maximum depth for nested facet recursion in the DTO-to-source direction
+    /// (the generated <c>ToSource()</c> method). When set to a positive value, depth-limited
+    /// <c>ToSource()</c> overloads are generated that stop recursing into nested child objects
+    /// once the depth limit is reached.
+    /// A value of 0 (default) means no depth limiting for <c>ToSource()</c>, preserving the
+    /// existing behaviour.
+    /// A value of 1 maps this object and its immediate children, but not grandchildren.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is useful when your backend has separation of duties and you don't want
+    /// <c>ToSource()</c> to cascade-save multiple entity layers in one call.
+    /// </para>
+    /// <para>
+    /// When set on a parent facet, the depth counter is passed to child facets that also have
+    /// <c>MaxDepthToSource &gt; 0</c>, enabling consistent depth enforcement across the graph.
+    /// Child facets that do <em>not</em> set <c>MaxDepthToSource</c> are always called via
+    /// their regular (unlimited) <c>ToSource()</c>.
+    /// </para>
+    /// <para>Example:
+    /// <code>
+    /// // Allow deep DTO nesting but prevent deep reverse mapping
+    /// [Facet(typeof(OrderEntity), MaxDepth = 5, MaxDepthToSource = 1,
+    ///        GenerateToSource = true, NestedFacets = [typeof(OrderLineDto)])]
+    /// public partial class OrderDto;
+    ///
+    /// // This call only maps OrderEntity-level properties;
+    /// // nested OrderLine entities are set to null / empty.
+    /// var entity = orderDto.ToSource();
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public int MaxDepthToSource { get; set; } = 0;
 
     /// <summary>
     /// When true, the generator will track object references during facet construction to prevent

--- a/src/Facet/AnalyzerReleases.Unshipped.md
+++ b/src/Facet/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 FAC023 | Usage | Warning | GenerateToSource is set to true, but ToSource cannot be generated
+FAC025 | Performance | Warning | MaxDepthToSource value is unusual

--- a/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
@@ -99,6 +99,16 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "MaxDepth values should typically be between 1 and 10 for most scenarios.");
 
+    // FAC025: MaxDepthToSource warning
+    public static readonly DiagnosticDescriptor MaxDepthToSourceWarningRule = new DiagnosticDescriptor(
+        "FAC025",
+        "MaxDepthToSource value is unusual",
+        "MaxDepthToSource is set to {0}: {1}",
+        "Performance",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "MaxDepthToSource values should typically be between 1 and 10 for most scenarios.");
+
     // FAC024: MapFrom references a non-existing source property
     public static readonly DiagnosticDescriptor InvalidMapFromPropertyRule = new DiagnosticDescriptor(
         "FAC024",
@@ -138,6 +148,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         CircularReferenceWarningRule,
         IncludeAndExcludeBothSpecifiedRule,
         MaxDepthWarningRule,
+        MaxDepthToSourceWarningRule,
         GenerateToSourceNotPossibleRule,
         SourceSignatureMismatchRule,
         InvalidMapFromPropertyRule);
@@ -376,7 +387,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
             if (maxDepthToSourceValue < 0)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    MaxDepthWarningRule,
+                    MaxDepthToSourceWarningRule,
                     facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
                     maxDepthToSourceValue,
                     "MaxDepthToSource cannot be negative"));
@@ -384,7 +395,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
             else if (maxDepthToSourceValue > 100)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    MaxDepthWarningRule,
+                    MaxDepthToSourceWarningRule,
                     facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
                     maxDepthToSourceValue,
                     "MaxDepthToSource is unusually large and may indicate a configuration error. Consider using a value between 1 and 10"));

--- a/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
+++ b/src/Facet/Analyzers/FacetAttributeAnalyzer.cs
@@ -210,6 +210,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         public KeyValuePair<string, TypedConstant> Configuration { get; }
         public KeyValuePair<string, TypedConstant> NestedFacets { get; }
         public KeyValuePair<string, TypedConstant> MaxDepth { get; }
+        public KeyValuePair<string, TypedConstant> MaxDepthToSource { get; }
         public KeyValuePair<string, TypedConstant> PreserveReferences { get; }
         public KeyValuePair<string, TypedConstant> SourceSignature { get; }
         public KeyValuePair<string, TypedConstant> IncludeFields { get; }
@@ -221,6 +222,7 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
             Configuration = namedArguments.FirstOrDefault(a => a.Key == "Configuration");
             NestedFacets = namedArguments.FirstOrDefault(a => a.Key == "NestedFacets");
             MaxDepth = namedArguments.FirstOrDefault(a => a.Key == "MaxDepth");
+            MaxDepthToSource = namedArguments.FirstOrDefault(a => a.Key == "MaxDepthToSource");
             PreserveReferences = namedArguments.FirstOrDefault(a => a.Key == "PreserveReferences");
             SourceSignature = namedArguments.FirstOrDefault(a => a.Key == "SourceSignature");
             IncludeFields = namedArguments.FirstOrDefault(a => a.Key == "IncludeFields");
@@ -366,6 +368,27 @@ public class FacetAttributeAnalyzer : DiagnosticAnalyzer
         if (!namedArgs.PreserveReferences.Equals(default) && namedArgs.PreserveReferences.Value.Value is bool preserveReferencesValue)
         {
             preserveReferences = preserveReferencesValue;
+        }
+
+        // Validate MaxDepthToSource range
+        if (!namedArgs.MaxDepthToSource.Equals(default) && namedArgs.MaxDepthToSource.Value.Value is int maxDepthToSourceValue)
+        {
+            if (maxDepthToSourceValue < 0)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    MaxDepthWarningRule,
+                    facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    maxDepthToSourceValue,
+                    "MaxDepthToSource cannot be negative"));
+            }
+            else if (maxDepthToSourceValue > 100)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    MaxDepthWarningRule,
+                    facetAttr.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
+                    maxDepthToSourceValue,
+                    "MaxDepthToSource is unusually large and may indicate a configuration error. Consider using a value between 1 and 10"));
+            }
         }
 
         // Check for circular reference risk

--- a/src/Facet/Facet.props
+++ b/src/Facet/Facet.props
@@ -19,6 +19,7 @@
     <CompilerVisibleProperty Include="Facet_GenerateCopyConstructor" />
     <CompilerVisibleProperty Include="Facet_GenerateEquality" />
     <CompilerVisibleProperty Include="Facet_MaxDepth" />
+    <CompilerVisibleProperty Include="Facet_MaxDepthToSource" />
     <CompilerVisibleProperty Include="Facet_PreserveReferences" />
   </ItemGroup>
 </Project>

--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -76,6 +76,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public bool CopyAttributes { get; }
     public int MaxDepth { get; }
     public bool PreserveReferences { get; }
+    public int MaxDepthToSource { get; }
     public ImmutableArray<string> BaseClassMemberNames { get; }
     public ImmutableArray<string> FlattenToTypes { get; }
 
@@ -174,7 +175,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         bool hasProjectionMapConfiguration = false,
         bool baseHidesFromSource = false,
         bool hasMapConfiguration = false,
-        BaseFacetInfo? baseFacetInfo = null)
+        BaseFacetInfo? baseFacetInfo = null,
+        int maxDepthToSource = 0)
     {
         Name = name;
         Namespace = @namespace;
@@ -203,6 +205,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         CopyAttributes = copyAttributes;
         MaxDepth = maxDepth;
         PreserveReferences = preserveReferences;
+        MaxDepthToSource = maxDepthToSource;
         BaseClassMemberNames = baseClassMemberNames.IsDefault ? ImmutableArray<string>.Empty : baseClassMemberNames;
         FlattenToTypes = flattenToTypes.IsDefault ? ImmutableArray<string>.Empty : flattenToTypes;
         ConvertEnumsTo = convertEnumsTo;
@@ -247,6 +250,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && CopyAttributes == other.CopyAttributes
             && MaxDepth == other.MaxDepth
             && PreserveReferences == other.PreserveReferences
+            && MaxDepthToSource == other.MaxDepthToSource
             && BaseClassMemberNames.SequenceEqual(other.BaseClassMemberNames)
             && FlattenToTypes.SequenceEqual(other.FlattenToTypes)
             && ConvertEnumsTo == other.ConvertEnumsTo
@@ -288,6 +292,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + CopyAttributes.GetHashCode();
             hash = hash * 31 + MaxDepth.GetHashCode();
             hash = hash * 31 + PreserveReferences.GetHashCode();
+            hash = hash * 31 + MaxDepthToSource.GetHashCode();
             hash = hash * 31 + (ConvertEnumsTo?.GetHashCode() ?? 0);
             hash = hash * 31 + GenerateCopyConstructor.GetHashCode();
             hash = hash * 31 + GenerateEquality.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -322,7 +322,7 @@ internal static class ExpressionBuilder
             return $"this.{member.Name} != null ? {collectionExpression} : null";
         }
 
-        return collectionExpression;
+        return $"this.{member.Name} != null ? {collectionExpression} : default!";
     }
 
     private static string BuildSingleToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName)
@@ -337,7 +337,7 @@ internal static class ExpressionBuilder
         }
 
         // Use the child facet's generated ToSource method
-        return $"this.{member.Name}.{toSourceMethodName}()";
+        return $"this.{member.Name} != null ? this.{member.Name}.{toSourceMethodName}() : default!";
     }
 
     private static string WrapCollectionProjection(string projection, string collectionWrapper, string? elementTypeName = null)

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -310,27 +310,15 @@ internal static class ExpressionBuilder
         }
     }
 
-    private static bool ChildHasDepthAwareToSource(string nestedFacetTypeName, string? nestedFacetSourceTypeName, Dictionary<string, List<FacetTargetModel>>? facetLookup)
-    {
-        if (facetLookup == null || !facetLookup.TryGetValue(nestedFacetTypeName, out var childModels) || childModels.Count == 0)
-        {
-            return false;
-        }
-
-        var matchingChildModels = string.IsNullOrEmpty(nestedFacetSourceTypeName)
-            ? childModels
-            : childModels.Where(x => x.SourceTypeName == nestedFacetSourceTypeName);
-
-        return matchingChildModels.Any(x => x.MaxDepthToSource > 0);
-    }
-
     private static string BuildCollectionToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName, int maxDepthToSource = 0, bool useDepthParameter = false)
     {
         // Determine the correct ToSource method name for the nested facet
         var toSourceMethodName = GetToSourceMethodName(member.TypeName, member.NestedFacetSourceTypeName, facetLookup, parentSourceTypeName);
 
-        // When inside a depth-aware method, pass __depth + 1 only if the selected child source mapping has a depth-aware overload
-        var childToSourceCall = useDepthParameter && ChildHasDepthAwareToSource(member.TypeName, member.NestedFacetSourceTypeName, facetLookup)
+        // When inside a depth-aware method, pass __depth + 1 only if the child facet has a depth-aware overload.
+        // Use FindNestedFacetModels (via the 2-param overload) because member.TypeName includes the "global::"
+        // prefix which does not match the FullName-keyed facetLookup directly.
+        var childToSourceCall = useDepthParameter && ChildHasDepthAwareToSource(member.TypeName, facetLookup)
             ? $"x.{toSourceMethodName}(__depth + 1)"
             : $"x.{toSourceMethodName}()";
 

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -76,7 +76,14 @@ internal static class ExpressionBuilder
     /// </summary>
     /// <param name="facetLookup">Dictionary mapping facet type names to their model lists (for resolving multi-source nested facets).</param>
     /// <param name="parentSourceTypeName">The source type name of the parent facet (used to determine which ToSource method to call for multi-source nested facets).</param>
-    public static string GetToSourceValueExpression(FacetMember member, Dictionary<string, List<FacetTargetModel>>? facetLookup = null, string? parentSourceTypeName = null)
+    /// <param name="maxDepthToSource">When &gt; 0, depth-aware expressions are emitted that guard nested calls with a depth check.</param>
+    /// <param name="useDepthParameter">When true the expression is being emitted inside a depth-aware <c>ToSource(int __depth)</c> overload.</param>
+    public static string GetToSourceValueExpression(
+        FacetMember member,
+        Dictionary<string, List<FacetTargetModel>>? facetLookup = null,
+        string? parentSourceTypeName = null,
+        int maxDepthToSource = 0,
+        bool useDepthParameter = false)
     {
         // Check if the member type is nullable (ends with ?)
         bool facetTypeIsNullable = member.TypeName.Contains("?");
@@ -86,11 +93,11 @@ internal static class ExpressionBuilder
 
         if (member.IsNestedFacet && member.IsCollection)
         {
-            return BuildCollectionToSourceExpression(member, facetTypeIsNullable, facetLookup, parentSourceTypeName);
+            return BuildCollectionToSourceExpression(member, facetTypeIsNullable, facetLookup, parentSourceTypeName, maxDepthToSource, useDepthParameter);
         }
         else if (member.IsNestedFacet)
         {
-            return BuildSingleToSourceExpression(member, facetTypeIsNullable, facetLookup, parentSourceTypeName);
+            return BuildSingleToSourceExpression(member, facetTypeIsNullable, facetLookup, parentSourceTypeName, maxDepthToSource, useDepthParameter);
         }
 
         // Handle enum conversion (reverse: string/int back to enum)
@@ -303,18 +310,35 @@ internal static class ExpressionBuilder
         }
     }
 
-    private static string BuildCollectionToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName)
+    private static string BuildCollectionToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName, int maxDepthToSource = 0, bool useDepthParameter = false)
     {
         // Determine the correct ToSource method name for the nested facet
         var toSourceMethodName = GetToSourceMethodName(member.TypeName, member.NestedFacetSourceTypeName, facetLookup, parentSourceTypeName);
 
+        // When inside a depth-aware method, pass __depth + 1 if the child also has a depth-aware overload
+        var childToSourceCall = useDepthParameter && ChildHasDepthAwareToSource(member.TypeName, facetLookup)
+            ? $"x.{toSourceMethodName}(__depth + 1)"
+            : $"x.{toSourceMethodName}()";
+
         // Use LINQ Select to map each element back
-        var projection = $"this.{member.Name}.Select(x => x.{toSourceMethodName}())";
+        var projection = $"this.{member.Name}.Select(x => {childToSourceCall})";
 
         // Use the original source collection wrapper (before any CollectionTargetType override)
         // so that the generated expression produces the correct source type.
         var toSourceWrapper = member.SourceCollectionWrapper ?? member.CollectionWrapper!;
         var collectionExpression = WrapCollectionProjection(projection, toSourceWrapper, member.NestedFacetSourceTypeName);
+
+        // When depth-limiting is active, guard nested calls with a depth check
+        if (useDepthParameter && maxDepthToSource > 0)
+        {
+            if (facetTypeIsNullable)
+            {
+                return $"__depth < {maxDepthToSource} ? (this.{member.Name} != null ? {collectionExpression} : null) : null";
+            }
+
+            var depthExceededDefault = GetToSourceCollectionDefault(toSourceWrapper, member.NestedFacetSourceTypeName);
+            return $"__depth < {maxDepthToSource} ? (this.{member.Name} != null ? {collectionExpression} : {depthExceededDefault}) : {depthExceededDefault}";
+        }
 
         // Add null check for nullable collections
         if (facetTypeIsNullable)
@@ -325,10 +349,26 @@ internal static class ExpressionBuilder
         return $"this.{member.Name} != null ? {collectionExpression} : default!";
     }
 
-    private static string BuildSingleToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName)
+    private static string BuildSingleToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName, int maxDepthToSource = 0, bool useDepthParameter = false)
     {
         // Determine the correct ToSource method name for the nested facet
         var toSourceMethodName = GetToSourceMethodName(member.TypeName, member.NestedFacetSourceTypeName, facetLookup, parentSourceTypeName);
+
+        // When inside a depth-aware method, pass __depth + 1 if the child also has a depth-aware overload
+        var childToSourceCall = useDepthParameter && ChildHasDepthAwareToSource(member.TypeName, facetLookup)
+            ? $"this.{member.Name}.{toSourceMethodName}(__depth + 1)"
+            : $"this.{member.Name}.{toSourceMethodName}()";
+
+        // When depth-limiting is active, guard the nested call with a depth check
+        if (useDepthParameter && maxDepthToSource > 0)
+        {
+            if (facetTypeIsNullable)
+            {
+                return $"__depth < {maxDepthToSource} ? (this.{member.Name} != null ? {childToSourceCall} : null) : null";
+            }
+
+            return $"__depth < {maxDepthToSource} ? (this.{member.Name} != null ? {childToSourceCall} : null!) : null!";
+        }
 
         // Add null check for nullable nested facets
         if (facetTypeIsNullable)
@@ -338,6 +378,42 @@ internal static class ExpressionBuilder
 
         // Use the child facet's generated ToSource method
         return $"this.{member.Name} != null ? this.{member.Name}.{toSourceMethodName}() : default!";
+    }
+
+    /// <summary>
+    /// Returns true if any model for the given facet type name has <c>MaxDepthToSource &gt; 0</c>
+    /// (meaning it has a depth-aware <c>ToSource(int __depth)</c> overload).
+    /// </summary>
+    private static bool ChildHasDepthAwareToSource(string facetTypeName, Dictionary<string, List<FacetTargetModel>>? facetLookup)
+    {
+        if (facetLookup == null) return false;
+
+        var models = FindNestedFacetModels(facetTypeName, facetLookup);
+        return models != null && models.Any(m => m.MaxDepthToSource > 0);
+    }
+
+    /// <summary>
+    /// Returns a safe default expression for a collection property when the depth limit is exceeded
+    /// during <c>ToSource()</c> — always an empty (non-null) collection so the source type remains valid.
+    /// </summary>
+    private static string GetToSourceCollectionDefault(string collectionWrapper, string? elementTypeName)
+    {
+        var et = elementTypeName ?? "object";
+        return collectionWrapper switch
+        {
+            FacetConstants.CollectionWrappers.Array => $"global::System.Array.Empty<{et}>()",
+            FacetConstants.CollectionWrappers.ImmutableArray => $"global::System.Collections.Immutable.ImmutableArray<{et}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableList => $"global::System.Collections.Immutable.ImmutableList<{et}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableHashSet => $"global::System.Collections.Immutable.ImmutableHashSet<{et}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableSortedSet => $"global::System.Collections.Immutable.ImmutableSortedSet<{et}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableQueue => $"global::System.Collections.Immutable.ImmutableQueue<{et}>.Empty",
+            FacetConstants.CollectionWrappers.ImmutableStack => $"global::System.Collections.Immutable.ImmutableStack<{et}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableList => $"global::System.Collections.Immutable.ImmutableList<{et}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableSet => $"global::System.Collections.Immutable.ImmutableHashSet<{et}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableQueue => $"global::System.Collections.Immutable.ImmutableQueue<{et}>.Empty",
+            FacetConstants.CollectionWrappers.IImmutableStack => $"global::System.Collections.Immutable.ImmutableStack<{et}>.Empty",
+            _ => $"new global::System.Collections.Generic.List<{et}>()"
+        };
     }
 
     private static string WrapCollectionProjection(string projection, string collectionWrapper, string? elementTypeName = null)

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -310,13 +310,27 @@ internal static class ExpressionBuilder
         }
     }
 
+    private static bool ChildHasDepthAwareToSource(string nestedFacetTypeName, string? nestedFacetSourceTypeName, Dictionary<string, List<FacetTargetModel>>? facetLookup)
+    {
+        if (facetLookup == null || !facetLookup.TryGetValue(nestedFacetTypeName, out var childModels) || childModels.Count == 0)
+        {
+            return false;
+        }
+
+        var matchingChildModels = string.IsNullOrEmpty(nestedFacetSourceTypeName)
+            ? childModels
+            : childModels.Where(x => x.SourceTypeName == nestedFacetSourceTypeName);
+
+        return matchingChildModels.Any(x => x.MaxDepthToSource > 0);
+    }
+
     private static string BuildCollectionToSourceExpression(FacetMember member, bool facetTypeIsNullable, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? parentSourceTypeName, int maxDepthToSource = 0, bool useDepthParameter = false)
     {
         // Determine the correct ToSource method name for the nested facet
         var toSourceMethodName = GetToSourceMethodName(member.TypeName, member.NestedFacetSourceTypeName, facetLookup, parentSourceTypeName);
 
-        // When inside a depth-aware method, pass __depth + 1 if the child also has a depth-aware overload
-        var childToSourceCall = useDepthParameter && ChildHasDepthAwareToSource(member.TypeName, facetLookup)
+        // When inside a depth-aware method, pass __depth + 1 only if the selected child source mapping has a depth-aware overload
+        var childToSourceCall = useDepthParameter && ChildHasDepthAwareToSource(member.TypeName, member.NestedFacetSourceTypeName, facetLookup)
             ? $"x.{toSourceMethodName}(__depth + 1)"
             : $"x.{toSourceMethodName}()";
 

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -108,6 +108,7 @@ internal static class ModelBuilder
         var inheritDocs = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.InheritDocs, globalDefaults.InheritDocs);
         var maxDepth = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.MaxDepth, globalDefaults.MaxDepth);
         var preserveReferences = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.PreserveReferences, globalDefaults.PreserveReferences);
+        var maxDepthToSource = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.MaxDepthToSource, globalDefaults.MaxDepthToSource);
 
         // Extract ConvertEnumsTo parameter
         var convertEnumsTo = AttributeParser.ExtractConvertEnumsTo(attribute);
@@ -336,7 +337,8 @@ internal static class ModelBuilder
             hasProjectionMapConfiguration,
             baseHidesFromSource,
             hasMapConfiguration,
-            baseFacetInfo);
+            baseFacetInfo,
+            maxDepthToSource);
     }
 
     #region Private Helper Methods

--- a/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
@@ -26,27 +26,34 @@ internal static class ToSourceGenerator
     {
         var methodName = toSourceMethodName ?? "ToSource";
         var isCustomName = toSourceMethodName != null;
+        var newMod = model.BaseHidesFacetMembers && !isCustomName ? "new " : "";
 
-        // Generate the main ToSource method
+        bool hasDepthLimit = model.MaxDepthToSource > 0;
+
+        // Generate the main public ToSource method
         sb.AppendLine();
         sb.AppendLine("    /// <summary>");
         sb.AppendLine($"    /// Converts this instance of <see cref=\"{model.Name}\"/> to an instance of <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\"/>.");
         sb.AppendLine("    /// </summary>");
         sb.AppendLine($"    /// <returns>An instance of <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\"/> with properties mapped from this instance.</returns>");
-        var newMod = model.BaseHidesFacetMembers && !isCustomName ? "new " : "";
-        sb.AppendLine($"    public {newMod}{model.SourceTypeName} {methodName}()");
-        sb.AppendLine("    {");
 
-        if (model.SourceHasPositionalConstructor)
+        if (hasDepthLimit)
         {
-            GeneratePositionalToSource(sb, model, facetLookup);
+            // Public entry-point delegates to the depth-aware overload, starting at depth 0
+            sb.AppendLine($"    public {newMod}{model.SourceTypeName} {methodName}() => {methodName}(0);");
         }
         else
         {
-            GenerateObjectInitializerToSource(sb, model, facetLookup);
-        }
+            sb.AppendLine($"    public {newMod}{model.SourceTypeName} {methodName}()");
+            sb.AppendLine("    {");
 
-        sb.AppendLine("    }");
+            if (model.SourceHasPositionalConstructor)
+                GeneratePositionalToSource(sb, model, facetLookup);
+            else
+                GenerateObjectInitializerToSource(sb, model, facetLookup);
+
+            sb.AppendLine("    }");
+        }
 
         // Generate the deprecated BackTo method only for the default (single-source) naming
         if (!isCustomName)
@@ -57,16 +64,32 @@ internal static class ToSourceGenerator
             sb.AppendLine("    /// </summary>");
             sb.AppendLine($"    /// <returns>An instance of the source type with properties mapped from this instance.</returns>");
             sb.AppendLine("    [global::System.Obsolete(\"Use ToSource() instead. This method will be removed in a future version.\")]");
-            sb.AppendLine($"    public {newMod}{model.SourceTypeName} BackTo() => ToSource();");
+            sb.AppendLine($"    public {newMod}{model.SourceTypeName} BackTo() => {methodName}();");
+        }
+
+        // Generate the internal depth-aware overload when MaxDepthToSource > 0
+        if (hasDepthLimit)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"    /// <summary>Depth-aware overload used for <c>MaxDepthToSource</c> enforcement. Do not call directly.</summary>");
+            sb.AppendLine($"    internal {model.SourceTypeName} {methodName}(int __depth)");
+            sb.AppendLine("    {");
+
+            if (model.SourceHasPositionalConstructor)
+                GeneratePositionalToSource(sb, model, facetLookup, useDepthParameter: true);
+            else
+                GenerateObjectInitializerToSource(sb, model, facetLookup, useDepthParameter: true);
+
+            sb.AppendLine("    }");
         }
     }
 
-    private static void GeneratePositionalToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup)
+    private static void GeneratePositionalToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup, bool useDepthParameter = false)
     {
         var constructorArgs = string.Join(", ",
             model.Members
                 .Where(m => m.MapFromReversible)
-                .Select(m => ExpressionBuilder.GetToSourceValueExpression(m, facetLookup, model.SourceTypeName)));
+                .Select(m => ExpressionBuilder.GetToSourceValueExpression(m, facetLookup, model.SourceTypeName, model.MaxDepthToSource, useDepthParameter)));
 
         if (model.ToSourceConfigurationTypeName != null)
         {
@@ -80,7 +103,7 @@ internal static class ToSourceGenerator
         }
     }
 
-    private static void GenerateObjectInitializerToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup)
+    private static void GenerateObjectInitializerToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup, bool useDepthParameter = false)
     {
         var propertyAssignments = new List<string>();
 
@@ -89,7 +112,7 @@ internal static class ToSourceGenerator
             if (!member.MapFromReversible)
                 continue;
 
-            var toSourceValue = ExpressionBuilder.GetToSourceValueExpression(member, facetLookup, model.SourceTypeName);
+            var toSourceValue = ExpressionBuilder.GetToSourceValueExpression(member, facetLookup, model.SourceTypeName, model.MaxDepthToSource, useDepthParameter);
             propertyAssignments.Add($"            {member.SourcePropertyName} = {toSourceValue}");
         }
 

--- a/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
@@ -72,7 +72,7 @@ internal static class ToSourceGenerator
         {
             sb.AppendLine();
             sb.AppendLine($"    /// <summary>Depth-aware overload used for <c>MaxDepthToSource</c> enforcement. Do not call directly.</summary>");
-            sb.AppendLine($"    internal {model.SourceTypeName} {methodName}(int __depth)");
+            sb.AppendLine($"    internal {newMod}{model.SourceTypeName} {methodName}(int __depth)");
             sb.AppendLine("    {");
 
             if (model.SourceHasPositionalConstructor)

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -128,6 +128,7 @@ internal static class FacetConstants
         public const string CopyDocs = "CopyDocs";
         public const string InheritDocs = "InheritDocs";
         public const string MaxDepth = "MaxDepth";
+        public const string MaxDepthToSource = "MaxDepthToSource";
         public const string PreserveReferences = "PreserveReferences";
         public const string UseFullName = "UseFullName";
         public const string ReadOnly = "ReadOnly";

--- a/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
+++ b/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
@@ -94,6 +94,12 @@ internal sealed class GlobalConfigurationDefaults
     public int MaxDepth { get; }
 
     /// <summary>
+    /// Default value for MaxDepthToSource (default: 0 = no limiting).
+    /// Can be overridden by setting the Facet_MaxDepthToSource MSBuild property.
+    /// </summary>
+    public int MaxDepthToSource { get; }
+
+    /// <summary>
     /// Default value for PreserveReferences (default: true).
     /// Can be overridden by setting the Facet_PreserveReferences MSBuild property.
     /// </summary>
@@ -114,7 +120,8 @@ internal sealed class GlobalConfigurationDefaults
         bool generateCopyConstructor,
         bool generateEquality,
         int maxDepth,
-        bool preserveReferences)
+        bool preserveReferences,
+        int maxDepthToSource)
     {
         GenerateConstructor = generateConstructor;
         GenerateParameterlessConstructor = generateParameterlessConstructor;
@@ -131,6 +138,7 @@ internal sealed class GlobalConfigurationDefaults
         GenerateEquality = generateEquality;
         MaxDepth = maxDepth;
         PreserveReferences = preserveReferences;
+        MaxDepthToSource = maxDepthToSource;
     }
 
     /// <summary>
@@ -154,7 +162,8 @@ internal sealed class GlobalConfigurationDefaults
             generateCopyConstructor: GetBoolOption(globalOptions, "build_property.Facet_GenerateCopyConstructor", defaultValue: false),
             generateEquality: GetBoolOption(globalOptions, "build_property.Facet_GenerateEquality", defaultValue: false),
             maxDepth: GetIntOption(globalOptions, "build_property.Facet_MaxDepth", defaultValue: FacetConstants.DefaultMaxDepth),
-            preserveReferences: GetBoolOption(globalOptions, "build_property.Facet_PreserveReferences", defaultValue: FacetConstants.DefaultPreserveReferences));
+            preserveReferences: GetBoolOption(globalOptions, "build_property.Facet_PreserveReferences", defaultValue: FacetConstants.DefaultPreserveReferences),
+            maxDepthToSource: GetIntOption(globalOptions, "build_property.Facet_MaxDepthToSource", defaultValue: 0));
     }
 
     private static bool GetBoolOption(AnalyzerConfigOptions? options, string key, bool defaultValue)

--- a/test/Facet.Tests/TestModels/CircularReferenceTestModels.cs
+++ b/test/Facet.Tests/TestModels/CircularReferenceTestModels.cs
@@ -74,3 +74,25 @@ public partial record Level2Facet;
 public partial record Level3Facet;
 [Facet(typeof(Level4))]
 public partial record Level4Facet;
+
+// ---------------------------------------------------------------------------
+// MaxDepthToSource test models
+// Scenario: MaxDepth = 5 (full ToFacet nesting allowed) but MaxDepthToSource = 1
+// (only the top-level object is reverse-mapped; nested children are dropped).
+// ---------------------------------------------------------------------------
+
+[Facet(typeof(Author),
+    MaxDepth = 5,
+    PreserveReferences = false,
+    GenerateToSource = true,
+    MaxDepthToSource = 1,
+    NestedFacets = [typeof(BookFacetDepthToSource)])]
+public partial record AuthorFacetDepthToSource;
+
+[Facet(typeof(Book),
+    MaxDepth = 5,
+    PreserveReferences = false,
+    GenerateToSource = true,
+    MaxDepthToSource = 1,
+    NestedFacets = [typeof(AuthorFacetDepthToSource)])]
+public partial record BookFacetDepthToSource;

--- a/test/Facet.Tests/TestModels/CircularReferenceTestModels.cs
+++ b/test/Facet.Tests/TestModels/CircularReferenceTestModels.cs
@@ -31,6 +31,13 @@ public partial record AuthorFacetWithDepth;
 [Facet(typeof(Book), MaxDepth = 2, PreserveReferences = false, NestedFacets = [typeof(AuthorFacetWithDepth)], GenerateToSource = true)]
 public partial record BookFacetWithDepth;
 
+// Facets with MaxDepth = 1 to test ToSource null-guard fix
+[Facet(typeof(Author), MaxDepth = 1, PreserveReferences = false, NestedFacets = [typeof(BookFacetMaxDepth1)], GenerateToSource = true)]
+public partial record AuthorFacetMaxDepth1;
+
+[Facet(typeof(Book), MaxDepth = 1, PreserveReferences = false, NestedFacets = [typeof(AuthorFacetMaxDepth1)], GenerateToSource = true)]
+public partial record BookFacetMaxDepth1;
+
 // Facets with PreserveReferences for runtime tracking (also needs MaxDepth to prevent generator SO)
 [Facet(typeof(Author), MaxDepth = 3, PreserveReferences = true, NestedFacets = [typeof(BookFacetWithTracking)])]
 public partial record AuthorFacetWithTracking;

--- a/test/Facet.Tests/UnitTests/Core/Facet/CircularReferenceTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CircularReferenceTests.cs
@@ -515,11 +515,10 @@ public class CircularReferenceTests
         var facet = new AuthorFacetMaxDepth1(author);
 
         // Act
-        var act = () => facet.ToSource();
+        var mappedAuthor = facet.ToSource();
 
         // Assert
-        act.Should().NotThrow();
-        var mappedAuthor = act();
+        mappedAuthor.Should().NotBeNull();
         mappedAuthor.Id.Should().Be(1);
         mappedAuthor.Name.Should().Be("Test Author");
     }
@@ -540,11 +539,10 @@ public class CircularReferenceTests
         var facet = new BookFacetMaxDepth1(book);
 
         // Act
-        var act = () => facet.ToSource();
+        var mappedBook = facet.ToSource();
 
         // Assert
-        act.Should().NotThrow();
-        var mappedBook = act();
+        mappedBook.Should().NotBeNull();
         mappedBook.Id.Should().Be(2);
         mappedBook.Title.Should().Be("Deep Dive");
     }

--- a/test/Facet.Tests/UnitTests/Core/Facet/CircularReferenceTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CircularReferenceTests.cs
@@ -500,6 +500,56 @@ public class CircularReferenceTests
     }
 
     [Fact]
+    public void ToSource_OnAuthorFacetMaxDepth1_ShouldNotThrow()
+    {
+        // Arrange
+        var author = new Author
+        {
+            Id = 1,
+            Name = "Test Author",
+            Books = new List<Book>()
+        };
+        var book = new Book { Id = 1, Title = "Some Book", Author = author };
+        author.Books.Add(book);
+
+        var facet = new AuthorFacetMaxDepth1(author);
+
+        // Act
+        var act = () => facet.ToSource();
+
+        // Assert
+        act.Should().NotThrow();
+        var mappedAuthor = act();
+        mappedAuthor.Id.Should().Be(1);
+        mappedAuthor.Name.Should().Be("Test Author");
+    }
+
+    [Fact]
+    public void ToSource_OnBookFacetMaxDepth1_ShouldNotThrow()
+    {
+        // Arrange
+        var author = new Author
+        {
+            Id = 3,
+            Name = "Some Author",
+            Books = new List<Book>()
+        };
+        var book = new Book { Id = 2, Title = "Deep Dive", Author = author };
+        author.Books.Add(book);
+
+        var facet = new BookFacetMaxDepth1(book);
+
+        // Act
+        var act = () => facet.ToSource();
+
+        // Assert
+        act.Should().NotThrow();
+        var mappedBook = act();
+        mappedBook.Id.Should().Be(2);
+        mappedBook.Title.Should().Be("Deep Dive");
+    }
+
+    [Fact]
     public void BackTo_Should_Handle_Circular_References_Without_Error()
     {
         // Arrange

--- a/test/Facet.Tests/UnitTests/Core/Facet/MaxDepthToSourceTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/MaxDepthToSourceTests.cs
@@ -84,7 +84,7 @@ public class MaxDepthToSourceTests
     }
 
     [Fact]
-    public void ToSource_From_Book_Should_Map_Only_TopLevel_When_MaxDepthToSource_Is_1()
+    public void ToSource_From_Book_Should_Map_Direct_Author_But_Not_AuthorsBooks_When_MaxDepthToSource_Is_1()
     {
         // Arrange
         var author = BuildAuthorWithBooks(1);
@@ -96,9 +96,13 @@ public class MaxDepthToSourceTests
         // Assert - Book's scalar properties are mapped
         entity.Title.Should().Be("Book 1");
 
-        // At MaxDepthToSource = 1: from Book (depth 0), Author is at depth 1 == limit,
-        // so Author is null
-        entity.Author.Should().BeNull();
+        // MaxDepthToSource = 1 means "allow 1 level of nesting":
+        //   Book (depth 0):  0 < 1 → true  → Author IS mapped
+        //   Author (depth 1): 1 < 1 → false → Author's Books are NOT mapped
+        entity.Author.Should().NotBeNull();
+        entity.Author!.Id.Should().Be(1);
+        entity.Author.Name.Should().Be("Allan Michaelsen");
+        entity.Author.Books.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Facet.Tests/UnitTests/Core/Facet/MaxDepthToSourceTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/MaxDepthToSourceTests.cs
@@ -1,0 +1,136 @@
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+/// <summary>
+/// Tests for the <c>MaxDepthToSource</c> attribute property which limits reverse-mapping depth
+/// independently of <c>MaxDepth</c> (the forward source-to-DTO direction).
+/// </summary>
+public class MaxDepthToSourceTests
+{
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static Author BuildAuthorWithBooks(int bookCount = 2)
+    {
+        var author = new Author { Id = 1, Name = "Allan Michaelsen", Books = new() };
+        for (var i = 1; i <= bookCount; i++)
+        {
+            author.Books.Add(new Book { Id = i, Title = $"Book {i}", Author = author });
+        }
+        return author;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Forward direction (ToFacet) is unaffected by MaxDepthToSource
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void ToFacet_Should_Map_FullDepth_When_MaxDepthToSource_Is_Set()
+    {
+        // Arrange
+        var author = BuildAuthorWithBooks(2);
+
+        // Act - MaxDepth = 5 so we expect full nesting (Author -> Books -> Author -> ...)
+        var dto = new AuthorFacetDepthToSource(author);
+
+        // Assert - forward mapping works normally
+        dto.Id.Should().Be(1);
+        dto.Name.Should().Be("Allan Michaelsen");
+        dto.Books.Should().HaveCount(2);
+        dto.Books![0].Title.Should().Be("Book 1");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Reverse direction (ToSource) is limited by MaxDepthToSource = 1
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void ToSource_Should_Map_TopLevel_Properties_When_MaxDepthToSource_Is_1()
+    {
+        // Arrange
+        var author = BuildAuthorWithBooks(2);
+        var dto = new AuthorFacetDepthToSource(author);
+
+        // Act
+        var entity = dto.ToSource();
+
+        // Assert - top-level scalar properties are mapped
+        entity.Id.Should().Be(1);
+        entity.Name.Should().Be("Allan Michaelsen");
+    }
+
+    [Fact]
+    public void ToSource_Should_Produce_Empty_Books_Collection_When_MaxDepthToSource_Depth_Exceeded()
+    {
+        // Arrange
+        var author = BuildAuthorWithBooks(2);
+        var dto = new AuthorFacetDepthToSource(author);
+
+        // Act - MaxDepthToSource = 1: depth 0 is allowed but at depth 1 the Books children
+        //       of each Book's Author are already at the limit
+        var entity = dto.ToSource();
+
+        // At depth 0 (root Author), Books is mapped
+        entity.Books.Should().NotBeNull();
+        entity.Books.Should().HaveCount(2);
+
+        // Each Book's Author should be null (depth 1 == limit, nested Author at depth 1 is skipped)
+        foreach (var book in entity.Books)
+        {
+            book.Author.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void ToSource_From_Book_Should_Map_Only_TopLevel_When_MaxDepthToSource_Is_1()
+    {
+        // Arrange
+        var author = BuildAuthorWithBooks(1);
+        var bookDto = new BookFacetDepthToSource(author.Books[0]);
+
+        // Act
+        var entity = bookDto.ToSource();
+
+        // Assert - Book's scalar properties are mapped
+        entity.Title.Should().Be("Book 1");
+
+        // At MaxDepthToSource = 1: from Book (depth 0), Author is at depth 1 == limit,
+        // so Author is null
+        entity.Author.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToSource_With_No_MaxDepthToSource_Should_Map_Nested_Objects()
+    {
+        // Arrange - use the existing facet that has no MaxDepthToSource (default 0 = unlimited)
+        var author = BuildAuthorWithBooks(1);
+        var dto = new AuthorFacetWithDepth(author);
+
+        // Act
+        var entity = dto.ToSource();
+
+        // Assert - nested Books should be mapped (no ToSource depth limit)
+        entity.Books.Should().HaveCount(1);
+        entity.Books[0].Title.Should().Be("Book 1");
+    }
+
+    [Fact]
+    public void MaxDepthToSource_Does_Not_Affect_MaxDepth_For_ToFacet()
+    {
+        // Arrange - verify the two settings are truly independent
+        var author = BuildAuthorWithBooks(1);
+
+        var withDepthToSource = new AuthorFacetDepthToSource(author);   // MaxDepth=5, MaxDepthToSource=1
+        var withoutDepthToSource = new AuthorFacetWithDepth(author);    // MaxDepth=2, MaxDepthToSource=0
+
+        // Both should have Books mapped in the forward direction
+        withDepthToSource.Books.Should().HaveCount(1);
+        withoutDepthToSource.Books.Should().HaveCount(1);
+
+        // Only the one with MaxDepthToSource=1 should have nested Author dropped in ToSource
+        var entityWithLimit = withDepthToSource.ToSource();
+        entityWithLimit.Books[0].Author.Should().BeNull();
+    }
+}


### PR DESCRIPTION
New attribute property introduced: `MaxDepthToSource`

```csharp
 [Facet(typeof(OrderEntity),
     MaxDepth = 5,              // forward (ToFacet) depth, unchanged
     MaxDepthToSource = 1,      // reverse (ToSource) depth
     GenerateToSource = true,
     NestedFacets = [typeof(OrderLineDto)])]
 public partial class OrderDto;
```

A value of 0 (default) means no depth limit on ToSource; identical to existing behaviour, so this is fully backwards-compatible.

**How it works**

When MaxDepthToSource > 0, the generator emits two ToSource methods instead of one:

```csharp
 // Public entry point — starts depth at 0
 public OrderEntity ToSource() => ToSource(0);
 
 // Internal depth-aware overload
 internal OrderEntity ToSource(int __depth)
 {
     return new OrderEntity
     {
         Id = this.Id,
         // Nested lines only mapped when __depth < 1
         Lines = __depth < 1
             ? (this.Lines != null ? this.Lines.Select(x => x.ToSource(__depth + 1)).ToList() : new List<OrderLineEntity>())
             : new List<OrderLineEntity>()
     };
 }
```

Child facets that also declare MaxDepthToSource > 0 receive the __depth + 1 argument, enabling consistent depth enforcement down the graph.