### PR TITLE
feat: split generated code into multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Facet are documented in this file.
 ### Added
 
 - Added `SetAccessor` parameter to `[Facet]` with `PropertySetAccessor` enum (`Preserve` / `Set` / `Init`) to override the set accessor emitted on all generated properties (#381). Supports the immutable builder pattern: one mutable facet for building, one init-only facet as the frozen read model.
+- Each facet type now emits two generated files by default: `{Type}.Properties.g.cs` (property declarations) and `{Type}.Mappings.g.cs` (constructors, projections, and conversion methods). Opt out globally by setting `<Facet_SplitGeneratedFiles>false</Facet_SplitGeneratedFiles>` in your `.csproj` or `Directory.Build.props` to restore the previous single-file output.
 
 ## [6.6.3] - 2026-05-22
 

--- a/docs/12_GeneratedFilesOutput.md
+++ b/docs/12_GeneratedFilesOutput.md
@@ -67,14 +67,16 @@ Generate files in a separate shared project:
 
 ## File Structure
 
-With the default configuration, generated files are organized by generator:
+By default, Facet emits **two files per type**: a `*.Properties.g.cs` file containing the property declarations (and XML doc comments) and a `*.Mappings.g.cs` file containing constructors, projections, and conversion methods. Generated files are organised by generator:
 
 ```
 Generated/
 ├── Facet/
 │   ├── Facet.Generators.FacetGenerator/
-│   │   ├── UserDto.g.cs
-│   │   ├── ProductDto.g.cs
+│   │   ├── UserDto.Properties.g.cs
+│   │   ├── UserDto.Mappings.g.cs
+│   │   ├── ProductDto.Properties.g.cs
+│   │   ├── ProductDto.Mappings.g.cs
 │   │   └── ...
 │   ├── Facet.Generators.FlattenGenerator/
 │   │   └── ...
@@ -83,6 +85,18 @@ Generated/
 └── OtherGenerator/
     └── ...
 ```
+
+### Opting Out of Split Output
+
+If you prefer the previous single-file output (`{Type}.g.cs`) you can opt out globally:
+
+```xml
+<PropertyGroup>
+  <Facet_SplitGeneratedFiles>false</Facet_SplitGeneratedFiles>
+</PropertyGroup>
+```
+
+With `false`, all generated code for a type is written to a single `{Type}.g.cs` file as in previous versions.
 
 ## Benefits of Visible Generated Files
 

--- a/docs/21_GlobalConfigurationDefaults.md
+++ b/docs/21_GlobalConfigurationDefaults.md
@@ -29,6 +29,14 @@ The following properties can be configured globally for the `[Facet]` attribute:
 | `MaxDepthToSource` | `0` | `Facet_MaxDepthToSource` |
 | `PreserveReferences` | `true` | `Facet_PreserveReferences` |
 
+The following property controls **generator-level** output behaviour (no per-type attribute equivalent):
+
+| Property | Default | MSBuild Property |
+|----------|---------|------------------|
+| *(generator)* Split output | `true` | `Facet_SplitGeneratedFiles` |
+
+When `Facet_SplitGeneratedFiles` is `true` (the default), each type emits two files: `*.Properties.g.cs` and `*.Mappings.g.cs`. Set it to `false` to restore single-file output. See [Generated Files Output](12_GeneratedFilesOutput.md) for details.
+
 ## How to Configure
 
 ### Option 1: Project File (.csproj)

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -177,6 +177,21 @@ internal static class CodeBuilder
     }
 
     /// <summary>
+    /// Split-output variant of <see cref="GenerateForGroup"/>.
+    /// Returns a Properties file (property declarations only) and a Mappings file
+    /// (constructors, projections, and conversion methods).
+    /// </summary>
+    public static (string propertiesCode, string mappingsCode) GenerateForGroupSplit(
+        IReadOnlyList<FacetTargetModel> models,
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
+    {
+        if (models.Count == 1)
+            return GenerateSplit(models[0], facetLookup);
+
+        return GenerateCombinedSplit(models, facetLookup);
+    }
+
+    /// <summary>
     /// Generates a single partial-class file that combines mappings from multiple source types
     /// to the same target type.
     /// <para>
@@ -398,8 +413,272 @@ internal static class CodeBuilder
         return angleBracket > 0 ? simpleName.Substring(0, angleBracket) : simpleName;
     }
 
-    /// <summary>
-    /// Generates a lazily-compiled <c>Action&lt;TSource, TTarget&gt;</c> from
+    private static (string propertiesCode, string mappingsCode) GenerateSplit(
+        FacetTargetModel model,
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
+    {
+        var namespacesToImport = CodeGenerationHelpers.CollectNamespaces(model);
+        var staticUsingTypes = CodeGenerationHelpers.CollectStaticUsingTypes(model);
+        var hasNullableRefTypeMembers = model.Members.Any(m => !m.IsValueType && m.TypeName.EndsWith("?"));
+        var needsNullable = hasNullableRefTypeMembers || model.MaxDepth > 0 || model.PreserveReferences;
+        var keyword = GetTypeKeyword(model);
+        var hasInitOnlyProperties = model.Members.Any(m => m.IsInitOnly);
+        var hasRequiredProperties = model.Members.Any(m => m.IsRequired);
+        var isPositional = model.IsRecord && !model.HasExistingPrimaryConstructor
+            && !(model.TypeKind == TypeKind.Class && hasRequiredProperties);
+        var hasCustomMapping = !string.IsNullOrWhiteSpace(model.ConfigurationTypeName);
+        var shouldGenerateEquality = model.GenerateEquality && !model.IsRecord;
+
+        // --- Properties file ---
+        var propsSb = new StringBuilder();
+        var propsIndent = WritePreamble(propsSb, model, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: true);
+
+        if (isPositional)
+            GeneratePositionalDeclaration(propsSb, model, keyword, propsIndent);
+
+        propsSb.AppendLine($"{propsIndent}{model.Accessibility} partial {keyword} {model.Name}");
+        propsSb.AppendLine($"{propsIndent}{{");
+
+        var propsMemberIndent = propsIndent + "    ";
+        if (!isPositional || model.HasExistingPrimaryConstructor)
+        {
+            MemberGenerator.GenerateMembers(propsSb, model, propsMemberIndent);
+        }
+        else
+        {
+            var membersWithDocs = model.Members
+                .Where(static m => !string.IsNullOrWhiteSpace(m.XmlDocumentation) && !m.IsUserDeclared)
+                .ToList();
+            MemberGenerator.GenerateMembers(propsSb, model, propsMemberIndent, membersWithDocs, usePropertyNameAsInitializer: true);
+        }
+
+        propsSb.AppendLine($"{propsIndent}}}");
+        CloseContainingTypeHierarchy(propsSb, model, propsIndent);
+
+        // --- Mappings file ---
+        var mapsSb = new StringBuilder();
+        var mapsIndent = WritePreamble(mapsSb, model, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: false);
+
+        if (shouldGenerateEquality)
+            mapsSb.AppendLine($"{mapsIndent}{model.Accessibility} partial {keyword} {model.Name} : {EqualityGenerator.GetEquatableInterface(model)}");
+        else
+            mapsSb.AppendLine($"{mapsIndent}{model.Accessibility} partial {keyword} {model.Name}");
+        mapsSb.AppendLine($"{mapsIndent}{{");
+
+        var mapsMemberIndent = mapsIndent + "    ";
+
+        if (model.GenerateParameterlessConstructor)
+            ConstructorGenerator.GenerateParameterlessConstructor(mapsSb, model, isPositional);
+
+        if (model.GenerateConstructor)
+            ConstructorGenerator.GenerateConstructor(mapsSb, model, isPositional, hasInitOnlyProperties, hasCustomMapping, hasRequiredProperties);
+
+        if (hasCustomMapping && !model.HasMapConfiguration && model.HasProjectionMapConfiguration)
+            GenerateProjectionMapAction(mapsSb, model, mapsMemberIndent);
+
+        if (model.GenerateCopyConstructor)
+            CopyConstructorGenerator.Generate(mapsSb, model, mapsMemberIndent);
+
+        if (model.GenerateExpressionProjection)
+        {
+            ProjectionGenerator.GenerateProjectionProperty(mapsSb, model, mapsMemberIndent, facetLookup);
+
+            if (!(model.HasExistingPrimaryConstructor && model.IsRecord))
+            {
+                var sourceSpecificName = "ProjectionFrom" + GetSourceSimpleName(model);
+                var baseSrcMatches = model.BaseHidesFacetMembers
+                    && model.BaseFacetInfo?.BaseSourceTypeName == model.SourceTypeName;
+                var aliasNewMod = baseSrcMatches ? "new " : "";
+                mapsSb.AppendLine();
+                ProjectionGenerator.GenerateProjectionDocumentation(mapsSb, model, mapsMemberIndent, sourceSpecificName);
+                mapsSb.AppendLine($"{mapsMemberIndent}public static {aliasNewMod}Expression<Func<{model.SourceTypeName}, {model.Name}>> {sourceSpecificName} => Projection;");
+            }
+        }
+
+        if (model.GenerateToSource)
+            ToSourceGenerator.Generate(mapsSb, model, facetLookup);
+
+        if (model.GenerateToSource && !model.SourceHasPositionalConstructor)
+            ToSourceGenerator.GenerateApplyToSource(mapsSb, model, facetLookup);
+
+        if (model.FlattenToTypes.Length > 0)
+            FlattenToGenerator.Generate(mapsSb, model, mapsMemberIndent, facetLookup);
+
+        if (shouldGenerateEquality)
+            EqualityGenerator.Generate(mapsSb, model, mapsMemberIndent);
+
+        mapsSb.AppendLine($"{mapsIndent}}}");
+        CloseContainingTypeHierarchy(mapsSb, model, mapsIndent);
+
+        return (propsSb.ToString(), mapsSb.ToString());
+    }
+
+    private static (string propertiesCode, string mappingsCode) GenerateCombinedSplit(
+        IReadOnlyList<FacetTargetModel> models,
+        Dictionary<string, List<FacetTargetModel>> facetLookup)
+    {
+        var primaryModel = models[0];
+
+        var namespacesToImport = new HashSet<string>();
+        var staticUsingTypes = new HashSet<string>();
+        foreach (var m in models)
+        {
+            foreach (var ns in CodeGenerationHelpers.CollectNamespaces(m))
+                namespacesToImport.Add(ns);
+            foreach (var su in CodeGenerationHelpers.CollectStaticUsingTypes(m))
+                staticUsingTypes.Add(su);
+        }
+
+        var needsNullable = models.Any(m =>
+            m.Members.Any(mem => !mem.IsValueType && mem.TypeName.EndsWith("?"))
+            || m.MaxDepth > 0
+            || m.PreserveReferences);
+
+        var keyword = GetTypeKeyword(primaryModel);
+
+        var seenMemberNames = new HashSet<string>();
+        var unionMembers = new System.Collections.Generic.List<FacetMember>();
+        foreach (var m in models)
+        {
+            foreach (var member in m.Members)
+            {
+                if (seenMemberNames.Add(member.Name))
+                    unionMembers.Add(member);
+            }
+        }
+
+        var hasRequiredUnion = unionMembers.Any(m => m.IsRequired);
+        var isPositional = primaryModel.IsRecord && !primaryModel.HasExistingPrimaryConstructor
+            && !(primaryModel.TypeKind == TypeKind.Class && hasRequiredUnion);
+        var shouldGenerateEquality = primaryModel.GenerateEquality && !primaryModel.IsRecord;
+
+        // --- Properties file ---
+        var propsSb = new StringBuilder();
+        var propsIndent = WritePreamble(propsSb, primaryModel, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: true);
+
+        if (isPositional)
+            GeneratePositionalDeclaration(propsSb, primaryModel, keyword, propsIndent);
+
+        propsSb.AppendLine($"{propsIndent}{primaryModel.Accessibility} partial {keyword} {primaryModel.Name}");
+        propsSb.AppendLine($"{propsIndent}{{");
+
+        if (!isPositional || primaryModel.HasExistingPrimaryConstructor)
+            MemberGenerator.GenerateMembers(propsSb, primaryModel, propsIndent + "    ", unionMembers);
+
+        propsSb.AppendLine($"{propsIndent}}}");
+        CloseContainingTypeHierarchy(propsSb, primaryModel, propsIndent);
+
+        // --- Mappings file ---
+        var mapsSb = new StringBuilder();
+        var mapsIndent = WritePreamble(mapsSb, primaryModel, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: false);
+
+        if (shouldGenerateEquality)
+            mapsSb.AppendLine($"{mapsIndent}{primaryModel.Accessibility} partial {keyword} {primaryModel.Name} : {EqualityGenerator.GetEquatableInterface(primaryModel)}");
+        else
+            mapsSb.AppendLine($"{mapsIndent}{primaryModel.Accessibility} partial {keyword} {primaryModel.Name}");
+        mapsSb.AppendLine($"{mapsIndent}{{");
+
+        var mapsMemberIndent = mapsIndent + "    ";
+
+        if (primaryModel.GenerateParameterlessConstructor)
+            ConstructorGenerator.GenerateParameterlessConstructor(mapsSb, primaryModel, isPositional);
+
+        foreach (var model in models)
+        {
+            if (!model.GenerateConstructor) continue;
+
+            var hasCustomMapping = !string.IsNullOrWhiteSpace(model.ConfigurationTypeName);
+            var modelHasInitOnly = model.Members.Any(mem => mem.IsInitOnly);
+            var modelHasRequired = model.Members.Any(mem => mem.IsRequired);
+
+            ConstructorGenerator.GenerateConstructor(
+                mapsSb, model, isPositional, modelHasInitOnly, hasCustomMapping, modelHasRequired);
+
+            if (hasCustomMapping && !model.HasMapConfiguration && model.HasProjectionMapConfiguration)
+                GenerateProjectionMapAction(mapsSb, model, mapsMemberIndent);
+        }
+
+        if (primaryModel.GenerateCopyConstructor)
+            CopyConstructorGenerator.Generate(mapsSb, primaryModel, mapsMemberIndent);
+
+        foreach (var model in models)
+        {
+            if (!model.GenerateExpressionProjection) continue;
+
+            var projectionName = GetProjectionName(model, models);
+            ProjectionGenerator.GenerateProjectionProperty(mapsSb, model, mapsMemberIndent, facetLookup, projectionName);
+        }
+
+        foreach (var model in models)
+        {
+            if (!model.GenerateToSource) continue;
+
+            var toSourceName = GetToSourceMethodName(model, models);
+            ToSourceGenerator.Generate(mapsSb, model, facetLookup, toSourceName);
+        }
+
+        foreach (var model in models)
+        {
+            if (!model.GenerateToSource || model.SourceHasPositionalConstructor) continue;
+
+            var applyMethodName = GetApplyToSourceMethodName(model, models);
+            ToSourceGenerator.GenerateApplyToSource(mapsSb, model, facetLookup, applyMethodName);
+        }
+
+        foreach (var model in models)
+        {
+            if (model.FlattenToTypes.Length > 0)
+                FlattenToGenerator.Generate(mapsSb, model, mapsMemberIndent, facetLookup);
+        }
+
+        if (shouldGenerateEquality)
+            EqualityGenerator.Generate(mapsSb, primaryModel, mapsMemberIndent);
+
+        mapsSb.AppendLine($"{mapsIndent}}}");
+        CloseContainingTypeHierarchy(mapsSb, primaryModel, mapsIndent);
+
+        return (propsSb.ToString(), mapsSb.ToString());
+    }
+
+    private static string WritePreamble(
+        StringBuilder sb,
+        FacetTargetModel model,
+        IEnumerable<string> namespacesToImport,
+        IEnumerable<string> staticUsingTypes,
+        bool needsNullable,
+        bool includeTypeDocs)
+    {
+        GenerateFileHeader(sb);
+
+        foreach (var ns in namespacesToImport.OrderBy(x => x))
+            sb.AppendLine($"using {ns};");
+
+        foreach (var type in staticUsingTypes.OrderBy(x => x))
+            sb.AppendLine($"using static {type};");
+
+        sb.AppendLine();
+
+        if (needsNullable)
+        {
+            sb.AppendLine("#nullable enable");
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.Namespace))
+            sb.AppendLine($"namespace {model.Namespace};");
+
+        var indent = GenerateContainingTypeHierarchy(sb, model);
+
+        if (includeTypeDocs && !string.IsNullOrWhiteSpace(model.TypeXmlDocumentation))
+        {
+            var indentedDoc = model.TypeXmlDocumentation!.Replace("\n", $"\n{indent}");
+            sb.AppendLine($"{indent}{indentedDoc}");
+        }
+
+        return indent;
+    }
+
+
     /// <c>ConfigureProjection</c> expressions. Called when the configuration type
     /// implements <c>IFacetProjectionMapConfiguration</c> but not <c>IFacetMapConfiguration</c>,
     /// allowing users to write mapping logic once as expressions and reuse it in both

--- a/src/Facet/Generators/FacetGenerators/FacetGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/FacetGenerator.cs
@@ -27,9 +27,11 @@ public sealed class FacetGenerator : IIncrementalGenerator
             .Where(static m => m is not null);
 
         var allFacets = facets.Collect();
+        var allFacetsWithConfig = allFacets.Combine(globalOptions);
 
-        context.RegisterSourceOutput(allFacets, static (spc, models) =>
+        context.RegisterSourceOutput(allFacetsWithConfig, static (spc, pair) =>
         {
+            var (models, globalConfig) = pair;
             spc.CancellationToken.ThrowIfCancellationRequested();
 
             var modelsByTarget = models
@@ -44,8 +46,18 @@ public sealed class FacetGenerator : IIncrementalGenerator
                 spc.CancellationToken.ThrowIfCancellationRequested();
 
                 var modelsForTarget = group.Select(m => m!).ToList();
-                var code = CodeBuilder.GenerateForGroup(modelsForTarget, facetLookup);
-                spc.AddSource($"{group.Key}.g.cs", SourceText.From(code, Encoding.UTF8));
+
+                if (globalConfig.SplitGeneratedFiles)
+                {
+                    var (propsCode, mapsCode) = CodeBuilder.GenerateForGroupSplit(modelsForTarget, facetLookup);
+                    spc.AddSource($"{group.Key}.Properties.g.cs", SourceText.From(propsCode, Encoding.UTF8));
+                    spc.AddSource($"{group.Key}.Mappings.g.cs", SourceText.From(mapsCode, Encoding.UTF8));
+                }
+                else
+                {
+                    var code = CodeBuilder.GenerateForGroup(modelsForTarget, facetLookup);
+                    spc.AddSource($"{group.Key}.g.cs", SourceText.From(code, Encoding.UTF8));
+                }
             }
         });
     }

--- a/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
+++ b/src/Facet/Generators/Shared/GlobalConfigurationDefaults.cs
@@ -105,6 +105,13 @@ internal sealed class GlobalConfigurationDefaults
     /// </summary>
     public bool PreserveReferences { get; }
 
+    /// <summary>
+    /// When true (default), generates two files per type: <c>{FullName}.Properties.g.cs</c> (properties only)
+    /// and <c>{FullName}.Mappings.g.cs</c> (constructors, projections, and conversion methods).
+    /// Set <c>Facet_SplitGeneratedFiles</c> to <c>false</c> to revert to a single combined file.
+    /// </summary>
+    public bool SplitGeneratedFiles { get; }
+
     private GlobalConfigurationDefaults(
         bool generateConstructor,
         bool generateParameterlessConstructor,
@@ -121,7 +128,8 @@ internal sealed class GlobalConfigurationDefaults
         bool generateEquality,
         int maxDepth,
         bool preserveReferences,
-        int maxDepthToSource)
+        int maxDepthToSource,
+        bool splitGeneratedFiles)
     {
         GenerateConstructor = generateConstructor;
         GenerateParameterlessConstructor = generateParameterlessConstructor;
@@ -139,6 +147,7 @@ internal sealed class GlobalConfigurationDefaults
         MaxDepth = maxDepth;
         PreserveReferences = preserveReferences;
         MaxDepthToSource = maxDepthToSource;
+        SplitGeneratedFiles = splitGeneratedFiles;
     }
 
     /// <summary>
@@ -163,7 +172,8 @@ internal sealed class GlobalConfigurationDefaults
             generateEquality: GetBoolOption(globalOptions, "build_property.Facet_GenerateEquality", defaultValue: false),
             maxDepth: GetIntOption(globalOptions, "build_property.Facet_MaxDepth", defaultValue: FacetConstants.DefaultMaxDepth),
             preserveReferences: GetBoolOption(globalOptions, "build_property.Facet_PreserveReferences", defaultValue: FacetConstants.DefaultPreserveReferences),
-            maxDepthToSource: GetIntOption(globalOptions, "build_property.Facet_MaxDepthToSource", defaultValue: 0));
+            maxDepthToSource: GetIntOption(globalOptions, "build_property.Facet_MaxDepthToSource", defaultValue: 0),
+            splitGeneratedFiles: GetBoolOption(globalOptions, "build_property.Facet_SplitGeneratedFiles", defaultValue: true));
     }
 
     private static bool GetBoolOption(AnalyzerConfigOptions? options, string key, bool defaultValue)

--- a/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CopyDocsTests.cs
@@ -77,8 +77,10 @@ public class InheritDocsTests
     private static string LoadGeneratedSource(string typeFullName)
     {
         var projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
-        var path = Path.Combine(projectRoot, "obj", "Generated", "Facet", "Facet.Generators.FacetGenerator", $"{typeFullName}.g.cs");
-        try { return File.ReadAllText(path); }
+        var dir = Path.Combine(projectRoot, "obj", "Generated", "Facet", "Facet.Generators.FacetGenerator");
+        var propertiesPath = Path.Combine(dir, $"{typeFullName}.Properties.g.cs");
+        var combinedPath = Path.Combine(dir, $"{typeFullName}.g.cs");
+        try { return File.ReadAllText(File.Exists(propertiesPath) ? propertiesPath : combinedPath); }
         catch (FileNotFoundException) { return string.Empty; }
     }
 

--- a/test/Facet.Tests/UnitTests/Core/Facet/CrossAssemblyCopyDocsTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/Facet/CrossAssemblyCopyDocsTests.cs
@@ -33,8 +33,10 @@ public class CrossAssemblyCopyDocsTests
     private static string LoadGeneratedSource(string typeFullName)
     {
         var projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
-        var path = Path.Combine(projectRoot, "obj", "Generated", "Facet", "Facet.Generators.FacetGenerator", $"{typeFullName}.g.cs");
-        try { return File.ReadAllText(path); }
+        var dir = Path.Combine(projectRoot, "obj", "Generated", "Facet", "Facet.Generators.FacetGenerator");
+        var propertiesPath = Path.Combine(dir, $"{typeFullName}.Properties.g.cs");
+        var combinedPath = Path.Combine(dir, $"{typeFullName}.g.cs");
+        try { return File.ReadAllText(File.Exists(propertiesPath) ? propertiesPath : combinedPath); }
         catch (FileNotFoundException) { return string.Empty; }
     }
 }

--- a/test/Facet.Tests/UnitTests/Features/SplitOutputTests.cs
+++ b/test/Facet.Tests/UnitTests/Features/SplitOutputTests.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using System.Reflection;
+
+namespace Facet.Tests.UnitTests.Features;
+
+public class SplitOutputEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+[Facet(typeof(SplitOutputEntity))]
+public partial class SplitOutputDto;
+
+public class SplitOutputTests
+{
+    [Fact]
+    public void SplitOutput_Constructor_MapsAllProperties()
+    {
+        var entity = new SplitOutputEntity { Id = 42, Name = "Test", Description = "Desc" };
+
+        var dto = new SplitOutputDto(entity);
+
+        dto.Id.Should().Be(42);
+        dto.Name.Should().Be("Test");
+        dto.Description.Should().Be("Desc");
+    }
+
+    [Fact]
+    public void SplitOutput_PropertiesFile_Exists()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var propsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputDto.Properties.g.cs");
+
+        File.Exists(propsFile).Should().BeTrue($"Expected Properties.g.cs at {propsFile}");
+    }
+
+    [Fact]
+    public void SplitOutput_MappingsFile_Exists()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var mapsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputDto.Mappings.g.cs");
+
+        File.Exists(mapsFile).Should().BeTrue($"Expected Mappings.g.cs at {mapsFile}");
+    }
+
+    [Fact]
+    public void SplitOutput_PropertiesFile_ContainsOnlyProperties()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var propsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputDto.Properties.g.cs");
+
+        if (!File.Exists(propsFile))
+            return;
+
+        var content = File.ReadAllText(propsFile);
+
+        content.Should().Contain("public int Id");
+        content.Should().Contain("public string Name");
+        content.Should().NotContain("public SplitOutputDto(");
+        content.Should().NotContain("public static");
+    }
+
+    [Fact]
+    public void SplitOutput_MappingsFile_ContainsConstructor()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var mapsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputDto.Mappings.g.cs");
+
+        if (!File.Exists(mapsFile))
+            return;
+
+        var content = File.ReadAllText(mapsFile);
+
+        content.Should().Contain("public SplitOutputDto(");
+        content.Should().NotContain("public int Id { get;");
+    }
+
+    [Fact]
+    public void SplitOutput_CombinedFile_DoesNotExist()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var combinedFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputDto.g.cs");
+
+        File.Exists(combinedFile).Should().BeFalse(
+            "SplitOutput = true should not emit a combined .g.cs file");
+    }
+
+    private static string GetGeneratedFilesDir()
+    {
+        var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+
+        // Assembly lives in bin/{Config}/net10.0 — 3 levels up is the project root (Facet.Tests/).
+        var projectRoot = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(assemblyDir)!))!;
+
+        return Path.Combine(projectRoot, "obj", "Generated", "Facet", "Facet.Generators.FacetGenerator");
+    }
+}


### PR DESCRIPTION
## Summary

Facet now generates **two files per type** by default instead of one:

- `{FullName}.Properties.g.cs` > property declarations only
- `{FullName}.Mappings.g.cs` > constructors, projections, ToSource, equality, and all mapping methods

### Why

Splitting the output keeps generated files smaller and more focused. It also lays the groundwork for DDD scenarios where only the properties file needs to be visible to a shared/contracts project, while the mappings file stays in the infrastructure layer.

### Opt out

If you prefer a single combined file, set the MSBuild property in your `.csproj`:

```xml
<PropertyGroup>
  <Facet_SplitGeneratedFiles>false</Facet_SplitGeneratedFiles>
</PropertyGroup>
```

This paves the way for a solution for issue #143  