### PR TITLE
feat: SetAccessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Facet are documented in this file.
 
 ### Added
 
-- No unreleased entries yet.
+- Added `SetAccessor` parameter to `[Facet]` with `PropertySetAccessor` enum (`Preserve` / `Set` / `Init`) to override the set accessor emitted on all generated properties (#381). Supports the immutable builder pattern: one mutable facet for building, one init-only facet as the frozen read model.
 
 ## [6.6.3] - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Instead of manually creating each facet, **Facet** auto-generates them from a si
 - **`CollectionTargetType`** - remap source collection types (e.g. `Collection<T>`) to `List<T>` or any target collection type globally per facet; per-property via `[MapFrom(..., AsCollection = typeof(List<>))]`
 - **`GenerateCopyConstructor`** - generate a copy constructor for cloning and MVVM scenarios
 - **`GenerateEquality`** - generate value-based `Equals`, `GetHashCode`, `==`, `!=` for class DTOs
+- **`SetAccessor`** - force `{ get; init; }` or `{ get; set; }` on all generated properties for immutable / mutable variants
 
 ### Advanced Features
 - **Multi-source mapping** — a single target class can carry multiple `[Facet]` attributes, each mapping from a different source type; produces per-source constructors, projections (`ProjectionFrom{Source}`), and reverse-mapping methods (`To{Source}()`)
@@ -748,6 +749,44 @@ var original = new UserDto(user);
 var copy = new UserDto(original);
 original == copy; // true — same values, different instances
 ```
+
+</details>
+
+<details>
+  <summary>Set Accessor Override (SetAccessor)</summary>
+
+Force `{ get; init; }` or `{ get; set; }` on every generated property with a single attribute parameter.
+
+| Value | Accessor | Use case |
+|---|---|---|
+| `Preserve` *(default)* | Matches source | Normal DTOs |
+| `Init` | `{ get; init; }` | Immutable read models |
+| `Set` | `{ get; set; }` | Mutable versions of init-only types |
+
+```csharp
+public class Order
+{
+    public int Id { get; set; }
+    public string Reference { get; set; } = string.Empty;
+    public decimal Total { get; set; }
+}
+
+// Mutable builder
+[Facet(typeof(Order))]
+public partial class OrderBuilder;
+
+// Immutable snapshot — all { get; init; }
+[Facet(typeof(Order), SetAccessor = PropertySetAccessor.Init)]
+public partial class ImmutableOrder;
+```
+
+```csharp
+var builder = new OrderBuilder { Reference = "ORD-001", Total = 99.99m };
+var order = new ImmutableOrder(builder.ToSource());
+// order.Reference = "x"; // compile error — init-only
+```
+
+See [Set Accessor Override](docs/03_AttributeReference.md#set-accessor-override) for full docs.
 
 </details>
 

--- a/docs/03_AttributeReference.md
+++ b/docs/03_AttributeReference.md
@@ -46,6 +46,7 @@ public partial class MyFacet { }
 | `CollectionTargetType`         | `Type?`   | Overrides the collection type used for **all** mapped collection properties on this facet. Use an open generic type such as `typeof(List<>)` to remap source collections (e.g. `Collection<T>` from EF Core entities) to a different target type. See [Collection Type Mapping](#collection-type-mapping) below. |
 | `GenerateCopyConstructor`      | `bool`    | Generate a copy constructor that accepts another instance of the same facet type and copies all member values (default: false). See [Copy Constructor](#copy-constructor) below. |
 | `GenerateEquality`             | `bool`    | Generate value-based equality members (`Equals`, `GetHashCode`, `==`, `!=`) and implement `IEquatable<T>` (default: false). Ignored for records. See [Equality Generation](#equality-generation) below. |
+| `SetAccessor`                  | `PropertySetAccessor` | Override the set accessor emitted on all generated properties. `Preserve` (default) keeps the source accessor; `Set` forces `{ get; set; }`; `Init` forces `{ get; init; }`. See [Set Accessor Override](#set-accessor-override) below. |
 
 ## Include vs Exclude
 
@@ -944,6 +945,88 @@ public partial class UnitDto { }
 // facet.Items is List<UnitItemDto>
 // facet.ToSource().Items is Collection<UnitItemEntity> , original source type restored
 ```
+
+---
+
+## Set Accessor Override
+
+The `SetAccessor` parameter controls which set accessor is emitted on **every** generated property, overriding the default behaviour.
+
+| Value | Generated accessor | When to use |
+|---|---|---|
+| `PropertySetAccessor.Preserve` *(default)* | Same as the source property | Usual DTO/projection work |
+| `PropertySetAccessor.Set` | `{ get; set; }` | Force mutability even when source uses `init` |
+| `PropertySetAccessor.Init` | `{ get; init; }` | Immutable DTOs — all properties settable only during construction |
+
+### Basic Usage
+
+```csharp
+// All generated properties use { get; init; }
+[Facet(typeof(Foo), SetAccessor = PropertySetAccessor.Init)]
+public partial class ImmutableFoo;
+
+// All generated properties use { get; set; }
+[Facet(typeof(Foo), SetAccessor = PropertySetAccessor.Set)]
+public partial class MutableFoo;
+```
+
+### Builder Pattern Example
+
+`SetAccessor` is ideal for a **mutable builder → immutable read model** workflow:
+
+```csharp
+public class Order
+{
+    public int Id { get; set; }
+    public string Reference { get; set; } = string.Empty;
+    public decimal Total { get; set; }
+}
+
+// Mutable version — build up the object in multiple steps
+[Facet(typeof(Order))]
+public partial class OrderBuilder;
+
+// Immutable version, locked down after construction
+[Facet(typeof(Order), SetAccessor = PropertySetAccessor.Init)]
+public partial class ImmutableOrder;
+```
+
+```csharp
+// Build
+var builder = new OrderBuilder();
+builder.Reference = "ORD-001";
+builder.Total = 99.99m;
+
+// Freeze into an immutable snapshot
+var order = new ImmutableOrder(builder.ToSource());
+// order.Reference = "x"; // <- compile error: init-only
+```
+
+### Generated Code
+
+```csharp
+// Source
+public class Foo
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+
+// SetAccessor = PropertySetAccessor.Init
+public partial class ImmutableFoo
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = default!;
+}
+```
+
+### Interaction with `PreserveInitOnlyProperties`
+
+`SetAccessor` takes full precedence:
+
+- `SetAccessor = Init` > all properties get `init`, regardless of source or `PreserveInitOnlyProperties`
+- `SetAccessor = Set` > all properties get `set`, even if `PreserveInitOnlyProperties = true`
+- `SetAccessor = Preserve` (default) > falls back to the normal `PreserveInitOnlyProperties` logic
 
 ---
 

--- a/src/Facet.Attributes/FacetAttribute.cs
+++ b/src/Facet.Attributes/FacetAttribute.cs
@@ -467,6 +467,23 @@ public sealed class FacetAttribute : Attribute
     public bool GenerateEquality { get; set; } = false;
 
     /// <summary>
+    /// Controls the set accessor emitted on all generated properties.
+    /// <list type="bullet">
+    ///   <item><description><see cref="PropertySetAccessor.Preserve"/> (default) — keeps the source accessor: <c>set</c> stays <c>set</c>, <c>init</c> stays <c>init</c>.</description></item>
+    ///   <item><description><see cref="PropertySetAccessor.Set"/> — forces <c>{ get; set; }</c> on every generated property.</description></item>
+    ///   <item><description><see cref="PropertySetAccessor.Init"/> — forces <c>{ get; init; }</c> on every generated property, producing an immutable facet.</description></item>
+    /// </list>
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Immutable DTO — all properties use { get; init; }
+    /// [Facet(typeof(Foo), SetAccessor = PropertySetAccessor.Init)]
+    /// public partial class ImmutableFoo;
+    /// </code>
+    /// </example>
+    public PropertySetAccessor SetAccessor { get; set; } = PropertySetAccessor.Preserve;
+
+    /// <summary>
     /// Creates a new FacetAttribute that targets a given source type and excludes specified members.
     /// </summary>
     /// <param name="sourceType">The type to generate from.</param>

--- a/src/Facet.Attributes/PropertySetAccessor.cs
+++ b/src/Facet.Attributes/PropertySetAccessor.cs
@@ -1,0 +1,25 @@
+namespace Facet;
+
+/// <summary>
+/// Controls the set accessor emitted on all generated properties of a facet.
+/// </summary>
+public enum PropertySetAccessor
+{
+    /// <summary>
+    /// Preserve the source property's accessor (default).
+    /// A <c>set</c> source property stays <c>set</c>; an <c>init</c> source property stays <c>init</c>.
+    /// </summary>
+    Preserve = 0,
+
+    /// <summary>
+    /// Force all generated properties to use <c>{ get; set; }</c>.
+    /// Useful for making an otherwise init-only type fully mutable.
+    /// </summary>
+    Set = 1,
+
+    /// <summary>
+    /// Force all generated properties to use <c>{ get; init; }</c>.
+    /// Useful for building immutable DTOs that support object-initializer syntax.
+    /// </summary>
+    Init = 2,
+}

--- a/src/Facet.Attributes/README.md
+++ b/src/Facet.Attributes/README.md
@@ -23,6 +23,10 @@ You should **not** need to install `Facet.Attributes` directly unless you're bui
 - `[GenerateDtos]` - Batch DTO generation
 - `[Wrapper]` - Generate wrapper types
 
+## Enums Included
+
+- `PropertySetAccessor` - Controls the set accessor emitted on generated properties (`Preserve` / `Set` / `Init`). Used via `[Facet(SetAccessor = PropertySetAccessor.Init)]`.
+
 ## AOT Compatibility
 
 This package is fully compatible with AOT (Ahead-Of-Time) compilation, including .NET MAUI applications. The separation of attributes from the source generator ensures that Roslyn dependencies do not leak into your runtime.

--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -103,6 +103,11 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public ImmutableArray<string> FlattenToTypes { get; }
 
     /// <summary>
+    /// Controls the set accessor emitted on all generated properties.
+    /// </summary>
+    public PropertySetAccessor SetAccessor { get; }
+
+    /// <summary>
     /// The top-level property and field names of the source type (including inherited members).
     /// Used to disambiguate navigation properties from static type names in MapFrom expressions.
     /// </summary>
@@ -214,7 +219,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         BaseFacetInfo? baseFacetInfo = null,
         int maxDepthToSource = 0,
         ImmutableArray<string> sourcePropertyNames = default,
-        bool baseHidesToSource = false)
+        bool baseHidesToSource = false,
+        PropertySetAccessor setAccessor = PropertySetAccessor.Preserve)
     {
         Name = name;
         Namespace = @namespace;
@@ -257,6 +263,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         BaseFacetInfo = baseFacetInfo;
         SourcePropertyNames = sourcePropertyNames.IsDefault ? ImmutableArray<string>.Empty : sourcePropertyNames;
         BaseHidesToSource = baseHidesToSource;
+        SetAccessor = setAccessor;
     }
 
     public bool Equals(FacetTargetModel? other)
@@ -302,7 +309,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && HasProjectionMapConfiguration == other.HasProjectionMapConfiguration
             && HasMapConfiguration == other.HasMapConfiguration
             && BaseHidesFromSource == other.BaseHidesFromSource
-            && SourcePropertyNames.SequenceEqual(other.SourcePropertyNames);
+            && SourcePropertyNames.SequenceEqual(other.SourcePropertyNames)
+            && SetAccessor == other.SetAccessor;
     }
 
     public override bool Equals(object? obj) => obj is FacetTargetModel other && Equals(other);
@@ -345,6 +353,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             hash = hash * 31 + HasMapConfiguration.GetHashCode();
             hash = hash * 31 + BaseHidesFromSource.GetHashCode();
             hash = hash * 31 + SourcePropertyNames.Length.GetHashCode();
+            hash = hash * 31 + SetAccessor.GetHashCode();
             hash = hash * 31 + Members.Length.GetHashCode();
 
             foreach (var member in Members)

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -114,6 +114,9 @@ internal static class ModelBuilder
         // Extract ConvertEnumsTo parameter
         var convertEnumsTo = AttributeParser.ExtractConvertEnumsTo(attribute);
 
+        // Extract SetAccessor parameter
+        var setAccessor = (PropertySetAccessor)AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.SetAccessor, (int)PropertySetAccessor.Preserve);
+
         // Extract GenerateCopyConstructor and GenerateEquality parameters - use global defaults
         var generateCopyConstructor = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateCopyConstructor, globalDefaults.GenerateCopyConstructor);
         var generateEquality = AttributeParser.GetNamedArg(attribute.NamedArguments, FacetConstants.AttributeNames.GenerateEquality, globalDefaults.GenerateEquality);
@@ -221,7 +224,8 @@ internal static class ModelBuilder
             baseClassMemberNames,
             collectionTargetType,
             externalDocProvider,
-            token);
+            token,
+            setAccessor);
 
         // Add expression-based members (from MapFrom with expressions)
         if (expressionMembers.Count > 0)
@@ -344,7 +348,8 @@ internal static class ModelBuilder
             baseFacetInfo,
             maxDepthToSource,
             sourcePropertyNames,
-            baseHidesToSource);
+            baseHidesToSource,
+            setAccessor);
     }
 
     #region Private Helper Methods
@@ -368,7 +373,8 @@ internal static class ModelBuilder
         ImmutableArray<string> baseClassMemberNames,
         string? collectionTargetType,
         ExternalXmlDocProvider? externalDocProvider,
-        CancellationToken token)
+        CancellationToken token,
+        PropertySetAccessor setAccessor = PropertySetAccessor.Preserve)
     {
         var members = new List<FacetMember>();
         var excludedRequiredMembers = new List<FacetMember>();
@@ -415,7 +421,8 @@ internal static class ModelBuilder
                     externalDocProvider,
                     members,
                     excludedRequiredMembers,
-                    addedMembers);
+                    addedMembers,
+                    setAccessor);
             }
             else if (includeFields && member is IFieldSymbol field && field.DeclaredAccessibility == Accessibility.Public)
             {
@@ -457,7 +464,8 @@ internal static class ModelBuilder
         ExternalXmlDocProvider? externalDocProvider,
         List<FacetMember> members,
         List<FacetMember> excludedRequiredMembers,
-        HashSet<string> addedMembers)
+        HashSet<string> addedMembers,
+        PropertySetAccessor setAccessor = PropertySetAccessor.Preserve)
     {
         var memberXmlDocumentation = copyDocs ? CodeGenerationHelpers.ExtractXmlDocumentation(property, inheritDocs, externalDocProvider) : null;
 
@@ -482,7 +490,12 @@ internal static class ModelBuilder
             return;
         }
 
-        var shouldPreserveInitOnly = preserveInitOnly && isInitOnly;
+        var shouldPreserveInitOnly = setAccessor switch
+        {
+            PropertySetAccessor.Init => true,
+            PropertySetAccessor.Set => false,
+            _ => preserveInitOnly && isInitOnly,
+        };
         // Honor the target property's own 'required' modifier when it maps from a non-required source property.
         var shouldPreserveRequired = (preserveRequired && isRequired) || (hasMapFrom && mapFromInfo.isTargetRequired);
 

--- a/src/Facet/Generators/Shared/FacetConstants.cs
+++ b/src/Facet/Generators/Shared/FacetConstants.cs
@@ -138,5 +138,6 @@ internal static class FacetConstants
         public const string ToSourceConfiguration = "ToSourceConfiguration";
         public const string CollectionTargetType = "CollectionTargetType";
         public const string AsCollection = "AsCollection";
+        public const string SetAccessor = "SetAccessor";
     }
 }

--- a/test/Facet.Tests/TestModels/TestDtos.cs
+++ b/test/Facet.Tests/TestModels/TestDtos.cs
@@ -404,3 +404,18 @@ public partial class UnitMultiSourceInheritedFacet : UnitBaseFacet;
 [Facet(typeof(LocationEntity), nameof(LocationEntity.Location), GenerateToSource = true)]
 public partial class LocationDto;
 
+// SetAccessor feature test DTOs (#381)
+[Facet(typeof(User), "Password", "CreatedAt", SetAccessor = PropertySetAccessor.Init)]
+public partial class UserImmutableDto;
+
+[Facet(typeof(User), "Password", "CreatedAt", SetAccessor = PropertySetAccessor.Set)]
+public partial class UserMutableDto;
+
+// Verify SetAccessor.Preserve keeps init-only from source (using record, which defaults preserveInitOnly = true)
+[Facet(typeof(ImmutableEntity), SetAccessor = PropertySetAccessor.Preserve)]
+public partial record ImmutableEntityPreserveDto;
+
+// Verify SetAccessor.Set forces set on init-only source
+[Facet(typeof(ImmutableEntity), SetAccessor = PropertySetAccessor.Set)]
+public partial class ImmutableEntityMutableDto;
+

--- a/test/Facet.Tests/TestModels/TestEntities.cs
+++ b/test/Facet.Tests/TestModels/TestEntities.cs
@@ -512,3 +512,11 @@ public class LocationEntity
     public required string Description { get; set; }
 }
 
+    // Test entity with init-only properties for SetAccessor tests
+    public class ImmutableEntity
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Description { get; init; } = string.Empty;
+    }
+

--- a/test/Facet.Tests/UnitTests/Features/SetAccessorTests.cs
+++ b/test/Facet.Tests/UnitTests/Features/SetAccessorTests.cs
@@ -1,0 +1,126 @@
+using System.Reflection;
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Features;
+
+public class SetAccessorTests
+{
+    [Fact]
+    public void SetAccessor_Init_AllPropertiesAreInitOnly()
+    {
+        var type = typeof(UserImmutableDto);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead)
+            .ToArray();
+
+        properties.Should().NotBeEmpty();
+        foreach (var prop in properties)
+        {
+            var setter = prop.SetMethod;
+            setter.Should().NotBeNull($"Property {prop.Name} should have a setter");
+            setter!.ReturnParameter.GetRequiredCustomModifiers()
+                .Should().Contain(typeof(System.Runtime.CompilerServices.IsExternalInit),
+                    $"Property {prop.Name} should be init-only");
+        }
+    }
+
+    [Fact]
+    public void SetAccessor_Init_CanConstructViaObjectInitializer()
+    {
+        var dto = new UserImmutableDto
+        {
+            Id = 1,
+            FirstName = "Alice",
+            LastName = "Smith",
+            Email = "alice@example.com",
+        };
+
+        dto.Id.Should().Be(1);
+        dto.FirstName.Should().Be("Alice");
+        dto.LastName.Should().Be("Smith");
+        dto.Email.Should().Be("alice@example.com");
+    }
+
+    [Fact]
+    public void SetAccessor_Init_CanConstructFromSource()
+    {
+        var user = new User
+        {
+            Id = 42,
+            FirstName = "Bob",
+            LastName = "Jones",
+            Email = "bob@example.com",
+            IsActive = true,
+        };
+
+        var dto = new UserImmutableDto(user);
+
+        dto.Id.Should().Be(42);
+        dto.FirstName.Should().Be("Bob");
+        dto.Email.Should().Be("bob@example.com");
+    }
+
+    [Fact]
+    public void SetAccessor_Set_AllPropertiesHaveMutableSetter()
+    {
+        var type = typeof(UserMutableDto);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite)
+            .ToArray();
+
+        properties.Should().NotBeEmpty();
+        foreach (var prop in properties)
+        {
+            var setter = prop.SetMethod;
+            setter.Should().NotBeNull($"Property {prop.Name} should have a setter");
+            setter!.ReturnParameter.GetRequiredCustomModifiers()
+                .Should().NotContain(typeof(System.Runtime.CompilerServices.IsExternalInit),
+                    $"Property {prop.Name} should NOT be init-only");
+        }
+    }
+
+    [Fact]
+    public void SetAccessor_Set_CanMutateAfterConstruction()
+    {
+        var user = new User { Id = 1, FirstName = "Alice", LastName = "Smith", Email = "a@b.com", IsActive = true };
+        var dto = new UserMutableDto(user);
+
+        dto.FirstName = "Changed";
+
+        dto.FirstName.Should().Be("Changed");
+    }
+
+    [Fact]
+    public void SetAccessor_Set_OverridesInitOnlyFromSource()
+    {
+        var type = typeof(ImmutableEntityMutableDto);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite)
+            .ToArray();
+
+        properties.Should().NotBeEmpty();
+        foreach (var prop in properties)
+        {
+            prop.SetMethod!.ReturnParameter.GetRequiredCustomModifiers()
+                .Should().NotContain(typeof(System.Runtime.CompilerServices.IsExternalInit),
+                    $"SetAccessor.Set should force set on init-only source property {prop.Name}");
+        }
+    }
+
+    [Fact]
+    public void SetAccessor_Preserve_KeepsInitOnlyFromSource()
+    {
+        var type = typeof(ImmutableEntityPreserveDto);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead)
+            .ToArray();
+
+        properties.Should().NotBeEmpty();
+        foreach (var prop in properties)
+        {
+            prop.SetMethod!.ReturnParameter.GetRequiredCustomModifiers()
+                .Should().Contain(typeof(System.Runtime.CompilerServices.IsExternalInit),
+                    $"SetAccessor.Preserve should keep init-only accessor for {prop.Name}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `SetAccessor` parameter to `[Facet]` that overrides the set accessor emitted on **all** generated properties.

## New API

```csharp
public enum PropertySetAccessor
{
    Preserve = 0,  // default; keep source accessor
    Set      = 1,  // force { get; set; }
    Init     = 2,  // force { get; init; }
}

// FacetAttribute
public PropertySetAccessor SetAccessor { get; set; } = PropertySetAccessor.Preserve;
```

## Usage

```csharp
// All properties become { get; init; }
[Facet(typeof(Order), SetAccessor = PropertySetAccessor.Init)]
public partial class ImmutableOrder;

// All properties become { get; set; } (even init-only source)
[Facet(typeof(Order), SetAccessor = PropertySetAccessor.Set)]
public partial class MutableOrder;
```

closes  #381 