### PR TITLE
fix: GenerateToSource=true uses wrong default value for custom struct types

### DIFF
--- a/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/ToSourceGenerator.cs
@@ -172,7 +172,7 @@ internal static class ToSourceGenerator
 
         foreach (var excludedMember in model.ExcludedRequiredMembers)
         {
-            var defaultValue = GeneratorUtilities.GetDefaultValueForType(excludedMember.TypeName);
+            var defaultValue = GeneratorUtilities.GetDefaultValueForType(excludedMember.TypeName, excludedMember.IsValueType);
             propertyAssignments.Add($"            {excludedMember.Name} = {defaultValue}");
         }
 

--- a/src/Facet/Generators/Shared/GeneratorUtilities.cs
+++ b/src/Facet/Generators/Shared/GeneratorUtilities.cs
@@ -260,6 +260,29 @@ internal static class GeneratorUtilities
     }
 
     /// <summary>
+    /// Gets the default value expression for a given type, using semantic type information
+    /// to correctly handle custom value types (structs) that aren't in the known type list.
+    /// </summary>
+    /// <param name="typeName">The fully qualified or simple type name.</param>
+    /// <param name="isValueType">Whether the type is a value type (from semantic analysis).</param>
+    /// <returns>A C# expression string representing the default value.</returns>
+    public static string GetDefaultValueForType(string typeName, bool isValueType)
+    {
+        // Try the standard lookup first (handles well-known types with specific defaults)
+        var result = GetDefaultValueForType(typeName);
+
+        // If the standard lookup returned "null" but we know it's a value type,
+        // use default(T) instead since null is not valid for value types.
+        if (result == "null" && isValueType)
+        {
+            var cleanTypeName = StripGlobalPrefix(typeName);
+            return $"default({cleanTypeName})";
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Gets a default value suitable for parameterless constructor initialization.
     /// Similar to GetDefaultValueForType but with slight variations for constructor contexts.
     /// </summary>

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -404,3 +404,8 @@ public partial class UnitBaseFacet;
        GenerateToSource = true,
        Include = new[] { nameof(UnitEntity.Name), nameof(UnitEntity.ValidationResult) })]
 public partial class UnitMultiSourceInheritedFacet : UnitBaseFacet;
+
+/// <summary>Facet that excludes a struct property (Location) from LocationEntity to test ToSource generates default(T) not null.</summary>
+[Facet(typeof(LocationEntity), nameof(LocationEntity.Location), GenerateToSource = true)]
+public partial class LocationDto;
+

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -497,3 +497,18 @@ public class OrderLineBaseEntity
     public UnitEntity? AssignedToUnit { get; set; }
 }
 
+/// <summary>A custom struct used to test excluded struct properties in ToSource.</summary>
+public struct GeoLocation
+{
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+}
+
+/// <summary>Source class with a required struct property for ToSource struct-default testing.</summary>
+public class LocationEntity
+{
+    public required string Name { get; set; }
+    public required GeoLocation Location { get; set; }
+    public required string Description { get; set; }
+}
+

--- a/test/Facet.Tests/UnitTests/Features/ToSourceRequiredFieldsTests.cs
+++ b/test/Facet.Tests/UnitTests/Features/ToSourceRequiredFieldsTests.cs
@@ -63,4 +63,27 @@ public class ToSourceRequiredFieldsTests
 
         mappedEventLog.Source.Should().Be(string.Empty); // String default value
     }
+
+    [Fact]
+    public void ToSource_ShouldProvideDefaultStruct_ForExcludedRequiredStructFields()
+    {
+        // Arrange
+        var entity = new LocationEntity
+        {
+            Name = "Office",
+            Location = new GeoLocation { Latitude = 51.5, Longitude = -0.1 },
+            Description = "Main office"
+        };
+
+        var dto = entity.ToFacet<LocationEntity, LocationDto>();
+
+        // Act
+        var result = dto.ToSource<LocationEntity>();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be("Office");
+        result.Description.Should().Be("Main office");
+        result.Location.Should().Be(default(GeoLocation)); // Struct default, not null
+    }
 }


### PR DESCRIPTION
When a `required` struct property is excluded from a facet with `GenerateToSource = true`, the generated `ToSource()` method assigns `null` instead of `default(T)`, causing a compilation error.

```csharp
// Generated (broken):
ExcludedStructProp = null  // CS0037: Cannot convert null to 'SomeStruct'

// Expected:
ExcludedStructProp = default(SomeStruct)
```

## Root Cause

`GeneratorUtilities.GetDefaultValueForType(string typeName)` only recognizes built-in value types (int, bool, DateTime, Guid, etc.) by name. Custom structs fall through to the `_ => "null"` default branch because the method has no way to know from the type name alone whether the type is a value type.

## Fix

Added an overload `GetDefaultValueForType(string typeName, bool isValueType)` that leverages the `IsValueType` flag already available on `FacetMember` (populated from Roslyn's semantic analysis). When the base method would return `"null"` but the type is known to be a value type, it returns `default(T)` instead.

closes #367 