### PR TITLE
feat: ApplyToSource

### DIFF
--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -31,7 +31,7 @@ public partial class MyFacet { }
 | `Configuration`                | `Type?`   | Custom mapping config type for forward mapping (Entity > DTO). See [Custom Mapping](04_CustomMapping.md).      |
 | `ToSourceConfiguration`        | `Type?`   | Custom mapping config type for reverse mapping (DTO > Entity), called inside `ToSource()`. Requires `GenerateToSource = true`. See [Reverse Mapping](04_CustomMapping.md#reverse-mapping-tosourceconfiguration). |
 | `GenerateProjection`           | `bool`    | Generate a static LINQ projection (default: true).                          |
-| `GenerateToSource`             | `bool`    | Generate a method to map back from facet to source type (default: false).    |
+| `GenerateToSource`             | `bool`    | Generates `ToSource()` (creates a new source instance) and `ApplyToSource(source)` (mutates an existing source instance) methods. Default: false. `ApplyToSource` is not generated for positional-record source types. |
 | `PreserveInitOnlyProperties`   | `bool`    | Preserve init-only modifiers from source properties (default: true for records). |
 | `PreserveRequiredProperties`   | `bool`    | Preserve required modifiers from source properties (default: true for records). |
 | `NullableProperties`           | `bool`    | Make all properties nullable in the generated facet (default: false). |
@@ -503,6 +503,29 @@ public partial record SimpleTypeDto;
 - **Level 2**: Second level nested objects (e.g., Product)
 - **Level 3**: Third level nested objects (e.g., Category)
 - Properties that would exceed MaxDepth are set to `null` (with default MaxDepth = 10, this covers most real-world scenarios)
+
+### ApplyToSource
+
+When `GenerateToSource = true`, Facet generates both `ToSource()` and `ApplyToSource()`. While `ToSource()` creates a **new** source instance, `ApplyToSource()` writes the mapped properties back onto an **existing** source instance without allocating a new one.
+
+```csharp
+[Facet(typeof(User), "Password", "CreatedAt", GenerateToSource = true)]
+public partial class UserDto { }
+
+// Load an existing entity from the database
+var entity = await dbContext.Users.FindAsync(id);
+
+// Apply DTO changes onto it - EF Core change tracking stays intact
+dto.ApplyToSource(entity);
+
+await dbContext.SaveChangesAsync();
+```
+
+**This is the recommended pattern for update operations** because the original entity reference is retained, which means ORM change tracking and audit hooks continue to work correctly.
+
+**Limitations:**
+- Not generated when the source type uses a positional constructor (e.g. `record User(string Id, string Name)`), because positional record properties are init-only and cannot be set after construction. Use `ToSource()` and re-attach the new instance instead.
+- Only properties included in the facet and marked as reversible are written. All other source properties are left untouched.
 
 ### MaxDepthToSource
 

--- a/docs/07_WhatIsBeingGenerated.md
+++ b/docs/07_WhatIsBeingGenerated.md
@@ -97,6 +97,20 @@ public partial class UserDto
         };
     }
 
+    /// <summary>
+    /// Applies the mapped properties of this UserDto instance onto an existing
+    /// User instance in place.
+    /// Only properties that are part of this facet are written.
+    /// Properties excluded from this facet are left unchanged on the source.
+    /// </summary>
+    public void ApplyToSource(User source)
+    {
+        source.Id = this.Id;
+        source.FirstName = this.FirstName;
+        source.LastName = this.LastName;
+        source.Email = this.Email;
+    }
+
     [Obsolete("Use ToSource() instead. This method will be removed in a future version.")]
     public User BackTo() => ToSource();
 }
@@ -110,6 +124,7 @@ public partial class UserDto
 - Parameterless constructor for deserialization
 - `Projection` expression for LINQ/EF queries
 - `ToSource()` method for reverse mapping (because `GenerateToSource = true`)
+- `ApplyToSource(User source)` method for mutating an existing instance in place
 - Obsolete `BackTo()` method for backward compatibility
 
 ---
@@ -985,6 +1000,7 @@ For a basic facet, Facet generates:
 ### Methods
 - `static Dto FromSource(Source source)` - factory method for optimal runtime performance
 - `Source ToSource()` - reverse mapping (when `GenerateToSource = true`)
+- `void ApplyToSource(Source source)` - mutates an existing source instance in place (when `GenerateToSource = true` and source is not a positional record)
 - `Source BackTo()` - obsolete, calls `ToSource()`
 - `Source Unwrap()` - for Wrapper only
 

--- a/src/Facet/FacetMember.cs
+++ b/src/Facet/FacetMember.cs
@@ -13,6 +13,13 @@ internal sealed class FacetMember : IEquatable<FacetMember>
     public bool IsInitOnly { get; }
     public bool IsRequired { get; }
     public bool IsReadOnly { get; }
+
+    /// <summary>
+    /// Whether the corresponding SOURCE property has an init-only setter.
+    /// This is the raw source accessor flag, independent of whether the facet preserves it.
+    /// Used by <c>ApplyToSource</c> to skip properties that cannot be assigned after construction.
+    /// </summary>
+    public bool IsSourceInitOnly { get; }
     public string? XmlDocumentation { get; }
     public bool IsNestedFacet { get; }
     public string? NestedFacetSourceTypeName { get; }
@@ -89,7 +96,8 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         bool isEnumConversion = false,
         string? originalEnumTypeName = null,
         bool isNestedType = false,
-        bool isPartial = false)
+        bool isPartial = false,
+        bool isSourceInitOnly = false)
     {
         Name = name;
         TypeName = typeName;
@@ -120,6 +128,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         OriginalEnumTypeName = originalEnumTypeName;
         IsNestedType = isNestedType;
         IsPartial = isPartial;
+        IsSourceInitOnly = isSourceInitOnly;
     }
 
     public bool Equals(FacetMember? other) =>
@@ -149,7 +158,8 @@ internal sealed class FacetMember : IEquatable<FacetMember>
         OriginalEnumTypeName == other.OriginalEnumTypeName &&
         IsNestedType == other.IsNestedType &&
         IsPartial == other.IsPartial &&
-        Attributes.SequenceEqual(other.Attributes) &&
+        IsSourceInitOnly == other.IsSourceInitOnly &&
+        Attributes.SequenceEqual(other.Attributes)&&
         AttributeNamespaces.SequenceEqual(other.AttributeNamespaces) &&
         MapWhenConditions.SequenceEqual(other.MapWhenConditions);
 
@@ -185,6 +195,7 @@ internal sealed class FacetMember : IEquatable<FacetMember>
             hash = hash * 31 + (OriginalEnumTypeName?.GetHashCode() ?? 0);
             hash = hash * 31 + IsNestedType.GetHashCode();
             hash = hash * 31 + IsPartial.GetHashCode();
+            hash = hash * 31 + IsSourceInitOnly.GetHashCode();
             hash = hash * 31 + Attributes.Count.GetHashCode();
             foreach (var attr in Attributes)
                 hash = hash * 31 + (attr?.GetHashCode() ?? 0);

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -149,6 +149,12 @@ internal static class CodeBuilder
             ToSourceGenerator.Generate(sb, model, facetLookup);
         }
 
+        // Generate ApplyToSource method (mutates an existing source instance)
+        if (model.GenerateToSource && !model.SourceHasPositionalConstructor)
+        {
+            ToSourceGenerator.GenerateApplyToSource(sb, model, facetLookup);
+        }
+
         // Generate FlattenTo methods
         if (model.FlattenToTypes.Length > 0)
         {
@@ -339,6 +345,15 @@ internal static class CodeBuilder
             ToSourceGenerator.Generate(sb, model, facetLookup, toSourceName);
         }
 
+        // Per-source: ApplyToSource methods (mutate an existing source instance)
+        foreach (var model in models)
+        {
+            if (!model.GenerateToSource || model.SourceHasPositionalConstructor) continue;
+
+            var applyMethodName = GetApplyToSourceMethodName(model, models);
+            ToSourceGenerator.GenerateApplyToSource(sb, model, facetLookup, applyMethodName);
+        }
+
         // Per-source: FlattenTo
         foreach (var model in models)
         {
@@ -384,6 +399,21 @@ internal static class CodeBuilder
             return null; // Use default "ToSource" + BackTo
 
         return "To" + GetSourceSimpleName(model);
+    }
+
+    /// <summary>
+    /// Returns the method name to use for the ApplyToSource operation of the given model.
+    /// <list type="bullet">
+    /// <item>Single-source: <c>null</c> → <c>"ApplyToSource"</c>.</item>
+    /// <item>Multi-source: <c>"ApplyTo{SourceSimpleName}"</c>.</item>
+    /// </list>
+    /// </summary>
+    private static string? GetApplyToSourceMethodName(FacetTargetModel model, IReadOnlyList<FacetTargetModel> allModels)
+    {
+        if (allModels.Count <= 1)
+            return null; // Use default "ApplyToSource"
+
+        return "ApplyTo" + GetSourceSimpleName(model);
     }
 
     /// <summary>

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -750,7 +750,8 @@ internal static class ModelBuilder
             isEnumConversion,
             originalEnumTypeName,
             isNestedType,
-            isPartial: false)); // Never propagate partial from source (GitHub issue #277)
+            isPartial: false, // Never propagate partial from source (GitHub issue #277)
+            isSourceInitOnly: isInitOnly)); // Raw source accessor — needed by ApplyToSource generation
         addedMembers.Add(memberName);
     }
 

--- a/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
@@ -84,6 +84,60 @@ internal static class ToSourceGenerator
         }
     }
 
+    /// <summary>
+    /// Generates an <c>ApplyToSource</c> method that writes the facet's reversible properties
+    /// back onto an existing source instance (mutation, not construction).
+    /// Not generated for positional-constructor sources because their properties cannot be
+    /// individually assigned after the object is created.
+    /// </summary>
+    /// <param name="methodName">
+    /// Override for the method name.  Pass <see langword="null"/> to use the default <c>ApplyToSource</c>.
+    /// Multi-source scenarios pass a source-specific name such as <c>ApplyToOrder</c>.
+    /// </param>
+    public static void GenerateApplyToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup, string? methodName = null)
+    {
+        // Positional (record) sources cannot have individual properties set after construction.
+        if (model.SourceHasPositionalConstructor)
+            return;
+
+        var applyMethodName = methodName ?? "ApplyToSource";
+        var newMod = model.BaseHidesFacetMembers && methodName == null ? "new " : "";
+
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Applies the mapped properties of this <see cref=\"{model.Name}\"/> instance onto an existing");
+        sb.AppendLine($"    /// <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\"/> instance in place.");
+        sb.AppendLine("    /// Only properties that are part of this facet and marked as reversible are written.");
+        sb.AppendLine("    /// Properties excluded from this facet are left unchanged on the source.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine($"    /// <param name=\"source\">The existing <see cref=\"{CodeGenerationHelpers.GetSimpleTypeName(model.SourceTypeName)}\"/> instance to update.</param>");
+        sb.AppendLine($"    public {newMod}void {applyMethodName}({model.SourceTypeName} source)");
+        sb.AppendLine("    {");
+
+        var hasMappable = false;
+        foreach (var member in model.Members)
+        {
+            if (!member.MapFromReversible)
+                continue;
+
+            // Cannot assign to init-only source properties outside of a constructor or object initializer
+            if (member.IsSourceInitOnly)
+                continue;
+
+            var value = ExpressionBuilder.GetToSourceValueExpression(member, facetLookup, model.SourceTypeName, 0, false);
+            sb.AppendLine($"        source.{member.SourcePropertyName} = {value};");
+            hasMappable = true;
+        }
+
+        if (!hasMappable)
+            sb.AppendLine("        // No settable reversible members configured for this facet");
+
+        if (model.ToSourceConfigurationTypeName != null)
+            sb.AppendLine($"        {model.ToSourceConfigurationTypeName}.Map(this, source);");
+
+        sb.AppendLine("    }");
+    }
+
     private static void GeneratePositionalToSource(StringBuilder sb, FacetTargetModel model, Dictionary<string, List<FacetTargetModel>>? facetLookup, bool useDepthParameter = false)
     {
         var constructorArgs = string.Join(", ",

--- a/test/Facet.Tests/UnitTests/Core/Facet/ApplyToSourceTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/ApplyToSourceTests.cs
@@ -1,0 +1,174 @@
+using Facet.Tests.TestModels;
+using Facet.Tests.Utilities;
+
+namespace Facet.Tests.UnitTests.Core.Facet;
+
+public class ApplyToSourceTests
+{
+    [Fact]
+    public void ApplyToSource_ShouldUpdateExistingInstance_WithMappedProperties()
+    {
+        // Arrange
+        var original = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var dto = new UserDto(original);
+        dto.FirstName = "Jane";
+        dto.Email = "jane@example.com";
+
+        var target = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+
+        // Act
+        dto.ApplyToSource(target);
+
+        // Assert
+        target.FirstName.Should().Be("Jane");
+        target.Email.Should().Be("jane@example.com");
+        target.LastName.Should().Be("Doe");
+    }
+
+    [Fact]
+    public void ApplyToSource_ShouldOnlyUpdateIncludedProperties_LeavingExcludedPropertiesUnchanged()
+    {
+        // Arrange
+        var original = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var dto = new UserDto(original);
+
+        var target = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var originalPassword = target.Password;
+        var originalCreatedAt = target.CreatedAt;
+
+        // Act
+        dto.ApplyToSource(target);
+
+        // Assert - excluded properties are untouched
+        target.Password.Should().Be(originalPassword);
+        target.CreatedAt.Should().Be(originalCreatedAt);
+    }
+
+    [Fact]
+    public void ApplyToSource_ShouldMutateInstance_NotCreateNewOne()
+    {
+        // Arrange
+        var original = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var dto = new UserDto(original);
+        dto.FirstName = "Alice";
+
+        var target = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var sameRef = target;
+
+        // Act
+        dto.ApplyToSource(target);
+
+        // Assert - it is the same object, mutated in place
+        object.ReferenceEquals(target, sameRef).Should().BeTrue();
+        target.FirstName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public void ApplyToSource_ShouldHandleInclude_UpdatesOnlyIncludedFields()
+    {
+        // Arrange
+        var original = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var dto = new UserIncludeDto(original);
+        dto.FirstName = "Bob";
+        dto.LastName = "Builder";
+        dto.Email = "bob@example.com";
+
+        var target = TestDataFactory.CreateUser("John", "Doe", "john@example.com");
+        var originalId = target.Id;
+
+        // Act
+        dto.ApplyToSource(target);
+
+        // Assert
+        target.FirstName.Should().Be("Bob");
+        target.LastName.Should().Be("Builder");
+        target.Email.Should().Be("bob@example.com");
+        // Id was not in the include list, so it should be unchanged
+        target.Id.Should().Be(originalId);
+    }
+
+    [Fact]
+    public void ApplyToSource_ShouldRoundtrip_WhenValuesAreModifiedOnDto()
+    {
+        // Arrange
+        var entity = TestDataFactory.CreateUser("Alice", "Wonderland", "alice@example.com");
+        entity.IsActive = true;
+        var dto = new UserDto(entity);
+
+        // Simulate an update from the UI
+        dto.FirstName = "Alicia";
+        dto.IsActive = false;
+
+        var existingEntity = TestDataFactory.CreateUser("Alice", "Wonderland", "alice@example.com");
+        existingEntity.IsActive = true;
+
+        // Act
+        dto.ApplyToSource(existingEntity);
+
+        // Assert
+        existingEntity.FirstName.Should().Be("Alicia");
+        existingEntity.IsActive.Should().BeFalse();
+        existingEntity.LastName.Should().Be("Wonderland");
+    }
+
+    [Fact]
+    public void ApplyToSource_WithNullableProperty_ShouldSetNullOnTarget()
+    {
+        // Arrange
+        var original = TestDataFactory.CreateUser();
+        original.LastLoginAt = DateTime.UtcNow;
+        var dto = new UserDto(original);
+        dto.LastLoginAt = null;
+
+        var target = TestDataFactory.CreateUser();
+        target.LastLoginAt = DateTime.UtcNow;
+
+        // Act
+        dto.ApplyToSource(target);
+
+        // Assert
+        target.LastLoginAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyToSource_WithEmployee_ShouldUpdateInheritedProperties()
+    {
+        // Arrange
+        var original = TestDataFactory.CreateEmployee("Jane", "Smith");
+        var dto = new EmployeeDto(original);
+        dto.FirstName = "Janet";
+        dto.Department = "Finance";
+
+        var target = TestDataFactory.CreateEmployee("Jane", "Smith");
+
+        // Act
+        dto.ApplyToSource(target);
+
+        // Assert
+        target.FirstName.Should().Be("Janet");
+        target.Department.Should().Be("Finance");
+        target.LastName.Should().Be("Smith");
+    }
+
+    [Fact]
+    public void ClassicUserDto_ShouldNotHaveApplyToSource_BecauseSourceIsPositionalRecord()
+    {
+        // ClassicUser is a positional record: record ClassicUser(string Id, string FirstName, ...)
+        // ApplyToSource cannot be generated for positional records because their properties
+        // are init-only and cannot be individually assigned after construction.
+        var type = typeof(ClassicUserDto);
+        var method = type.GetMethod("ApplyToSource");
+
+        method.Should().BeNull("positional record sources do not support mutation via ApplyToSource");
+    }
+
+    [Fact]
+    public void ProductDto_ShouldHaveApplyToSource_BecauseProductIsAMutableClass()
+    {
+        // Product is a regular class with { get; set; } properties - fully mutable
+        var type = typeof(ProductDto);
+        var method = type.GetMethod("ApplyToSource");
+
+        method.Should().NotBeNull("Product is a mutable class, so ApplyToSource should be generated");
+    }
+}


### PR DESCRIPTION
Closes #285 

When `GenerateToSource = true`, Facet now generates an `ApplyToSource` method alongside `ToSource`. While `ToSource()` creates a new source instance, `ApplyToSource` writes the mapped properties back onto an existing one

```csharp
[Facet(typeof(User), "Password", "CreatedAt", GenerateToSource = true)]
public partial class UserDto { }
 
// Load from database
var entity = await dbContext.Users.FindAsync(id);
 
// Apply DTO changes; EF Core change tracking stays intact
dto.ApplyToSource(entity);
 
await dbContext.SaveChangesAsync();
```
Why this matters

The existing `ApplyFacet` extension in `Facet.Extensions` does the same job but uses reflection. `ApplyToSource` is fully source-generated: zero reflection, no allocations, AOT/trim safe.