### PR TITLE
fix: Unable to map expression with navigation property

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -81,6 +81,12 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public ImmutableArray<string> FlattenToTypes { get; }
 
     /// <summary>
+    /// The top-level property and field names of the source type (including inherited members).
+    /// Used to disambiguate navigation properties from static type names in MapFrom expressions.
+    /// </summary>
+    public ImmutableArray<string> SourcePropertyNames { get; }
+
+    /// <summary>
     /// The target type for enum conversion. "string" or "int", or null if no conversion.
     /// </summary>
     public string? ConvertEnumsTo { get; }
@@ -176,7 +182,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         bool baseHidesFromSource = false,
         bool hasMapConfiguration = false,
         BaseFacetInfo? baseFacetInfo = null,
-        int maxDepthToSource = 0)
+        int maxDepthToSource = 0,
+        ImmutableArray<string> sourcePropertyNames = default)
     {
         Name = name;
         Namespace = @namespace;
@@ -217,6 +224,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         HasMapConfiguration = hasMapConfiguration;
         BaseHidesFromSource = baseHidesFromSource;
         BaseFacetInfo = baseFacetInfo;
+        SourcePropertyNames = sourcePropertyNames.IsDefault ? ImmutableArray<string>.Empty : sourcePropertyNames;
     }
 
     public bool Equals(FacetTargetModel? other)
@@ -260,7 +268,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && BaseHidesFacetMembers == other.BaseHidesFacetMembers
             && HasProjectionMapConfiguration == other.HasProjectionMapConfiguration
             && HasMapConfiguration == other.HasMapConfiguration
-            && BaseHidesFromSource == other.BaseHidesFromSource;
+            && BaseHidesFromSource == other.BaseHidesFromSource
+            && SourcePropertyNames.SequenceEqual(other.SourcePropertyNames);
     }
 
     public override bool Equals(object? obj) => obj is FacetTargetModel other && Equals(other);
@@ -301,6 +310,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + HasProjectionMapConfiguration.GetHashCode();
             hash = hash * 31 + HasMapConfiguration.GetHashCode();
             hash = hash * 31 + BaseHidesFromSource.GetHashCode();
+            hash = hash * 31 + SourcePropertyNames.Length.GetHashCode();
             hash = hash * 31 + Members.Length.GetHashCode();
 
             foreach (var member in Members)

--- a/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ConstructorGenerator.cs
@@ -1,4 +1,6 @@
 using Facet.Generators.Shared;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -135,8 +137,9 @@ internal static class ConstructorGenerator
         else if (isPositional && !model.HasExistingPrimaryConstructor)
         {
             // Traditional positional record - chain to primary constructor
+            var sourceNames = GetSourcePropertySet(model);
             var args = string.Join(", ",
-                model.Members.Select(m => ExpressionBuilder.GetSourceValueExpression(m, "source")));
+                model.Members.Select(m => ExpressionBuilder.GetSourceValueExpression(m, "source", 0, false, false, sourceNames)));
             ctorSig += $" : this({args})";
         }
         else if (model.ChainToParameterlessConstructor && !isPositional)
@@ -191,9 +194,10 @@ internal static class ConstructorGenerator
             {
                 // Regular mutable properties - initialize properly (including nested facets), then apply custom mapping
                 // This ensures nested facets are instantiated before custom mapping logic runs
+                var sourceNames = GetSourcePropertySet(model);
                 foreach (var m in model.Members)
                 {
-                    var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source");
+                    var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", 0, false, false, sourceNames);
                     sb.AppendLine($"        this.{m.Name} = {sourceValue};");
                 }
                 sb.AppendLine($"        {GetMappingCall(model, "source", "this")};");
@@ -202,9 +206,10 @@ internal static class ConstructorGenerator
             {
                 // No custom mapping - copy properties directly
                 // Init-only properties are included because constructors can set init accessors
+                var sourceNames = GetSourcePropertySet(model);
                 foreach (var m in model.Members)
                 {
-                    var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source");
+                    var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", 0, false, false, sourceNames);
                     sb.AppendLine($"        this.{m.Name} = {sourceValue};");
                 }
             }
@@ -271,8 +276,9 @@ internal static class ConstructorGenerator
         if (isPositional && !model.HasExistingPrimaryConstructor)
         {
             // Traditional positional record - chain to primary constructor
+            var sourceNames = GetSourcePropertySet(model);
             var args = string.Join(", ",
-                model.Members.Select(m => ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences)));
+                model.Members.Select(m => ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences, sourceNames)));
             ctorSig += $" : this({args})";
         }
         else if (model.ChainToParameterlessConstructor && !isPositional)
@@ -327,9 +333,10 @@ internal static class ConstructorGenerator
             // Regular mutable properties - initialize with depth tracking, then apply custom mapping
             // This ensures nested facets are properly instantiated with depth parameters
             // before custom mapping logic runs (which can override values if needed)
+            var sourceNames = GetSourcePropertySet(model);
             foreach (var m in model.Members)
             {
-                var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences);
+                var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences, sourceNames);
                 sb.AppendLine($"        this.{m.Name} = {sourceValue};");
             }
             sb.AppendLine($"        {GetMappingCall(model, "source", "this")};");
@@ -338,9 +345,10 @@ internal static class ConstructorGenerator
         {
             // No custom mapping - copy properties directly with depth tracking
             // Init-only properties are included because constructors can set init accessors
+            var sourceNames = GetSourcePropertySet(model);
             foreach (var m in model.Members)
             {
-                var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences);
+                var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", model.MaxDepth, true, model.PreserveReferences, sourceNames);
                 sb.AppendLine($"        this.{m.Name} = {sourceValue};");
             }
         }
@@ -390,10 +398,11 @@ internal static class ConstructorGenerator
             // For simple cases, use object initializer syntax for best performance
             sb.AppendLine($"        return new {model.Name}");
             sb.AppendLine("        {");
+            var sourceNames = GetSourcePropertySet(model);
             foreach (var m in model.Members)
             {
                 var comma = m == model.Members.Last() ? "" : ",";
-                var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source");
+                var sourceValue = ExpressionBuilder.GetSourceValueExpression(m, "source", 0, false, false, sourceNames);
                 sb.AppendLine($"            {m.Name} = {sourceValue}{comma}");
             }
             sb.AppendLine("        };");
@@ -437,6 +446,11 @@ internal static class ConstructorGenerator
     }
 
     #endregion
+
+    private static HashSet<string> GetSourcePropertySet(FacetTargetModel model)
+        => model.SourcePropertyNames.Length > 0
+            ? new HashSet<string>(model.SourcePropertyNames, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
 
     /// <summary>
     /// Returns the appropriate mapping call for the constructor body.

--- a/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ExpressionBuilder.cs
@@ -21,7 +21,8 @@ internal static class ExpressionBuilder
         string sourceVariableName,
         int maxDepth = 0,
         bool useDepthParameter = false,
-        bool preserveReferences = false)
+        bool preserveReferences = false,
+        HashSet<string>? sourcePropertyNames = null)
     {
         bool isNullable = member.TypeName.Contains("?");
 
@@ -40,7 +41,7 @@ internal static class ExpressionBuilder
         string valueExpression;
         if (member.MapFromSource != null && IsExpression(member.MapFromSource))
         {
-            valueExpression = TransformExpression(member.MapFromSource, sourceVariableName);
+            valueExpression = TransformExpression(member.MapFromSource, sourceVariableName, sourcePropertyNames);
         }
         else if (member.MapFromSource != null)
         {
@@ -62,7 +63,7 @@ internal static class ExpressionBuilder
         // Apply MapWhen conditions if present
         if (member.MapWhenConditions.Count > 0)
         {
-            valueExpression = WrapWithMapWhenCondition(member, valueExpression, sourceVariableName);
+            valueExpression = WrapWithMapWhenCondition(member, valueExpression, sourceVariableName, sourcePropertyNames);
         }
 
         return valueExpression;
@@ -161,11 +162,11 @@ internal static class ExpressionBuilder
     /// <summary>
     /// Wraps a value expression with MapWhen condition(s), generating a ternary expression.
     /// </summary>
-    private static string WrapWithMapWhenCondition(FacetMember member, string valueExpression, string sourceVariableName)
+    private static string WrapWithMapWhenCondition(FacetMember member, string valueExpression, string sourceVariableName, HashSet<string>? sourcePropertyNames = null)
     {
         // Combine multiple conditions with &&
         var combinedCondition = string.Join(" && ", member.MapWhenConditions.Select(c =>
-            $"({TransformExpression(c, sourceVariableName)})"));
+            $"({TransformExpression(c, sourceVariableName, sourcePropertyNames)})"));
 
         // Determine the default value
         var defaultValue = member.MapWhenDefault ?? Shared.GeneratorUtilities.GetDefaultValueForType(member.TypeName);
@@ -448,7 +449,7 @@ internal static class ExpressionBuilder
 
     // Expression parsing methods delegated to shared ExpressionHelper
     private static bool IsExpression(string source) => ExpressionHelper.IsExpression(source);
-    private static string TransformExpression(string expression, string sourceVariableName) => ExpressionHelper.TransformExpression(expression, sourceVariableName);
+    private static string TransformExpression(string expression, string sourceVariableName, HashSet<string>? sourcePropertyNames = null) => ExpressionHelper.TransformExpression(expression, sourceVariableName, sourcePropertyNames);
 
     /// <summary>
     /// Applies enum-to-target-type conversion (source enum ? facet string/int).

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -2,6 +2,7 @@ using Facet.Generators.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -299,6 +300,9 @@ internal static class ModelBuilder
         var baseHidesFacetMembers = BaseHidesFacetMembers(targetSymbol);
         var baseHidesFromSource = BaseHidesFromSource(targetSymbol, sourceTypeFullName);
 
+        // Collect source type member names for MapFrom expression disambiguation
+        var sourcePropertyNames = CollectSourcePropertyNames(sourceType);
+
         return new FacetTargetModel(
             targetSymbol.Name,
             ns,
@@ -338,7 +342,8 @@ internal static class ModelBuilder
             baseHidesFromSource,
             hasMapConfiguration,
             baseFacetInfo,
-            maxDepthToSource);
+            maxDepthToSource,
+            sourcePropertyNames);
     }
 
     #region Private Helper Methods
@@ -1496,6 +1501,22 @@ private static Dictionary<string, (string targetName, string source, bool revers
         }
 
         return false;
+    }
+
+    private static ImmutableArray<string> CollectSourcePropertyNames(INamedTypeSymbol sourceType)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var current = (INamedTypeSymbol?)sourceType;
+        while (current != null && current.SpecialType != SpecialType.System_Object)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member.Kind == SymbolKind.Property || member.Kind == SymbolKind.Field)
+                    names.Add(member.Name);
+            }
+            current = current.BaseType;
+        }
+        return names.ToImmutableArray();
     }
 
     #endregion

--- a/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ProjectionGenerator.cs
@@ -1,4 +1,5 @@
 using Facet.Generators.Shared;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -635,13 +636,16 @@ internal static class ProjectionGenerator
     {
         var visitedTypes = new HashSet<string> { model.Name };
         var includedMembers = model.Members.Where(m => m.MapFromIncludeInProjection).ToArray();
+        var sourceNames = model.SourcePropertyNames.Length > 0
+            ? new HashSet<string>(model.SourcePropertyNames, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
         
         sb.Append($"{indent}source => new {model.Name}(");
         
         for (int i = 0; i < includedMembers.Length; i++)
         {
             var member = includedMembers[i];
-            var projectionValue = GetProjectionValueExpression(member, "source", indent, facetLookup, visitedTypes, 0, model.MaxDepth);
+            var projectionValue = GetProjectionValueExpression(member, "source", indent, facetLookup, visitedTypes, 0, model.MaxDepth, sourceNames);
             sb.Append(projectionValue);
             
             if (i < includedMembers.Length - 1)
@@ -671,6 +675,9 @@ internal static class ProjectionGenerator
         // Pre-filter included members to avoid O(n²) comma placement check
         var includedMembers = members.Where(m => m.MapFromIncludeInProjection).ToArray();
         var includedCount = includedMembers.Length;
+        var sourceNames = model.SourcePropertyNames.Length > 0
+            ? new HashSet<string>(model.SourcePropertyNames, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
 
         for (int i = 0; i < includedCount; i++)
         {
@@ -678,7 +685,7 @@ internal static class ProjectionGenerator
             var memberIndent = indent + "    ";
 
             // Generate the property assignment
-            var projectionValue = GetProjectionValueExpression(member, "source", memberIndent, facetLookup, visitedTypes, 0, model.MaxDepth);
+            var projectionValue = GetProjectionValueExpression(member, "source", memberIndent, facetLookup, visitedTypes, 0, model.MaxDepth, sourceNames);
             sb.Append($"{memberIndent}{member.Name} = {projectionValue}");
 
             // Add comma if not the last member
@@ -701,7 +708,8 @@ internal static class ProjectionGenerator
         Dictionary<string, List<FacetTargetModel>> facetLookup,
         HashSet<string> visitedTypes,
         int currentDepth = 0,
-        int maxDepth = 0)
+        int maxDepth = 0,
+        HashSet<string>? sourcePropertyNames = null)
     {
         // Check if the member type is nullable
         bool isNullable = member.TypeName.Contains("?");
@@ -719,7 +727,7 @@ internal static class ProjectionGenerator
         string valueExpression;
         if (member.MapFromSource != null && IsExpression(member.MapFromSource))
         {
-            valueExpression = TransformExpression(member.MapFromSource, sourceVariableName);
+            valueExpression = TransformExpression(member.MapFromSource, sourceVariableName, sourcePropertyNames);
         }
         else if (member.MapFromSource != null)
         {
@@ -741,7 +749,7 @@ internal static class ProjectionGenerator
         // Apply MapWhen conditions if present and IncludeInProjection is true
         if (member.MapWhenConditions.Count > 0 && member.MapWhenIncludeInProjection)
         {
-            valueExpression = WrapWithMapWhenCondition(member, valueExpression, sourceVariableName);
+            valueExpression = WrapWithMapWhenCondition(member, valueExpression, sourceVariableName, sourcePropertyNames);
         }
 
         return valueExpression;
@@ -886,10 +894,13 @@ internal static class ProjectionGenerator
         sb.Append($"new {facetTypeName} {{ ");
 
         var members = nestedFacetModel.Members;
+        var sourceNames = nestedFacetModel.SourcePropertyNames.Length > 0
+            ? new HashSet<string>(nestedFacetModel.SourcePropertyNames, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < members.Length; i++)
         {
             var member = members[i];
-            var projectionValue = GetProjectionValueExpression(member, sourceExpression, indent, facetLookup, visitedTypes, currentDepth, maxDepth);
+            var projectionValue = GetProjectionValueExpression(member, sourceExpression, indent, facetLookup, visitedTypes, currentDepth, maxDepth, sourceNames);
             sb.Append($"{member.Name} = {projectionValue}");
 
             if (i < members.Length - 1)
@@ -1063,7 +1074,7 @@ internal static class ProjectionGenerator
 
     // Expression parsing methods delegated to shared ExpressionHelper
     private static bool IsExpression(string source) => ExpressionHelper.IsExpression(source);
-    private static string TransformExpression(string expression, string sourceVariableName) => ExpressionHelper.TransformExpression(expression, sourceVariableName);
+    private static string TransformExpression(string expression, string sourceVariableName, HashSet<string>? sourcePropertyNames = null) => ExpressionHelper.TransformExpression(expression, sourceVariableName, sourcePropertyNames);
 
     /// <summary>
     /// Applies enum-to-target-type conversion for projection expressions (EF Core compatible).
@@ -1165,11 +1176,11 @@ internal static class ProjectionGenerator
     /// <summary>
     /// Wraps a value expression with MapWhen condition(s), generating a ternary expression.
     /// </summary>
-    private static string WrapWithMapWhenCondition(FacetMember member, string valueExpression, string sourceVariableName)
+    private static string WrapWithMapWhenCondition(FacetMember member, string valueExpression, string sourceVariableName, HashSet<string>? sourcePropertyNames = null)
     {
         // Combine multiple conditions with &&
         var combinedCondition = string.Join(" && ", member.MapWhenConditions.Select(c =>
-            $"({TransformExpression(c, sourceVariableName)})"));
+            $"({TransformExpression(c, sourceVariableName, sourcePropertyNames)})"));
 
         // Determine the default value
         var defaultValue = member.MapWhenDefault ?? Shared.GeneratorUtilities.GetDefaultValueForType(member.TypeName);

--- a/src/Facet/Generators/Shared/ExpressionHelper.cs
+++ b/src/Facet/Generators/Shared/ExpressionHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text;
 
 namespace Facet.Generators.Shared;
@@ -23,7 +24,7 @@ internal static class ExpressionHelper
     /// Transforms a MapFrom expression by prefixing identifiers with the source variable name.
     /// For example: "FirstName + \" \" + LastName" becomes "source.FirstName + \" \" + source.LastName"
     /// </summary>
-    public static string TransformExpression(string expression, string sourceVariableName)
+    public static string TransformExpression(string expression, string sourceVariableName, HashSet<string>? sourcePropertyNames = null)
     {
         var result = new StringBuilder();
         var identifier = new StringBuilder();
@@ -47,7 +48,7 @@ internal static class ExpressionHelper
                     inString = false;
                 }
 
-                FlushIdentifier(result, identifier, sourceVariableName, expression, i);
+                FlushIdentifier(result, identifier, sourceVariableName, expression, i, sourcePropertyNames);
                 result.Append(c);
                 continue;
             }
@@ -65,19 +66,19 @@ internal static class ExpressionHelper
             }
             else
             {
-                FlushIdentifier(result, identifier, sourceVariableName, expression, i);
+                FlushIdentifier(result, identifier, sourceVariableName, expression, i, sourcePropertyNames);
                 result.Append(c);
             }
         }
 
-        FlushIdentifier(result, identifier, sourceVariableName, expression, expression.Length);
+        FlushIdentifier(result, identifier, sourceVariableName, expression, expression.Length, sourcePropertyNames);
         return result.ToString();
     }
 
     /// <summary>
     /// Flushes an accumulated identifier to the result, prefixing with source variable if needed.
     /// </summary>
-    private static void FlushIdentifier(StringBuilder result, StringBuilder identifier, string sourceVariableName, string expression, int currentIndex)
+    private static void FlushIdentifier(StringBuilder result, StringBuilder identifier, string sourceVariableName, string expression, int currentIndex, HashSet<string>? sourcePropertyNames = null)
     {
         if (identifier.Length > 0)
         {
@@ -86,7 +87,7 @@ internal static class ExpressionHelper
             var identifierStartIndex = currentIndex - identifier.Length;
             var isPrecededByDot = identifierStartIndex > 0 && expression[identifierStartIndex - 1] == '.';
 
-            if (!IsKeyword(id) && !char.IsDigit(id[0]) && !IsLikelyTypeName(id, expression, currentIndex) && !isPrecededByDot)
+            if (!IsKeyword(id) && !char.IsDigit(id[0]) && !IsLikelyTypeName(id, expression, currentIndex, sourcePropertyNames) && !isPrecededByDot)
             {
                 result.Append($"{sourceVariableName}.");
             }
@@ -113,14 +114,18 @@ internal static class ExpressionHelper
     /// <summary>
     /// Checks if an identifier appears to be a type name (starts with uppercase and is followed by '.')
     /// This helps avoid prefixing enum type names like OrderStatus in "OrderStatus.Completed".
+    /// Known source property names take priority: if the identifier is a known source property, it is NOT treated as a type name.
     /// </summary>
-    public static bool IsLikelyTypeName(string identifier, string expression, int identifierEndIndex)
+    public static bool IsLikelyTypeName(string identifier, string expression, int identifierEndIndex, HashSet<string>? sourcePropertyNames = null)
     {
         // If identifier starts with uppercase and is followed by '.', it's likely a type name
         if (identifier.Length > 0 && char.IsUpper(identifier[0]))
         {
             if (identifierEndIndex < expression.Length && expression[identifierEndIndex] == '.')
             {
+                // If the identifier is a known source property, it is NOT a type name
+                if (sourcePropertyNames != null && sourcePropertyNames.Contains(identifier))
+                    return false;
                 return true;
             }
         }

--- a/test/Facet.Tests/UnitTests/Core/Facet/MapFromTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/MapFromTests.cs
@@ -149,6 +149,32 @@ public partial class MapFromMultiLevelPathFacet
     public string EmployeeName { get; set; } = string.Empty;
 }
 
+// Navigation property expression test models - reproduces issue with MapFrom expressions
+// referencing navigation properties (e.g. "User.PrimaryGroupId == GroupId")
+public class MapFromGroupMembershipEntity
+{
+    public int Id { get; set; }
+    public int GroupId { get; set; }
+    public MapFromUserEntity? User { get; set; }
+}
+
+public class MapFromUserEntity
+{
+    public string Username { get; set; } = string.Empty;
+    public int PrimaryGroupId { get; set; }
+}
+
+[Facet(typeof(MapFromGroupMembershipEntity),
+    Include = [nameof(MapFromGroupMembershipEntity.Id), nameof(MapFromGroupMembershipEntity.GroupId)])]
+public partial class MapFromNavigationExpressionFacet
+{
+    [MapFrom("User.Username")]
+    public string Username { get; set; } = string.Empty;
+
+    [MapFrom("User.PrimaryGroupId == GroupId")]
+    public bool IsPrimary { get; set; }
+}
+
 public class MapFromTests
 {
     [Fact]
@@ -735,5 +761,63 @@ public class MapFromTests
 
         // Should NOT have the "Company" navigation property (it's mapped to nested paths)
         propertyNames.Should().NotContain("Company");
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapNavigationPropertyExpression()
+    {
+        // Arrange - User.PrimaryGroupId matches GroupId
+        var entity = new MapFromGroupMembershipEntity
+        {
+            Id = 42,
+            GroupId = 7,
+            User = new MapFromUserEntity { Username = "alice", PrimaryGroupId = 7 }
+        };
+
+        // Act
+        var facet = new MapFromNavigationExpressionFacet(entity);
+
+        // Assert
+        facet.Username.Should().Be("alice");
+        facet.IsPrimary.Should().BeTrue("User.PrimaryGroupId (7) == GroupId (7)");
+    }
+
+    [Fact]
+    public void Constructor_ShouldMapNavigationPropertyExpression_WhenNotPrimary()
+    {
+        // Arrange - User.PrimaryGroupId does NOT match GroupId
+        var entity = new MapFromGroupMembershipEntity
+        {
+            Id = 43,
+            GroupId = 7,
+            User = new MapFromUserEntity { Username = "bob", PrimaryGroupId = 99 }
+        };
+
+        // Act
+        var facet = new MapFromNavigationExpressionFacet(entity);
+
+        // Assert
+        facet.Username.Should().Be("bob");
+        facet.IsPrimary.Should().BeFalse("User.PrimaryGroupId (99) != GroupId (7)");
+    }
+
+    [Fact]
+    public void Projection_ShouldMapNavigationPropertyExpression()
+    {
+        // Arrange
+        var entities = new List<MapFromGroupMembershipEntity>
+        {
+            new() { Id = 1, GroupId = 5, User = new MapFromUserEntity { Username = "alice", PrimaryGroupId = 5 } },
+            new() { Id = 2, GroupId = 5, User = new MapFromUserEntity { Username = "bob", PrimaryGroupId = 9 } },
+        };
+
+        // Act
+        var results = entities.AsQueryable().Select(MapFromNavigationExpressionFacet.Projection).ToList();
+
+        // Assert
+        results[0].Username.Should().Be("alice");
+        results[0].IsPrimary.Should().BeTrue();
+        results[1].Username.Should().Be("bob");
+        results[1].IsPrimary.Should().BeFalse();
     }
 }


### PR DESCRIPTION
Closes #358 

Source type property names are now collected at model-build time and passed through to the expression transformer. If a PascalCase identifier is a known property on the source type, it is treated as a navigation property rather than a static type reference, and source. is correctly prepended.