### PR TITLE
Fix redundant usings in split g.cs files

### DIFF
--- a/src/Facet/FacetTarget.cs
+++ b/src/Facet/FacetTarget.cs
@@ -127,6 +127,14 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
     public PropertySetAccessor SetAccessor { get; }
 
     /// <summary>
+    /// Fully-qualified names (with <c>global::</c> prefix) of the user-declared base class
+    /// and interfaces on the target type. Emitted in the <c>.Properties.g.cs</c> partial
+    /// declaration so that the type's inheritance chain is preserved even when the
+    /// <c>.Mappings.g.cs</c> file is excluded from compilation (e.g. to avoid back-end references).
+    /// </summary>
+    public ImmutableArray<string> DeclaredBaseTypeNames { get; }
+
+    /// <summary>
     /// The top-level property and field names of the source type (including inherited members).
     /// Used to disambiguate navigation properties from static type names in MapFrom expressions.
     /// </summary>
@@ -239,7 +247,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         int maxDepthToSource = 0,
         ImmutableArray<string> sourcePropertyNames = default,
         bool baseHidesToSource = false,
-        PropertySetAccessor setAccessor = PropertySetAccessor.Preserve)
+        PropertySetAccessor setAccessor = PropertySetAccessor.Preserve,
+        ImmutableArray<string> declaredBaseTypeNames = default)
     {
         Name = name;
         Namespace = @namespace;
@@ -283,6 +292,7 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
         SourcePropertyNames = sourcePropertyNames.IsDefault ? ImmutableArray<string>.Empty : sourcePropertyNames;
         BaseHidesToSource = baseHidesToSource;
         SetAccessor = setAccessor;
+        DeclaredBaseTypeNames = declaredBaseTypeNames.IsDefault ? ImmutableArray<string>.Empty : declaredBaseTypeNames;
     }
 
     public bool Equals(FacetTargetModel? other)
@@ -329,7 +339,8 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
             && HasMapConfiguration == other.HasMapConfiguration
             && BaseHidesFromSource == other.BaseHidesFromSource
             && SourcePropertyNames.SequenceEqual(other.SourcePropertyNames)
-            && SetAccessor == other.SetAccessor;
+            && SetAccessor == other.SetAccessor
+            && DeclaredBaseTypeNames.SequenceEqual(other.DeclaredBaseTypeNames);
     }
 
     public override bool Equals(object? obj) => obj is FacetTargetModel other && Equals(other);
@@ -392,6 +403,9 @@ internal sealed class FacetTargetModel : IEquatable<FacetTargetModel>
 
             foreach (var flattenToType in FlattenToTypes)
                 hash = hash * 31 + (flattenToType?.GetHashCode() ?? 0);
+
+            foreach (var baseTypeName in DeclaredBaseTypeNames)
+                hash = hash * 31 + (baseTypeName?.GetHashCode() ?? 0);
 
             return hash;
         }

--- a/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Facet.Generators.Shared;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
@@ -417,10 +418,14 @@ internal static class CodeBuilder
         FacetTargetModel model,
         Dictionary<string, List<FacetTargetModel>> facetLookup)
     {
-        var namespacesToImport = CodeGenerationHelpers.CollectNamespaces(model);
-        var staticUsingTypes = CodeGenerationHelpers.CollectStaticUsingTypes(model);
+        var mapsNamespaces = CodeGenerationHelpers.CollectNamespaces(model);
+        var mapsStaticUsings = CodeGenerationHelpers.CollectStaticUsingTypes(model);
+        var propsNamespaces = CodeGenerationHelpers.CollectNamespacesForProperties(model);
+        var propsStaticUsings = CodeGenerationHelpers.CollectStaticUsingTypesForProperties(model);
         var hasNullableRefTypeMembers = model.Members.Any(m => !m.IsValueType && m.TypeName.EndsWith("?"));
         var needsNullable = hasNullableRefTypeMembers || model.MaxDepth > 0 || model.PreserveReferences;
+        var needsNullableInProps = needsNullable;
+        var needsNullableInMaps = needsNullable;
         var keyword = GetTypeKeyword(model);
         var hasInitOnlyProperties = model.Members.Any(m => m.IsInitOnly);
         var hasRequiredProperties = model.Members.Any(m => m.IsRequired);
@@ -431,12 +436,13 @@ internal static class CodeBuilder
 
         // --- Properties file ---
         var propsSb = new StringBuilder();
-        var propsIndent = WritePreamble(propsSb, model, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: true);
+        var propsIndent = WritePreamble(propsSb, model, propsNamespaces, propsStaticUsings, needsNullableInProps, includeTypeDocs: true);
 
         if (isPositional)
             GeneratePositionalDeclaration(propsSb, model, keyword, propsIndent);
 
-        propsSb.AppendLine($"{propsIndent}{model.Accessibility} partial {keyword} {model.Name}");
+        var propsBaseList = FormatBaseTypeList(model.DeclaredBaseTypeNames);
+        propsSb.AppendLine($"{propsIndent}{model.Accessibility} partial {keyword} {model.Name}{propsBaseList}");
         propsSb.AppendLine($"{propsIndent}{{");
 
         var propsMemberIndent = propsIndent + "    ";
@@ -457,7 +463,7 @@ internal static class CodeBuilder
 
         // --- Mappings file ---
         var mapsSb = new StringBuilder();
-        var mapsIndent = WritePreamble(mapsSb, model, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: false);
+        var mapsIndent = WritePreamble(mapsSb, model, mapsNamespaces, mapsStaticUsings, needsNullableInMaps, includeTypeDocs: false);
 
         if (shouldGenerateEquality)
             mapsSb.AppendLine($"{mapsIndent}{model.Accessibility} partial {keyword} {model.Name} : {EqualityGenerator.GetEquatableInterface(model)}");
@@ -519,20 +525,26 @@ internal static class CodeBuilder
     {
         var primaryModel = models[0];
 
-        var namespacesToImport = new HashSet<string>();
-        var staticUsingTypes = new HashSet<string>();
+        var mapsNamespaces = new HashSet<string>();
+        var mapsStaticUsings = new HashSet<string>();
+        var propsNamespaces = new HashSet<string>();
+        var propsStaticUsings = new HashSet<string>();
         foreach (var m in models)
         {
             foreach (var ns in CodeGenerationHelpers.CollectNamespaces(m))
-                namespacesToImport.Add(ns);
+                mapsNamespaces.Add(ns);
             foreach (var su in CodeGenerationHelpers.CollectStaticUsingTypes(m))
-                staticUsingTypes.Add(su);
+                mapsStaticUsings.Add(su);
+            foreach (var ns in CodeGenerationHelpers.CollectNamespacesForProperties(m))
+                propsNamespaces.Add(ns);
+            foreach (var su in CodeGenerationHelpers.CollectStaticUsingTypesForProperties(m))
+                propsStaticUsings.Add(su);
         }
 
-        var needsNullable = models.Any(m =>
-            m.Members.Any(mem => !mem.IsValueType && mem.TypeName.EndsWith("?"))
-            || m.MaxDepth > 0
-            || m.PreserveReferences);
+        var needsNullable = models.Any(m => m.Members.Any(mem => !mem.IsValueType && mem.TypeName.EndsWith("?")))
+            || models.Any(m => m.MaxDepth > 0 || m.PreserveReferences);
+        var needsNullableInProps = needsNullable;
+        var needsNullableInMaps = needsNullable;
 
         var keyword = GetTypeKeyword(primaryModel);
 
@@ -554,12 +566,13 @@ internal static class CodeBuilder
 
         // --- Properties file ---
         var propsSb = new StringBuilder();
-        var propsIndent = WritePreamble(propsSb, primaryModel, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: true);
+        var propsIndent = WritePreamble(propsSb, primaryModel, propsNamespaces, propsStaticUsings, needsNullableInProps, includeTypeDocs: true);
 
         if (isPositional)
             GeneratePositionalDeclaration(propsSb, primaryModel, keyword, propsIndent);
 
-        propsSb.AppendLine($"{propsIndent}{primaryModel.Accessibility} partial {keyword} {primaryModel.Name}");
+        var propsBaseList = FormatBaseTypeList(primaryModel.DeclaredBaseTypeNames);
+        propsSb.AppendLine($"{propsIndent}{primaryModel.Accessibility} partial {keyword} {primaryModel.Name}{propsBaseList}");
         propsSb.AppendLine($"{propsIndent}{{");
 
         if (!isPositional || primaryModel.HasExistingPrimaryConstructor)
@@ -570,7 +583,7 @@ internal static class CodeBuilder
 
         // --- Mappings file ---
         var mapsSb = new StringBuilder();
-        var mapsIndent = WritePreamble(mapsSb, primaryModel, namespacesToImport, staticUsingTypes, needsNullable, includeTypeDocs: false);
+        var mapsIndent = WritePreamble(mapsSb, primaryModel, mapsNamespaces, mapsStaticUsings, needsNullableInMaps, includeTypeDocs: false);
 
         if (shouldGenerateEquality)
             mapsSb.AppendLine($"{mapsIndent}{primaryModel.Accessibility} partial {keyword} {primaryModel.Name} : {EqualityGenerator.GetEquatableInterface(primaryModel)}");
@@ -756,6 +769,17 @@ internal static class CodeBuilder
         sb.AppendLine("//     the code is regenerated.");
         sb.AppendLine("// </auto-generated>");
         sb.AppendLine();
+    }
+
+    /// <summary>
+    /// Formats the base-type list for a class/struct/record declaration.
+    /// Returns an empty string when there are no declared base types,
+    /// otherwise returns <c>" : TypeA, TypeB"</c> (leading space included).
+    /// </summary>
+    private static string FormatBaseTypeList(ImmutableArray<string> baseTypeNames)
+    {
+        if (baseTypeNames.IsDefaultOrEmpty) return string.Empty;
+        return " : " + string.Join(", ", baseTypeNames);
     }
 
     private static string GenerateContainingTypeHierarchy(StringBuilder sb, FacetTargetModel model)

--- a/src/Facet/Generators/FacetGenerators/CodeGenerationHelpers.cs
+++ b/src/Facet/Generators/FacetGenerators/CodeGenerationHelpers.cs
@@ -12,6 +12,107 @@ namespace Facet.Generators;
 internal static class CodeGenerationHelpers
 {
     /// <summary>
+    /// Collects namespaces needed only for the <c>.Properties.g.cs</c> split file.
+    /// Excludes mapping-only namespaces such as <c>System.Linq</c>,
+    /// <c>System.Linq.Expressions</c>, the source type's namespace, and the
+    /// configuration type's namespace — those are only required by the Mappings file.
+    /// </summary>
+    public static HashSet<string> CollectNamespacesForProperties(FacetTargetModel model)
+    {
+        var namespaces = new HashSet<string>();
+
+        bool hasImmutableCollections = false;
+        foreach (var member in model.Members)
+        {
+            foreach (var attrNamespace in member.AttributeNamespaces)
+                if (!string.IsNullOrWhiteSpace(attrNamespace))
+                    namespaces.Add(attrNamespace);
+
+            if (member.CollectionWrapper != null && IsImmutableCollectionWrapper(member.CollectionWrapper))
+                hasImmutableCollections = true;
+
+            if (member.IsNestedFacet || member.IsNestedType)
+                continue;
+
+            var memberTypeNamespace = ExtractNamespaceFromFullyQualifiedType(member.TypeName);
+            if (!string.IsNullOrWhiteSpace(memberTypeNamespace))
+                namespaces.Add(memberTypeNamespace!);
+        }
+
+        if (hasImmutableCollections)
+            namespaces.Add("System.Collections.Immutable");
+
+        if (!string.IsNullOrWhiteSpace(model.Namespace))
+            namespaces.Remove(model.Namespace!);
+
+        namespaces.Remove("");
+        return namespaces;
+    }
+
+    /// <summary>
+    /// Collects <c>using static</c> directives needed only for the <c>.Properties.g.cs</c>
+    /// split file. Excludes source-type containing-type entries (those are only needed by
+    /// the Mappings file for constructor parameters and projection expressions).
+    /// </summary>
+    public static HashSet<string> CollectStaticUsingTypesForProperties(FacetTargetModel model)
+    {
+        var staticUsingTypes = new HashSet<string>();
+
+        foreach (var member in model.Members)
+        {
+            if (member.IsNestedType && !member.IsNestedFacet)
+            {
+                var memberTypeName = GeneratorUtilities.StripGlobalPrefix(member.TypeName);
+
+                var genericIndex = memberTypeName.IndexOf('<');
+                if (genericIndex > 0)
+                {
+                    var genericEnd = memberTypeName.LastIndexOf('>');
+                    if (genericEnd > genericIndex)
+                        memberTypeName = GeneratorUtilities.StripGlobalPrefix(
+                            memberTypeName.Substring(genericIndex + 1, genericEnd - genericIndex - 1));
+                }
+
+                if (memberTypeName.EndsWith("?"))
+                    memberTypeName = memberTypeName.Substring(0, memberTypeName.Length - 1);
+
+                var lastDotIndex = memberTypeName.LastIndexOf('.');
+                if (lastDotIndex > 0)
+                    staticUsingTypes.Add(memberTypeName.Substring(0, lastDotIndex));
+            }
+        }
+
+        foreach (var member in model.Members)
+        {
+            if (member.IsNestedFacet)
+            {
+                var memberTypeName = GeneratorUtilities.StripGlobalPrefix(member.TypeName);
+
+                var genericIndex = memberTypeName.IndexOf('<');
+                if (genericIndex > 0)
+                    memberTypeName = memberTypeName.Substring(0, genericIndex);
+
+                if (memberTypeName.EndsWith("?"))
+                    memberTypeName = memberTypeName.Substring(0, memberTypeName.Length - 1);
+
+                var memberNamespace = ExtractNamespaceFromFullyQualifiedType(memberTypeName);
+                string typeNameWithoutNamespace = !string.IsNullOrWhiteSpace(memberNamespace)
+                    ? memberTypeName.Substring(memberNamespace.Length + 1)
+                    : memberTypeName;
+
+                if (typeNameWithoutNamespace.Contains('.'))
+                {
+                    var lastDotIndex = memberTypeName.LastIndexOf('.');
+                    if (lastDotIndex > 0)
+                        staticUsingTypes.Add(memberTypeName.Substring(0, lastDotIndex));
+                }
+            }
+        }
+
+        return staticUsingTypes;
+    }
+
+    /// <summary>
     /// Collects all namespaces that need to be imported based on the types used in the model.
     /// </summary>
     public static HashSet<string> CollectNamespaces(FacetTargetModel model)

--- a/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
+++ b/src/Facet/Generators/FacetGenerators/ModelBuilder.cs
@@ -261,6 +261,7 @@ internal static class ModelBuilder
         var baseHidesToSource = BaseHidesToSourceMembers(targetSymbol);
 
         var sourcePropertyNames = CollectSourcePropertyNames(sourceType);
+        var declaredBaseTypeNames = GetDeclaredBaseTypeNames(targetSymbol, generateEquality);
 
         return new FacetTargetModel(
             targetSymbol.Name,
@@ -304,7 +305,8 @@ internal static class ModelBuilder
             maxDepthToSource,
             sourcePropertyNames,
             baseHidesToSource,
-            setAccessor);
+            setAccessor,
+            declaredBaseTypeNames);
     }
 
     #region Private Helper Methods
@@ -1444,6 +1446,34 @@ private static Dictionary<string, (string targetName, string source, bool revers
             current = current.BaseType;
         }
         return names.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Returns fully-qualified names (with <c>global::</c>) of the user-declared base class
+    /// and interfaces on <paramref name="targetSymbol"/>. Used to preserve the type's
+    /// inheritance chain in the <c>.Properties.g.cs</c> split file.
+    /// <para>
+    /// <c>IEquatable&lt;T&gt;</c> is excluded when <paramref name="generateEquality"/> is
+    /// <see langword="true"/> because Facet emits that interface itself on the Mappings partial.
+    /// </para>
+    /// </summary>
+    private static ImmutableArray<string> GetDeclaredBaseTypeNames(INamedTypeSymbol targetSymbol, bool generateEquality)
+    {
+        var result = ImmutableArray.CreateBuilder<string>();
+
+        if (targetSymbol.BaseType is { SpecialType: not SpecialType.System_Object and not SpecialType.System_ValueType })
+            result.Add(targetSymbol.BaseType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+
+        foreach (var iface in targetSymbol.Interfaces)
+        {
+            if (generateEquality &&
+                iface.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.IEquatable<T>")
+                continue;
+
+            result.Add(iface.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        }
+
+        return result.ToImmutable();
     }
 
     #endregion

--- a/test/Facet.Tests/UnitTests/Features/SplitOutputTests.cs
+++ b/test/Facet.Tests/UnitTests/Features/SplitOutputTests.cs
@@ -10,8 +10,18 @@ public class SplitOutputEntity
     public string Description { get; set; } = string.Empty;
 }
 
+public interface ISplitOutputMarker { }
+
+public abstract class SplitOutputBase
+{
+    public string BaseProp { get; set; } = string.Empty;
+}
+
 [Facet(typeof(SplitOutputEntity))]
 public partial class SplitOutputDto;
+
+[Facet(typeof(SplitOutputEntity))]
+public partial class SplitOutputWithInheritanceDto : SplitOutputBase, ISplitOutputMarker;
 
 public class SplitOutputTests
 {
@@ -85,6 +95,52 @@ public class SplitOutputTests
 
         File.Exists(combinedFile).Should().BeFalse(
             "SplitOutput = true should not emit a combined .g.cs file");
+    }
+
+    [Fact]
+    public void SplitOutput_PropertiesFile_NoMappingUsings()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var propsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputDto.Properties.g.cs");
+
+        if (!File.Exists(propsFile))
+            return;
+
+        var content = File.ReadAllText(propsFile);
+
+        content.Should().NotContain("using System.Linq;");
+        content.Should().NotContain("using System.Linq.Expressions;");
+    }
+
+    [Fact]
+    public void SplitOutput_PropertiesFile_ContainsInheritance()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var propsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputWithInheritanceDto.Properties.g.cs");
+
+        if (!File.Exists(propsFile))
+            return;
+
+        var content = File.ReadAllText(propsFile);
+
+        content.Should().Contain("SplitOutputBase");
+        content.Should().Contain("ISplitOutputMarker");
+    }
+
+    [Fact]
+    public void SplitOutput_MappingsFile_NoInheritanceFromProperties()
+    {
+        var generatedDir = GetGeneratedFilesDir();
+        var mapsFile = Path.Combine(generatedDir, "Facet.Tests.UnitTests.Features.SplitOutputWithInheritanceDto.Mappings.g.cs");
+
+        if (!File.Exists(mapsFile))
+            return;
+
+        var content = File.ReadAllText(mapsFile);
+
+        // Base class and interface are in Properties file only
+        content.Should().NotContain("SplitOutputBase");
+        content.Should().NotContain("ISplitOutputMarker");
     }
 
     private static string GetGeneratedFilesDir()


### PR DESCRIPTION
Properties.g.cs now has no System.Linq, System.Linq.Expressions, or EF namespace. Only member/attribute-needed usings remain.
Properties.g.cs now includes the base class in the class declaration.

No EF/mapping references bleed in
