### PR TITLE
feat(generate-dtos): add OutputType.PartialClass

### DIFF
--- a/docs/09_GenerateDtosAttribute.md
+++ b/docs/09_GenerateDtosAttribute.md
@@ -58,6 +58,7 @@ public class User
 | `Struct`      | Generate as structs      |
 | `RecordStruct`| Generate as record structs |
 | `Interface`   | Generate as interfaces declaring entity-mapped properties as get-only members. See [Interface Output](#interface-output). |
+| `PartialClass`| Generate as `partial class` (not sealed) with the same properties and constructors as `Class`, but without projections or `ToSource`/`BackTo` — meant to be extended by a hand-written partial. See [Partial Class Output](#partial-class-output). |
 
 ## Interface Output
 
@@ -142,6 +143,127 @@ public sealed record UpdateUserRequest(
 ```
 
 If you instead want the generator to own the DTO outright — including constructors, projections, and mapping — use `OutputType.Class`, `OutputType.Record`, `OutputType.Struct`, or `OutputType.RecordStruct`.
+
+## Partial Class Output
+
+Setting `OutputType = OutputType.PartialClass` emits the DTO as a `public partial class` (not sealed) with get/set properties and the same constructors as `OutputType.Class`, but **without** the `Projection` expression, `ToSource`, or `BackTo` methods. The intent is for callers to extend the DTO with their own hand-written partial in the same project — adding validation attributes, computed members, custom mapping, or extra request-only fields — without giving up the generator-emitted property surface or constructors.
+
+### Usage
+
+```csharp
+[GenerateDtos(Types = DtoTypes.Update, OutputType = OutputType.PartialClass)]
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public bool IsActive { get; set; }
+}
+```
+
+This generates:
+
+```csharp
+[Facet.Facet(typeof(User))]
+public partial class UpdateUserRequest
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = default!;
+    public bool IsActive { get; set; }
+
+    public UpdateUserRequest(User source)
+    {
+        this.Id = source.Id;
+        this.Name = source.Name;
+        this.IsActive = source.IsActive;
+    }
+
+    public UpdateUserRequest() { }
+}
+```
+
+You then add a sibling partial file with whatever the generator can't (or shouldn't) own:
+
+```csharp
+public partial class UpdateUserRequest
+{
+    [Required, MinLength(2)]
+    public string Name { get; set; } = default!; // overrides the generated declaration via the partial
+
+    // Extra non-entity field
+    public string? CorrelationId { get; set; }
+
+    public string DisplayLabel => $"{Id}: {Name}";
+}
+```
+
+### What is (and isn't) emitted
+
+`OutputType.PartialClass` emits:
+
+- A `public partial class` declaration (the `partial` keyword is the only structural difference from `OutputType.Class`)
+- All entity-mapped properties as `public { get; set; }`
+- The source-copy constructor (`new XDto(SourceEntity source)`) — with `[SetsRequiredMembers]` when any property is `required`
+- The parameterless constructor
+- The `[Facet]` attribute
+
+The following are intentionally **not** emitted (in contrast to `OutputType.Class`):
+
+- The `Projection` expression
+- `FromSource` factory
+- `ToSource` / `BackTo` methods
+
+The rationale: a hand-written partial may add members the generator can't see, so a generator-owned mapping would be incomplete. Callers who want full mapping should use `OutputType.Class` instead; callers who want extensibility own the mapping themselves.
+
+### Not sealed
+
+`OutputType.PartialClass` deliberately does not seal the emitted class so it can serve as a shared base for hand-written derived types — useful when several DTOs share most of an entity's shape but differ in a few fields (e.g. `GlobalSoftware` / `LocalSoftware` extending a generated `SoftwareDto`).
+
+### Composing with `OutputType.Interface`
+
+When the same entity carries **both** an `OutputType.Interface` attribute and an `OutputType.PartialClass` attribute with overlapping `DtoTypes`, the partial class declares the matching generated interface as a base — pairing the two outputs into a contract + implementation set automatically.
+
+```csharp
+[GenerateDtos(Types = DtoTypes.Update, OutputType = OutputType.Interface)]
+[GenerateDtos(Types = DtoTypes.Update, OutputType = OutputType.PartialClass)]
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+```
+
+Generates:
+
+```csharp
+public interface IUpdateUserRequest
+{
+    int Id { get; }
+    string Name { get; }
+}
+
+public partial class UpdateUserRequest : IUpdateUserRequest
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = default!;
+    // ... constructors as above
+}
+```
+
+The match requires equal `Prefix`, `Suffix`, and `Namespace` between the two attributes. Bits in `DtoTypes` that aren't shared are not coupled — e.g. an Interface attribute covering `Create | Update` paired with a PartialClass attribute covering `Update | Response` produces an `IUpdateUserRequest` interface and partial class only for `Update`; `Create` is interface-only and `Response` is a plain (unimplemented) partial.
+
+### Patch DTOs
+
+`DtoTypes.Patch` is generated normally under `OutputType.PartialClass` — the patch DTO is emitted as `partial class` with its `ApplyTo` method, and a hand-written partial can extend it like any other DTO type.
+
+### When to use it
+
+Pick `OutputType.PartialClass` when:
+
+- You want the generator to own the property surface and constructors, but reserve the right to extend them.
+- You want a shared, unsealed base for several derived DTOs.
+- You want to layer hand-written validation attributes or computed members onto a generated DTO without forking the generator's output.
+
+If you don't need extensibility, prefer `OutputType.Class` — it also emits `Projection`, `ToSource`, and `BackTo` for full round-tripping.
 
 ## Excluding Audit Fields
 

--- a/src/Facet.Attributes/GenerateDtosAttribute.cs
+++ b/src/Facet.Attributes/GenerateDtosAttribute.cs
@@ -36,7 +36,19 @@ public enum OutputType
     /// Constructors, projections, and ToSource methods are not emitted on interface output.
     /// Not supported for Patch DTOs (their ApplyTo method requires a concrete implementation).
     /// </summary>
-    Interface = 4
+    Interface = 4,
+    /// <summary>
+    /// Generates a <c>partial class</c> (not sealed) with get/set properties and the same constructors
+    /// as <see cref="Class"/>, but without projection, <c>ToSource</c>, or <c>BackTo</c> methods.
+    /// Designed to be extended by a hand-written partial file in the same project — that is where
+    /// callers add validation attributes, computed members, custom constructors, or mapping logic.
+    /// When a sibling <c>[GenerateDtos]</c> attribute on the same type uses
+    /// <see cref="Interface"/> for the matching DTO type, the generated partial class also declares
+    /// the matching generated interface as a base (e.g. <c>: ICreateUserRequest</c>) so the two
+    /// outputs compose into a contract + implementation pair.
+    /// Not supported for Patch DTOs (their <c>ApplyTo</c> method already lives on a concrete type).
+    /// </summary>
+    PartialClass = 5
 }
 
 /// <summary>

--- a/src/Facet/GenerateDtosTargetModel.cs
+++ b/src/Facet/GenerateDtosTargetModel.cs
@@ -20,6 +20,14 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
     public ImmutableArray<string> ExcludeProperties { get; }
     public ImmutableArray<FacetMember> Members { get; }
     public bool UseFullName { get; }
+    /// <summary>
+    /// The set of DTO type bits for which a sibling <see cref="OutputType.Interface"/> attribute on the
+    /// same source type generates a matching interface (same Prefix/Suffix/Namespace, overlapping
+    /// <see cref="DtoTypes"/>). Only meaningful for <see cref="OutputType.PartialClass"/> models;
+    /// lets the generator declare <c>: I{Name}</c> on the partial class so the two outputs compose
+    /// into a contract + implementation pair.
+    /// </summary>
+    public DtoTypes SiblingInterfaceTypes { get; }
 
     public GenerateDtosTargetModel(
         string sourceTypeName,
@@ -35,7 +43,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
         string? convertEnumsTo,
         ImmutableArray<string> excludeProperties,
         ImmutableArray<FacetMember> members,
-        bool useFullName)
+        bool useFullName,
+        DtoTypes siblingInterfaceTypes = DtoTypes.None)
     {
         SourceTypeName = sourceTypeName;
         SourceNamespace = sourceNamespace;
@@ -51,6 +60,7 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
         ExcludeProperties = excludeProperties;
         Members = members;
         UseFullName = useFullName;
+        SiblingInterfaceTypes = siblingInterfaceTypes;
     }
 
     public bool Equals(GenerateDtosTargetModel? other)
@@ -71,7 +81,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             && ConvertEnumsTo == other.ConvertEnumsTo
             && ExcludeProperties.SequenceEqual(other.ExcludeProperties)
             && Members.SequenceEqual(other.Members)
-            && UseFullName == other.UseFullName;
+            && UseFullName == other.UseFullName
+            && SiblingInterfaceTypes == other.SiblingInterfaceTypes;
     }
 
     public override bool Equals(object? obj) => obj is GenerateDtosTargetModel other && Equals(other);
@@ -93,6 +104,7 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             hash = hash * 31 + GenerateProjections.GetHashCode();
             hash = hash * 31 + (ConvertEnumsTo?.GetHashCode() ?? 0);
             hash = hash * 31 + UseFullName.GetHashCode();
+            hash = hash * 31 + SiblingInterfaceTypes.GetHashCode();
 
             foreach (var prop in ExcludeProperties)
                 hash = hash * 31 + prop.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
@@ -109,7 +109,54 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             }
         }
 
-        return models.Count > 0 ? models : null;
+        if (models.Count == 0) return null;
+
+        // Resolve sibling interface composition: a PartialClass output should declare a base of
+        // `: I{Name}` for any DTO type that ALSO has a matching Interface attribute on the same source
+        // (same Prefix/Suffix/Namespace, overlapping DtoTypes). This pairs the two outputs into a
+        // contract + implementation without the user having to wire it up by hand.
+        var interfaceModels = models.Where(m => m.OutputType == OutputType.Interface).ToList();
+        if (interfaceModels.Count == 0)
+        {
+            return models;
+        }
+
+        for (int i = 0; i < models.Count; i++)
+        {
+            var model = models[i];
+            if (model.OutputType != OutputType.PartialClass) continue;
+
+            DtoTypes siblingMask = DtoTypes.None;
+            foreach (var iface in interfaceModels)
+            {
+                if (iface.Prefix != model.Prefix) continue;
+                if (iface.Suffix != model.Suffix) continue;
+                if (iface.TargetNamespace != model.TargetNamespace) continue;
+
+                siblingMask |= iface.Types & model.Types;
+            }
+
+            if (siblingMask == DtoTypes.None) continue;
+
+            models[i] = new GenerateDtosTargetModel(
+                model.SourceTypeName,
+                model.SourceNamespace,
+                model.TargetNamespace,
+                model.Types,
+                model.OutputType,
+                model.Prefix,
+                model.Suffix,
+                model.IncludeFields,
+                model.GenerateConstructors,
+                model.GenerateProjections,
+                model.ConvertEnumsTo,
+                model.ExcludeProperties,
+                model.Members,
+                model.UseFullName,
+                siblingMask);
+        }
+
+        return models;
     }
 
     private static GenerateDtosTargetModel? GetDtosModel(GeneratorAttributeSyntaxContext context, AttributeData attribute, INamedTypeSymbol sourceSymbol, bool forceExcludeAuditFields, CancellationToken token)
@@ -239,7 +286,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         {
             var createMembers = FilterMembers(model.Members, model.ExcludeProperties, IdFieldPatterns);
             var createDtoName = interfaceLeader + BuildDtoName(sourceTypeName, "Create", "Request", model.Prefix, model.Suffix);
-            var createCode = GenerateDtoCode(model, createDtoName, createMembers, "Create");
+            var createCode = GenerateDtoCode(model, createDtoName, createMembers, "Create", DtoTypes.Create);
             context.AddSource($"{GenerateFileDtoFullName(model, createDtoName)}", SourceText.From(createCode, Encoding.UTF8));
         }
 
@@ -248,7 +295,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         {
             var updateMembers = FilterMembers(model.Members, model.ExcludeProperties);
             var updateDtoName = interfaceLeader + BuildDtoName(sourceTypeName, "Update", "Request", model.Prefix, model.Suffix);
-            var updateCode = GenerateDtoCode(model, updateDtoName, updateMembers, "Update");
+            var updateCode = GenerateDtoCode(model, updateDtoName, updateMembers, "Update", DtoTypes.Update);
             context.AddSource($"{GenerateFileDtoFullName(model, updateDtoName)}", SourceText.From(updateCode, Encoding.UTF8));
         }
 
@@ -257,7 +304,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         {
             var upsertMembers = FilterMembers(model.Members, model.ExcludeProperties);
             var upsertDtoName = interfaceLeader + BuildDtoName(sourceTypeName, "Upsert", "Request", model.Prefix, model.Suffix);
-            var upsertCode = GenerateDtoCode(model, upsertDtoName, upsertMembers, "Upsert");
+            var upsertCode = GenerateDtoCode(model, upsertDtoName, upsertMembers, "Upsert", DtoTypes.Upsert);
             context.AddSource($"{GenerateFileDtoFullName(model, upsertDtoName)}", SourceText.From(upsertCode, Encoding.UTF8));
         }
 
@@ -266,7 +313,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         {
             var responseMembers = FilterMembers(model.Members, model.ExcludeProperties);
             var responseDtoName = interfaceLeader + BuildDtoName(sourceTypeName, "", "Response", model.Prefix, model.Suffix);
-            var responseCode = GenerateDtoCode(model, responseDtoName, responseMembers, "Response");
+            var responseCode = GenerateDtoCode(model, responseDtoName, responseMembers, "Response", DtoTypes.Response);
             context.AddSource($"{GenerateFileDtoFullName(model, responseDtoName)}", SourceText.From(responseCode, Encoding.UTF8));
         }
 
@@ -279,7 +326,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
 
             var queryDtoName = interfaceLeader + BuildDtoName(sourceTypeName, "", "Query", model.Prefix, model.Suffix);
 
-            var queryCode = GenerateDtoCode(model, queryDtoName, queryMembers, "Query");
+            var queryCode = GenerateDtoCode(model, queryDtoName, queryMembers, "Query", DtoTypes.Query);
             context.AddSource($"{GenerateFileDtoFullName(model, queryDtoName)}", SourceText.From(queryCode, Encoding.UTF8));
         }
 
@@ -358,17 +405,18 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         return members.Where(m => !exclusions.Contains(m.Name)).ToImmutableArray();
     }
 
-    private static string GenerateDtoCode(GenerateDtosTargetModel model, string dtoName, ImmutableArray<FacetMember> members, string purpose)
+    private static string GenerateDtoCode(GenerateDtosTargetModel model, string dtoName, ImmutableArray<FacetMember> members, string purpose, DtoTypes dtoType)
     {
         var sb = new StringBuilder();
         var sourceTypeName = GetSimpleTypeName(model.SourceTypeName);
         var isInterface = model.OutputType == OutputType.Interface;
+        var isPartialClass = model.OutputType == OutputType.PartialClass;
         var hasInitOnlyProperties = members.Any(m => m.IsInitOnly);
         var hasReadOnlyFields = members.Any(m => m.IsReadOnly);
 
         // Generate file structure
         GenerateDtoFileHeader(sb, model);
-        GenerateDtoTypeDeclaration(sb, model, dtoName, sourceTypeName, purpose);
+        GenerateDtoTypeDeclaration(sb, model, dtoName, sourceTypeName, purpose, dtoType);
 
         // Generate members
         GenerateDtoMembers(sb, model, members);
@@ -382,13 +430,19 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
                 GenerateDtoConstructors(sb, model, dtoName, sourceTypeName, members, hasInitOnlyProperties, hasReadOnlyFields);
             }
 
-            if (model.GenerateProjections)
+            // PartialClass is meant to be extended by a hand-written partial — the user owns mapping
+            // (and may need to map into hand-added members the generator can't see), so we skip
+            // Projection / ToSource / BackTo. The all-args ctor and parameterless ctor are still emitted.
+            if (!isPartialClass)
             {
-                GenerateDtoProjection(sb, model, dtoName, sourceTypeName, members, hasInitOnlyProperties, hasReadOnlyFields);
-            }
+                if (model.GenerateProjections)
+                {
+                    GenerateDtoProjection(sb, model, dtoName, sourceTypeName, members, hasInitOnlyProperties, hasReadOnlyFields);
+                }
 
-            GenerateDtoToSource(sb, model, dtoName, sourceTypeName, members);
-            GenerateDtoBackTo(sb, model, dtoName, sourceTypeName);
+                GenerateDtoToSource(sb, model, dtoName, sourceTypeName, members);
+                GenerateDtoBackTo(sb, model, dtoName, sourceTypeName);
+            }
         }
 
         sb.AppendLine("}");
@@ -419,7 +473,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         }
     }
 
-    private static void GenerateDtoTypeDeclaration(StringBuilder sb, GenerateDtosTargetModel model, string dtoName, string sourceTypeName, string purpose)
+    private static void GenerateDtoTypeDeclaration(StringBuilder sb, GenerateDtosTargetModel model, string dtoName, string sourceTypeName, string purpose, DtoTypes dtoType)
     {
         var keyword = model.OutputType switch
         {
@@ -428,6 +482,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             OutputType.RecordStruct => "record struct",
             OutputType.Struct => "struct",
             OutputType.Interface => "interface",
+            OutputType.PartialClass => "partial class",
             _ => "record"
         };
 
@@ -450,7 +505,16 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             }
         }
 
-        sb.AppendLine($"public {keyword} {dtoName}");
+        // For PartialClass output, declare the matching generated interface as a base type when a
+        // sibling Interface attribute on the same source covers this DTO type. The interface name
+        // mirrors the partial class name with an `I` leader (e.g. `ICreateUserRequest`).
+        var baseList = "";
+        if (model.OutputType == OutputType.PartialClass && (model.SiblingInterfaceTypes & dtoType) != 0)
+        {
+            baseList = $" : I{dtoName}";
+        }
+
+        sb.AppendLine($"public {keyword} {dtoName}{baseList}");
         sb.AppendLine("{");
     }
 
@@ -761,6 +825,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             OutputType.Record => "record",
             OutputType.RecordStruct => "record struct",
             OutputType.Struct => "struct",
+            OutputType.PartialClass => "partial class",
             _ => "record"
         };
 

--- a/test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs
+++ b/test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs
@@ -160,3 +160,40 @@ public class TestInterfaceEntity
     public string? Description { get; set; }
     public bool IsActive { get; set; }
 }
+
+// PartialClass output: emits CreateTestPartialClassEntityRequest / UpdateTestPartialClassEntityRequest /
+// TestPartialClassEntityResponse as `public partial class` (not sealed) with get/set properties and the
+// same constructors as OutputType.Class — but without projection/ToSource/BackTo. The hand-written
+// partial below adds an extra computed property to prove the partial keyword survived generation.
+[GenerateDtos(Types = DtoTypes.Create | DtoTypes.Update | DtoTypes.Response, OutputType = OutputType.PartialClass)]
+public class TestPartialClassEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool IsActive { get; set; }
+}
+
+// Hand-written partial extension — fails to compile if the generated DTOs are NOT emitted as `partial class`.
+public partial class UpdateTestPartialClassEntityRequest
+{
+    public string DisplayLabel => $"{Id}: {Name}";
+}
+
+// Both Interface and PartialClass on the same entity: the PartialClass output should declare the
+// matching generated interface as a base type, composing into a contract + implementation pair.
+[GenerateDtos(Types = DtoTypes.Create | DtoTypes.Update | DtoTypes.Response, OutputType = OutputType.Interface)]
+[GenerateDtos(Types = DtoTypes.Create | DtoTypes.Update | DtoTypes.Response, OutputType = OutputType.PartialClass)]
+public class TestPartialAndInterfaceEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+}
+
+// PartialClass intentionally NOT sealed: a hand-written derived type should compile.
+// This exercises the GlobalSoftware/LocalSoftware-style inheritance scenario.
+public class DerivedFromGeneratedPartial : UpdateTestPartialClassEntityRequest
+{
+    public string DerivedOnly { get; set; } = string.Empty;
+}

--- a/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPartialClassTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPartialClassTests.cs
@@ -1,0 +1,180 @@
+using Facet.Tests.TestModels;
+using System.Reflection;
+
+namespace Facet.Tests.UnitTests.Core.GenerateDtos;
+
+/// <summary>
+/// Tests for <see cref="OutputType.PartialClass"/> output kind on <c>[GenerateDtos]</c>.
+/// </summary>
+public class GenerateDtosPartialClassTests
+{
+    private static readonly Assembly TestAssembly = Assembly.GetAssembly(typeof(TestPartialClassEntity))!;
+
+    [Fact]
+    public void PartialClass_CreateDto_IsEmittedAsClass()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.CreateTestPartialClassEntityRequest");
+
+        type.Should().NotBeNull("PartialClass-output Create DTO should be emitted");
+        type!.IsClass.Should().BeTrue("the generated type should be a class");
+        type.IsInterface.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PartialClass_UpdateDto_IsEmittedAsClass()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialClassEntityRequest");
+
+        type.Should().NotBeNull("PartialClass-output Update DTO should be emitted");
+        type!.IsClass.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PartialClass_ResponseDto_IsEmittedAsClass()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.TestPartialClassEntityResponse");
+
+        type.Should().NotBeNull("PartialClass-output Response DTO should be emitted");
+        type!.IsClass.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PartialClass_CreateDto_ExcludesId()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.CreateTestPartialClassEntityRequest");
+        type.Should().NotBeNull();
+        type!.GetProperty("Id").Should().BeNull("Create DTOs should exclude Id by default");
+    }
+
+    [Fact]
+    public void PartialClass_UpdateDto_IncludesId()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialClassEntityRequest");
+        type.Should().NotBeNull();
+        type!.GetProperty("Id").Should().NotBeNull("Update DTOs should include Id for identification");
+    }
+
+    [Fact]
+    public void PartialClass_PropertiesAreGetSet()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialClassEntityRequest");
+        type.Should().NotBeNull();
+
+        // The generator-emitted properties (Id/Name/Description/IsActive) must be get/set, distinguishing
+        // PartialClass from the Interface output (which is get-only). DisplayLabel comes from a hand-written
+        // partial and is intentionally get-only — skip it.
+        var generatedProps = new[] { "Id", "Name", "Description", "IsActive" };
+        foreach (var name in generatedProps)
+        {
+            var prop = type!.GetProperty(name);
+            prop.Should().NotBeNull($"{name} should be present on the generated DTO");
+            prop!.GetGetMethod().Should().NotBeNull($"{name} should have a getter");
+            prop.GetSetMethod().Should().NotBeNull($"{name} should have a public setter (PartialClass mirrors Class)");
+        }
+    }
+
+    [Fact]
+    public void PartialClass_IsNotSealed()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialClassEntityRequest");
+        type.Should().NotBeNull();
+        type!.IsSealed.Should().BeFalse("PartialClass output must not seal so callers can derive from it");
+    }
+
+    [Fact]
+    public void PartialClass_HasAllArgsAndParameterlessConstructors()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialClassEntityRequest");
+        type.Should().NotBeNull();
+
+        // Parameterless constructor
+        type!.GetConstructor(Type.EmptyTypes).Should().NotBeNull("PartialClass should emit a parameterless constructor");
+
+        // Source-copy constructor: ctor(TestPartialClassEntity source)
+        var sourceCtor = type.GetConstructor(new[] { typeof(TestPartialClassEntity) });
+        sourceCtor.Should().NotBeNull("PartialClass should emit a constructor taking the source type");
+    }
+
+    [Fact]
+    public void PartialClass_DoesNotEmitProjectionOrToSource()
+    {
+        var type = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialClassEntityRequest");
+        type.Should().NotBeNull();
+
+        // PartialClass intentionally omits projection / ToSource / BackTo — the user owns mapping in their
+        // hand-written partial. (The DisplayLabel partial below adds a member but not these helpers.)
+        type!.GetMember("Projection").Should().BeEmpty();
+        type.GetMember("FromSource").Should().BeEmpty();
+        type.GetMember("ToSource").Should().BeEmpty();
+        type.GetMember("BackTo").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PartialClass_CanBeExtendedWithHandWrittenPartial()
+    {
+        // The hand-written `public partial class UpdateTestPartialClassEntityRequest { public string DisplayLabel ... }`
+        // in TestModels can only compile if the generator emitted the class with the `partial` keyword.
+        var dto = new UpdateTestPartialClassEntityRequest { Id = 7, Name = "Widget" };
+        dto.DisplayLabel.Should().Be("7: Widget");
+    }
+
+    [Fact]
+    public void PartialClass_CanBeDerivedFrom()
+    {
+        // Sanity check that the generated class isn't sealed — exercises the GlobalSoftware/LocalSoftware
+        // inheritance scenario the PartialClass output is designed to support.
+        var derived = new DerivedFromGeneratedPartial { Id = 1, Name = "x", DerivedOnly = "y" };
+        derived.Should().BeAssignableTo<UpdateTestPartialClassEntityRequest>();
+    }
+
+    [Fact]
+    public void PartialClass_ConstructorCopiesFromSource()
+    {
+        var source = new TestPartialClassEntity
+        {
+            Id = 42,
+            Name = "From Source",
+            Description = "Desc",
+            IsActive = true
+        };
+
+        var dto = new UpdateTestPartialClassEntityRequest(source);
+
+        dto.Id.Should().Be(42);
+        dto.Name.Should().Be("From Source");
+        dto.Description.Should().Be("Desc");
+        dto.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PartialClass_WithSiblingInterface_ImplementsGeneratedInterface()
+    {
+        // When both OutputType.Interface and OutputType.PartialClass are configured on the same source
+        // entity (with matching DtoTypes), the PartialClass output should declare the matching generated
+        // interface as a base type — composing into a contract + implementation pair.
+        var partialType = TestAssembly.GetType("Facet.Tests.TestModels.UpdateTestPartialAndInterfaceEntityRequest");
+        var interfaceType = TestAssembly.GetType("Facet.Tests.TestModels.IUpdateTestPartialAndInterfaceEntityRequest");
+
+        partialType.Should().NotBeNull();
+        interfaceType.Should().NotBeNull();
+        interfaceType!.IsInterface.Should().BeTrue();
+
+        partialType!.GetInterfaces().Should().Contain(interfaceType, "PartialClass should implement the sibling generated interface");
+    }
+
+    [Fact]
+    public void PartialClass_WithoutSiblingInterface_DoesNotImplementUnrelatedInterface()
+    {
+        // The TestPartialClassEntity declares ONLY a PartialClass attribute (no sibling Interface attribute).
+        // The matching ICreateTestPartialClassEntityRequest interface must NOT exist, and the partial
+        // class must not declare any generated interface base.
+        var partialType = TestAssembly.GetType("Facet.Tests.TestModels.CreateTestPartialClassEntityRequest");
+        var stranglerInterface = TestAssembly.GetType("Facet.Tests.TestModels.ICreateTestPartialClassEntityRequest");
+
+        partialType.Should().NotBeNull();
+        stranglerInterface.Should().BeNull("Interface output was not requested, so no I-prefixed type should be generated");
+
+        // Only system-provided interfaces (none expected) — no generated ones.
+        partialType!.GetInterfaces().Where(i => i.Namespace == "Facet.Tests.TestModels").Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `OutputType.PartialClass` as a new value on the `OutputType` enum consumed by `[GenerateDtos]`.

The new output kind emits each DTO as `public partial class XDto` (not sealed), with the same properties and constructors as `OutputType.Class`, but **without** `Projection`, `ToSource`, or `BackTo` — making it safe to extend with a hand-written partial in the same project. Callers add validation attributes, computed members, custom mapping, or extra request-only fields on the hand-written side without giving up the generator-emitted property surface or constructors.

This follows the same shape as #378 (`OutputType.Interface`), but produces a concrete extensible implementation rather than a contract.

## Behavior

- Emits `public partial class XDto` (the `partial` keyword is the only structural difference from `OutputType.Class`).
- Entity-mapped properties emit as `public { get; set; }`.
- Generates the all-args constructor (`new XDto(SourceEntity source)`) — with `[SetsRequiredMembers]` when any property is `required`.
- Generates the parameterless constructor.
- Emits the `[Facet]` attribute.
- Does **not** emit `Projection`, `FromSource`, `ToSource`, or `BackTo` — a hand-written partial may add members the generator can't see, so a generator-owned mapping would be incomplete. Callers wanting full mapping should use `OutputType.Class` instead.
- Class is intentionally not sealed so it can serve as a shared base for hand-written derived types (e.g. `GlobalSoftware` / `LocalSoftware` extending a generated base).

### Composition with `OutputType.Interface`

When the same entity carries both an `OutputType.Interface` attribute and an `OutputType.PartialClass` attribute with overlapping `DtoTypes` (and equal `Prefix` / `Suffix` / `Namespace`), the partial class declares the matching generated interface as a base — pairing the two outputs into a contract + implementation set automatically:

```csharp
[GenerateDtos(Types = DtoTypes.Update, OutputType = OutputType.Interface)]
[GenerateDtos(Types = DtoTypes.Update, OutputType = OutputType.PartialClass)]
public class User { public int Id { get; set; } public string Name { get; set; } }

// Generated:
public interface IUpdateUserRequest { int Id { get; } string Name { get; } }
public partial class UpdateUserRequest : IUpdateUserRequest { /* ... */ }
```

The match requires equal `Prefix`, `Suffix`, and `Namespace`; unshared `DtoTypes` bits aren't coupled.

### Patch DTOs

`DtoTypes.Patch` is generated normally under `OutputType.PartialClass` — emitted as `partial class XPatch` with its `ApplyTo` method. A hand-written partial can extend it like any other DTO type.

## Changes

- `src/Facet.Attributes/GenerateDtosAttribute.cs` — adds `PartialClass = 5` to `OutputType` with XML docs.
- `src/Facet/GenerateDtosTargetModel.cs` — adds `SiblingInterfaceTypes` flag for cross-attribute composition.
- `src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs` — handles the new keyword, skips `Projection`/`ToSource`/`BackTo` for `PartialClass`, computes the sibling-interface mask after parsing all attributes on a source type, and emits `: I{name}` on the partial class declaration when a matching interface exists.
- `docs/09_GenerateDtosAttribute.md` — adds the `PartialClass` row to the `OutputType` table and a full "Partial Class Output" section with examples.
- `test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs` — adds `TestPartialClassEntity`, a hand-written partial, a derived type, and `TestPartialAndInterfaceEntity` exercising composition.
- `test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPartialClassTests.cs` — 14 reflection-based tests mirroring the Interface test suite plus the composition + inheritance cases.

## Test plan

- [x] `dotnet test test/Facet.Tests/Facet.Tests.csproj` — 858 / 858 passing locally, including 14 new `GenerateDtosPartialClassTests`.
- [x] Hand-written `partial class UpdateTestPartialClassEntityRequest` in `TestModels` exists alongside the generated type — proves the `partial` keyword landed (compilation fails otherwise).
- [x] `DerivedFromGeneratedPartial : UpdateTestPartialClassEntityRequest` compiles — proves the type is not sealed.
- [x] `TestPartialAndInterfaceEntity` carries both attributes and produces a `partial class : I…` declaration — proves the sibling composition logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)