### PR TITLE
fix: InheritDocs should resolve '@inheritdocs' until content is found

### DIFF
--- a/src/Facet/Generators/FacetGenerators/CodeGenerationHelpers.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeGenerationHelpers.cs
@@ -410,57 +410,82 @@ internal static class CodeGenerationHelpers
 
     /// <summary>
     /// Extracts and formats XML documentation from a symbol.
-    /// When <paramref name="inheritDocs"/> is true and the symbol has no documentation,
-    /// falls back to base classes and then interfaces to find inherited documentation.
+    /// When <paramref name="inheritDocs"/> is true and the symbol has no usable
+    /// documentation (no docs at all, or only <c>&lt;inheritdoc/&gt;</c>), falls back to
+    /// base classes and then interfaces. The walk continues past hierarchy entries that
+    /// themselves only contain <c>&lt;inheritdoc/&gt;</c>. Supported for both member
+    /// symbols (properties and fields) and type symbols.
     /// </summary>
     public static string? ExtractXmlDocumentation(ISymbol symbol, bool inheritDocs = false)
     {
-        var documentationComment = symbol.GetDocumentationCommentXml();
-        if (!string.IsNullOrWhiteSpace(documentationComment))
-            return FormatXmlDocumentation(documentationComment!);
+        return ExtractXmlDocumentationCore(symbol, inheritDocs, visited: null);
+    }
+
+    private static string? ExtractXmlDocumentationCore(ISymbol symbol, bool inheritDocs, HashSet<ISymbol>? visited)
+    {
+        var rawXml = symbol.GetDocumentationCommentXml();
+        var formatted = FormatXmlDocumentation(rawXml ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(formatted))
+            return formatted;
 
         if (!inheritDocs)
             return null;
 
-        return ExtractXmlDocumentationFromHierarchy(symbol);
-    }
-
-    private static string? ExtractXmlDocumentationFromHierarchy(ISymbol symbol)
-    {
-        if (symbol is not (IPropertySymbol or IFieldSymbol))
+        visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        if (!visited.Add(symbol))
             return null;
 
-        var containingType = symbol.ContainingType;
+        return symbol switch
+        {
+            IPropertySymbol or IFieldSymbol => WalkMemberHierarchy(symbol, visited),
+            INamedTypeSymbol type => WalkTypeHierarchy(type, visited),
+            _ => null
+        };
+    }
+
+    private static string? WalkMemberHierarchy(ISymbol member, HashSet<ISymbol> visited)
+    {
+        var containingType = member.ContainingType;
         if (containingType is null)
             return null;
 
-        var baseType = containingType.BaseType;
-        while (baseType is not null)
+        foreach (var ancestor in EnumerateBaseTypesThenInterfaces(containingType))
         {
-            if (baseType.SpecialType == SpecialType.System_Object)
-                break;
-            var match = baseType.GetMembers(symbol.Name).FirstOrDefault(m => m.Kind == symbol.Kind);
-            if (match is not null)
-            {
-                var doc = match.GetDocumentationCommentXml();
-                if (!string.IsNullOrWhiteSpace(doc))
-                    return FormatXmlDocumentation(doc!);
-            }
-            baseType = baseType.BaseType;
-        }
+            var match = ancestor.GetMembers(member.Name).FirstOrDefault(m => m.Kind == member.Kind);
+            if (match is null)
+                continue;
 
-        foreach (var iface in containingType.AllInterfaces)
-        {
-            var match = iface.GetMembers(symbol.Name).FirstOrDefault(m => m.Kind == symbol.Kind);
-            if (match is not null)
-            {
-                var doc = match.GetDocumentationCommentXml();
-                if (!string.IsNullOrWhiteSpace(doc))
-                    return FormatXmlDocumentation(doc!);
-            }
+            var doc = ExtractXmlDocumentationCore(match, inheritDocs: true, visited);
+            if (!string.IsNullOrWhiteSpace(doc))
+                return doc;
         }
 
         return null;
+    }
+
+    private static string? WalkTypeHierarchy(INamedTypeSymbol type, HashSet<ISymbol> visited)
+    {
+        foreach (var ancestor in EnumerateBaseTypesThenInterfaces(type))
+        {
+            var doc = ExtractXmlDocumentationCore(ancestor, inheritDocs: true, visited);
+            if (!string.IsNullOrWhiteSpace(doc))
+                return doc;
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateBaseTypesThenInterfaces(INamedTypeSymbol type)
+    {
+        for (var baseType = type.BaseType;
+             baseType is not null && baseType.SpecialType != SpecialType.System_Object;
+             baseType = baseType.BaseType)
+        {
+            yield return baseType;
+        }
+
+        foreach (var iface in type.AllInterfaces)
+            yield return iface;
     }
 
     /// <summary>

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -155,7 +155,7 @@ internal static class ModelBuilder
         var mapWhenMappings = ExtractMapWhenMappings(targetSymbol);
 
         // Extract type-level XML documentation from the source type
-        var typeXmlDocumentation = CodeGenerationHelpers.ExtractXmlDocumentation(sourceType);
+        var typeXmlDocumentation = CodeGenerationHelpers.ExtractXmlDocumentation(sourceType, inheritDocs);
 
         // Collect base class member names early, needed by ExtractMembers to auto-include
         var baseClassMemberNames = GetBaseClassMemberNames(targetSymbol);

--- a/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
@@ -143,7 +143,246 @@ public class InheritDocsTests
         source.Should().Contain("The entity identifier.");
         source.Should().Contain("The entity name.");
     }
+
+    [Fact]
+    public void Facet_ShouldInheritDocsThroughMultiLevelInterfaceChain()
+    {
+        // Docs live on IBaseShape; intermediate IDerivedShape and IGrandDerivedShape
+        // do not redeclare. The walk must continue through every interface in
+        // AllInterfaces, not stop at the first one that lacks the member.
+        var source = LoadGeneratedSource(typeof(GrandConcreteShapeDto).FullName!);
+        source.Should().Contain("The shape area.");
+    }
+
+    [Fact]
+    public void Facet_ShouldInheritDocs_WhenInterfaceHidesBaseWithNew()
+    {
+        // IFooDerived redeclares Foo with `new` and no docs; IFooBase has the real docs.
+        var source = LoadGeneratedSource(typeof(FooConcreteDto).FullName!);
+        source.Should().Contain("Original foo doc.");
+    }
+
+    [Fact]
+    public void Facet_ShouldResolveInheritdoc_OnSourceMember()
+    {
+        // BarDerived.Bar has only <inheritdoc/>. The DTO doesn't share the source's
+        // hierarchy, so emitting <inheritdoc/> verbatim would leave nothing to inherit
+        // from. The generator must resolve it to the concrete docs on BarBase.Bar.
+        var source = LoadGeneratedSource(typeof(BarDerivedDto).FullName!);
+        source.Should().Contain("The bar value.");
+        source.Should().NotContain("<inheritdoc/>");
+    }
+
+    [Fact]
+    public void Facet_ShouldInheritDocs_ThroughBaseClassToInterface()
+    {
+        // ChildLeaf.Label has no docs, LeafBase.Label has no docs, the docs live on
+        // ILeafService.Label. The walk must traverse base classes and then reach the
+        // interface implemented by the base class.
+        var source = LoadGeneratedSource(typeof(ChildLeafDto).FullName!);
+        source.Should().Contain("Leaf via base interface.");
+    }
+
+    [Fact]
+    public void Facet_ShouldKeepWalking_WhenFirstInterfaceMatchHasInheritdocOnly()
+    {
+        // IEchoDerived redeclares Echo with <inheritdoc/>; IEchoBase has the real docs.
+        // Without the fix, the walk treats <inheritdoc/> as a non-empty doc and stops
+        // at IEchoDerived, dropping the actual summary on IEchoBase.
+        var source = LoadGeneratedSource(typeof(EchoConcreteDto).FullName!);
+        source.Should().Contain("The echo string.");
+    }
+
+    [Fact]
+    public void Facet_ShouldKeepWalking_WhenBaseClassMemberHasInheritdocOnly()
+    {
+        // EchoBaseClass.Ping uses <inheritdoc/>, EchoChild.Ping has no docs, the real
+        // docs live on IPing.Ping. Walking the base class chain must skip past the
+        // <inheritdoc/>-only entry and continue into the interfaces.
+        var source = LoadGeneratedSource(typeof(EchoChildDto).FullName!);
+        source.Should().Contain("Pinged value.");
+    }
+
+    [Fact]
+    public void Facet_ShouldNotResolveInheritdoc_WhenInheritDocsIsFalse()
+    {
+        // BarDerived.Bar has <inheritdoc/>; with InheritDocs=false the generator must
+        // not walk the hierarchy. The DTO ends up with no docs for Bar (the same
+        // outcome as any other undocumented member when InheritDocs is off).
+        var source = LoadGeneratedSource(typeof(BarDerivedNoInheritDto).FullName!);
+        source.Should().NotBeEmpty();
+        source.Should().NotContain("The bar value.");
+        source.Should().NotContain("<inheritdoc/>");
+    }
+
+    [Fact]
+    public void Facet_ShouldInheritTypeLevelDocs_FromBaseClass_WhenInheritDocsIsTrue()
+    {
+        // DocumentedBase has a class-level summary. InheritedDocChild has no summary,
+        // and InheritDocs=true should pull the summary down from the base class.
+        var source = LoadGeneratedSource(typeof(InheritedDocChildDto).FullName!);
+        source.Should().Contain("Documented base type.");
+    }
+
+    [Fact]
+    public void Facet_ShouldInheritTypeLevelDocs_FromInterface_WhenInheritDocsIsTrue()
+    {
+        // The source class has no type-level docs; the implemented interface does.
+        var source = LoadGeneratedSource(typeof(TypedocServiceDto).FullName!);
+        source.Should().Contain("Service contract docs.");
+    }
+
+    [Fact]
+    public void Facet_ShouldNotInheritTypeLevelDocs_WhenInheritDocsIsFalse()
+    {
+        // Same hierarchy as the base-class test, but InheritDocs=false. No type-level
+        // summary should be emitted on the DTO.
+        var source = LoadGeneratedSource(typeof(InheritedDocChildNoInheritDto).FullName!);
+        source.Should().NotBeEmpty();
+        source.Should().NotContain("Documented base type.");
+    }
 }
+
+// ---- Test models ----
+
+public interface IBaseShape
+{
+    /// <summary>The shape area.</summary>
+    double Area { get; }
+}
+
+public interface IDerivedShape : IBaseShape { }
+
+public interface IGrandDerivedShape : IDerivedShape { }
+
+public class GrandConcreteShape : IGrandDerivedShape
+{
+    public double Area => 0.0;
+}
+
+[Facet(typeof(GrandConcreteShape), CopyDocs = true, InheritDocs = true)]
+public partial class GrandConcreteShapeDto { }
+
+public interface IFooBase
+{
+    /// <summary>Original foo doc.</summary>
+    int Foo { get; }
+}
+
+public interface IFooDerived : IFooBase
+{
+    new int Foo { get; }
+}
+
+public class FooConcrete : IFooDerived
+{
+    public int Foo => 0;
+}
+
+[Facet(typeof(FooConcrete), CopyDocs = true, InheritDocs = true)]
+public partial class FooConcreteDto { }
+
+public class BarBase
+{
+    /// <summary>The bar value.</summary>
+    public virtual int Bar { get; set; }
+}
+
+public class BarDerived : BarBase
+{
+    /// <inheritdoc/>
+    public override int Bar { get; set; }
+}
+
+[Facet(typeof(BarDerived), CopyDocs = true, InheritDocs = true)]
+public partial class BarDerivedDto { }
+
+[Facet(typeof(BarDerived), CopyDocs = true, InheritDocs = false)]
+public partial class BarDerivedNoInheritDto { }
+
+public interface ILeafService
+{
+    /// <summary>Leaf via base interface.</summary>
+    string Label { get; }
+}
+
+public class LeafBase : ILeafService
+{
+    public virtual string Label => string.Empty;
+}
+
+public class ChildLeaf : LeafBase
+{
+    public override string Label => string.Empty;
+}
+
+[Facet(typeof(ChildLeaf), CopyDocs = true, InheritDocs = true)]
+public partial class ChildLeafDto { }
+
+public interface IEchoBase
+{
+    /// <summary>The echo string.</summary>
+    string Echo { get; }
+}
+
+public interface IEchoDerived : IEchoBase
+{
+    /// <inheritdoc/>
+    new string Echo { get; }
+}
+
+public class EchoConcrete : IEchoDerived
+{
+    public string Echo => string.Empty;
+}
+
+[Facet(typeof(EchoConcrete), CopyDocs = true, InheritDocs = true)]
+public partial class EchoConcreteDto { }
+
+public interface IPing
+{
+    /// <summary>Pinged value.</summary>
+    string Ping { get; }
+}
+
+public class EchoBaseClass : IPing
+{
+    /// <inheritdoc/>
+    public virtual string Ping => string.Empty;
+}
+
+public class EchoChild : EchoBaseClass
+{
+    public override string Ping => string.Empty;
+}
+
+[Facet(typeof(EchoChild), CopyDocs = true, InheritDocs = true)]
+public partial class EchoChildDto { }
+
+/// <summary>Documented base type.</summary>
+public class DocumentedBase { }
+
+public class InheritedDocChild : DocumentedBase { }
+
+[Facet(typeof(InheritedDocChild), CopyDocs = true, InheritDocs = true)]
+public partial class InheritedDocChildDto { }
+
+[Facet(typeof(InheritedDocChild), CopyDocs = true, InheritDocs = false)]
+public partial class InheritedDocChildNoInheritDto { }
+
+/// <summary>Service contract docs.</summary>
+public interface ITypedocService
+{
+    string Run();
+}
+
+public class TypedocService : ITypedocService
+{
+    public string Run() => string.Empty;
+}
+
+[Facet(typeof(TypedocService), CopyDocs = true, InheritDocs = true)]
+public partial class TypedocServiceDto { }
 
 // Base class whose virtual property has documentation
 public class ProductBase


### PR DESCRIPTION
Ran into a few inheritdocs issues related to actually resolving the inherited values.

Also added inheritDocs handling to the class level itself (Previously was only on members)