### PR TITLE
feat: JSON Merge Patch (RFC 7396) wire format for Patch DTOs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
 
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+		<PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
 

--- a/docs/09_GenerateDtosAttribute.md
+++ b/docs/09_GenerateDtosAttribute.md
@@ -476,6 +476,28 @@ Patch DTOs are designed for HTTP PATCH scenarios where you need to update only s
 2. **Explicitly Null** - Property should be set to null
 3. **Has Value** - Property should be updated to the specified value
 
+### Wire format: JSON Merge Patch (RFC 7396)
+
+The generator gives Patch DTOs merge-patch wire semantics automatically, for **both** JSON stacks — each gated on the consuming compilation actually referencing it, so projects without either still compile:
+
+- **System.Text.Json**: a `[JsonConverter]` + `[JsonIgnore(WhenWritingDefault)]` pair on every generated property, plus an internal converter factory generated into the consuming assembly.
+- **Newtonsoft.Json**: a `[JsonConverter]` + `[JsonProperty(DefaultValueHandling = Ignore)]` pair, plus an internal Json.NET converter — because ASP.NET Core apps using `AddNewtonsoftJson` bind MVC request bodies through Json.NET, where System.Text.Json attributes are invisible.
+
+Both serializers honor per-property converter attributes, so **no serializer or MVC startup registration is needed** — the DTOs are self-describing. Facet.Attributes takes no package dependency on either library (the converters are generated, the same trick strongly-typed-ID libraries use).
+
+| JSON payload | `Optional<T>` state | Effect of `ApplyTo` |
+|---|---|---|
+| property absent | Unspecified (`HasValue == false`) | not touched |
+| `"email": null` (nullable target) | Specified null | set to `null` |
+| `"isActive": null` (non-nullable value type) | — | `JsonException` → HTTP 400 in ASP.NET Core |
+| `"name": "x"` | Specified value | set to `"x"` |
+
+The mechanics: System.Text.Json never invokes a converter for an **absent** property — the field keeps `default(Optional<T>)`, i.e. unspecified. A **present** property always routes through the converter and becomes specified, including explicit null. Serialization skips unspecified properties, so a round-trip never clobbers fields the sender didn't mention.
+
+**Typed clients**: in TypeScript, `undefined` is the "don't touch" value — `JSON.stringify` omits `undefined`-valued keys entirely, so a client type of `email?: string | null` expresses all three states with no sentinel values.
+
+**Known limitation**: nullable-reference annotations are erased at runtime, so an explicit null into `Optional<string>` (non-nullable reference) deserializes as a specified null rather than failing — only non-nullable *value types* get the automatic 400. Validate reference-type nulls server-side where it matters.
+
 ### Usage Example
 
 ```csharp

--- a/src/Facet/GenerateDtosTargetModel.cs
+++ b/src/Facet/GenerateDtosTargetModel.cs
@@ -48,6 +48,18 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
     /// mask for the message.
     /// </summary>
     public OutputTypeIssue Issue { get; }
+    /// <summary>
+    /// Whether the consuming compilation references System.Text.Json. Gates emission of
+    /// the Optional&lt;T&gt; wire-format attributes and converter on Patch DTOs so projects
+    /// without STJ still compile.
+    /// </summary>
+    public bool SupportsSystemTextJson { get; }
+    /// <summary>
+    /// Whether the consuming compilation references Newtonsoft.Json. Gates emission of the
+    /// Json.NET counterpart attributes and converter on Patch DTOs (e.g. for ASP.NET Core
+    /// apps using AddNewtonsoftJson, whose MVC body binding bypasses System.Text.Json).
+    /// </summary>
+    public bool SupportsNewtonsoftJson { get; }
 
     public GenerateDtosTargetModel(
         string sourceTypeName,
@@ -65,7 +77,9 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
         ImmutableArray<FacetMember> members,
         bool useFullName,
         DtoTypes siblingInterfaceTypes = DtoTypes.None,
-        OutputTypeIssue issue = OutputTypeIssue.None)
+        OutputTypeIssue issue = OutputTypeIssue.None,
+        bool supportsSystemTextJson = false,
+        bool supportsNewtonsoftJson = false)
     {
         SourceTypeName = sourceTypeName;
         SourceNamespace = sourceNamespace;
@@ -83,6 +97,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
         UseFullName = useFullName;
         SiblingInterfaceTypes = siblingInterfaceTypes;
         Issue = issue;
+        SupportsSystemTextJson = supportsSystemTextJson;
+        SupportsNewtonsoftJson = supportsNewtonsoftJson;
     }
 
     /// <summary>
@@ -106,7 +122,10 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             ExcludeProperties,
             Members,
             UseFullName,
-            SiblingInterfaceTypes);
+            SiblingInterfaceTypes,
+            Issue,
+            SupportsSystemTextJson,
+            SupportsNewtonsoftJson);
     }
 
     /// <summary>
@@ -131,7 +150,9 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             Members,
             UseFullName,
             SiblingInterfaceTypes,
-            issue);
+            issue,
+            SupportsSystemTextJson,
+            SupportsNewtonsoftJson);
     }
 
     public bool Equals(GenerateDtosTargetModel? other)
@@ -154,7 +175,9 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             && Members.SequenceEqual(other.Members)
             && UseFullName == other.UseFullName
             && SiblingInterfaceTypes == other.SiblingInterfaceTypes
-            && Issue == other.Issue;
+            && Issue == other.Issue
+            && SupportsSystemTextJson == other.SupportsSystemTextJson
+            && SupportsNewtonsoftJson == other.SupportsNewtonsoftJson;
     }
 
     public override bool Equals(object? obj) => obj is GenerateDtosTargetModel other && Equals(other);
@@ -178,6 +201,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             hash = hash * 31 + UseFullName.GetHashCode();
             hash = hash * 31 + SiblingInterfaceTypes.GetHashCode();
             hash = hash * 31 + Issue.GetHashCode();
+            hash = hash * 31 + SupportsSystemTextJson.GetHashCode();
+            hash = hash * 31 + SupportsNewtonsoftJson.GetHashCode();
 
             foreach (var prop in ExcludeProperties)
                 hash = hash * 31 + prop.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
@@ -91,9 +91,28 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
 
         context.RegisterSourceOutput(allTargets, (spc, models) =>
         {
-            foreach (var model in models)
+            var modelList = models.Where(m => m != null).Cast<GenerateDtosTargetModel>().ToList();
+
+            // The Optional<T> JSON converter is generated (not shipped in Facet.Attributes)
+            // so Facet adds no System.Text.Json package dependency; emit it once per
+            // compilation when any Patch DTO needs it.
+            bool NeedsPatchWireSupport(GenerateDtosTargetModel m) =>
+                m.Issue == OutputTypeIssue.None
+                && (m.Types & DtoTypes.Patch) != 0
+                && GetKind(m.OutputType) != OutputType.Interface;
+
+            if (modelList.Any(m => NeedsPatchWireSupport(m) && m.SupportsSystemTextJson))
             {
-                if (model != null)
+                spc.AddSource("FacetOptionalJsonSupport.g.cs", SourceText.From(OptionalJsonSupportSource, Encoding.UTF8));
+            }
+
+            if (modelList.Any(m => NeedsPatchWireSupport(m) && m.SupportsNewtonsoftJson))
+            {
+                spc.AddSource("FacetOptionalNewtonsoftJsonSupport.g.cs", SourceText.From(OptionalNewtonsoftJsonSupportSource, Encoding.UTF8));
+            }
+
+            foreach (var model in modelList)
+            {
                 {
                     spc.CancellationToken.ThrowIfCancellationRequested();
 
@@ -130,7 +149,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         token.ThrowIfCancellationRequested();
         if (context.TargetSymbol is not INamedTypeSymbol sourceSymbol) return null;
 
-        return BuildModels(context.Attributes, _ => sourceSymbol, forceExcludeAuditFields, token);
+        return BuildModels(context.Attributes, _ => sourceSymbol, context.SemanticModel.Compilation, forceExcludeAuditFields, token);
     }
 
     /// <summary>
@@ -149,6 +168,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             static attr => attr.ConstructorArguments.Length == 1
                 ? attr.ConstructorArguments[0].Value as INamedTypeSymbol
                 : null,
+            context.SemanticModel.Compilation,
             forceExcludeAuditFields: false,
             token);
     }
@@ -156,6 +176,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
     private static IEnumerable<GenerateDtosTargetModel>? BuildModels(
         ImmutableArray<AttributeData> attributes,
         Func<AttributeData, INamedTypeSymbol?> sourceSelector,
+        Compilation compilation,
         bool forceExcludeAuditFields,
         CancellationToken token)
     {
@@ -169,7 +190,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
 
             if (sourceSelector(attribute) is not INamedTypeSymbol sourceSymbol) continue;
 
-            var model = GetDtosModel(attribute, sourceSymbol, forceExcludeAuditFields, token);
+            var model = GetDtosModel(attribute, sourceSymbol, compilation, forceExcludeAuditFields, token);
             if (model == null) continue;
 
             // OutputType is a [Flags] value: kind bits (Class/Record/Struct/RecordStruct/
@@ -251,13 +272,16 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
                 model.ExcludeProperties,
                 model.Members,
                 model.UseFullName,
-                siblingMask);
+                siblingMask,
+                model.Issue,
+                model.SupportsSystemTextJson,
+                model.SupportsNewtonsoftJson);
         }
 
         return models;
     }
 
-    private static GenerateDtosTargetModel? GetDtosModel(AttributeData attribute, INamedTypeSymbol sourceSymbol, bool forceExcludeAuditFields, CancellationToken token)
+    private static GenerateDtosTargetModel? GetDtosModel(AttributeData attribute, INamedTypeSymbol sourceSymbol, Compilation compilation, bool forceExcludeAuditFields, CancellationToken token)
     {
         token.ThrowIfCancellationRequested();
 
@@ -275,6 +299,10 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             var convertEnumsTo = ExtractConvertEnumsTo(attribute.NamedArguments);
             
             var excludeAuditFields = forceExcludeAuditFields || GetNamedArg(attribute.NamedArguments, "ExcludeAuditFields", false);
+            var supportsSystemTextJson = compilation
+                .GetTypeByMetadataName("System.Text.Json.Serialization.JsonConverterAttribute") is not null;
+            var supportsNewtonsoftJson = compilation
+                .GetTypeByMetadataName("Newtonsoft.Json.JsonConverterAttribute") is not null;
 
             var userExcludeProperties = new List<string>();
             var excludePropertiesArg = attribute.NamedArguments.FirstOrDefault(kvp => kvp.Key == "ExcludeProperties");
@@ -355,7 +383,9 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
                 convertEnumsTo,
                 excludeProperties.ToImmutableArray(),
                 members.ToImmutableArray(),
-                useFullName);
+                useFullName,
+                supportsSystemTextJson: supportsSystemTextJson,
+                supportsNewtonsoftJson: supportsNewtonsoftJson);
         }
         catch (Exception ex)
         {
@@ -902,6 +932,21 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             if (member.Kind == FacetMemberKind.Property)
             {
                 sb.AppendLine($"    /// <summary>Optional value for {member.Name}.</summary>");
+                // RFC 7396 (JSON Merge Patch) wire semantics: an absent property never
+                // reaches a converter, so the Optional stays unspecified; an explicit
+                // null becomes a specified null (or a 400 for non-nullable value types).
+                // Unspecified values are skipped when serializing. Both serializers honor
+                // per-property converter attributes, so no startup registration is needed.
+                if (model.SupportsSystemTextJson)
+                {
+                    sb.AppendLine($"    [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Facet.Generated.OptionalJsonConverterFactory))]");
+                    sb.AppendLine($"    [global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]");
+                }
+                if (model.SupportsNewtonsoftJson)
+                {
+                    sb.AppendLine($"    [global::Newtonsoft.Json.JsonConverter(typeof(global::Facet.Generated.OptionalNewtonsoftJsonConverter))]");
+                    sb.AppendLine($"    [global::Newtonsoft.Json.JsonProperty(DefaultValueHandling = global::Newtonsoft.Json.DefaultValueHandling.Ignore)]");
+                }
                 sb.AppendLine($"    public global::Facet.Optional<{member.TypeName}> {member.Name} {{ get; set; }}");
             }
         }
@@ -1301,6 +1346,146 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
 
     /// <summary>Whether the <see cref="OutputType.Partial"/> modifier is set.</summary>
     private static bool IsPartial(OutputType value) => (value & OutputType.Partial) != 0;
+
+    /// <summary>
+    /// Generated System.Text.Json support for <c>Facet.Optional&lt;T&gt;</c> giving Patch DTOs
+    /// RFC 7396 (JSON Merge Patch) wire semantics. Generated into the consuming assembly —
+    /// like strongly-typed-ID libraries do for their converters — so Facet.Attributes takes
+    /// no System.Text.Json package dependency.
+    /// </summary>
+    private const string OptionalJsonSupportSource = """
+// <auto-generated>
+//     This code was generated by the Facet GenerateDtos source generator.
+//     Changes to this file may cause incorrect behavior and will be lost if
+//     the code is regenerated.
+// </auto-generated>
+
+#nullable enable
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Facet.Generated;
+
+/// <summary>
+/// Creates converters giving <see cref="global::Facet.Optional{T}"/> JSON Merge Patch
+/// (RFC 7396) semantics: an absent property stays unspecified, an explicit null becomes
+/// a specified null (or a JsonException — surfaced by ASP.NET Core as HTTP 400 — for
+/// non-nullable value types), and a value becomes a specified value.
+/// </summary>
+internal sealed class OptionalJsonConverterFactory : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert)
+        => typeToConvert.IsGenericType
+           && typeToConvert.GetGenericTypeDefinition() == typeof(global::Facet.Optional<>);
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var valueType = typeToConvert.GetGenericArguments()[0];
+        return (JsonConverter)Activator.CreateInstance(
+            typeof(OptionalJsonConverter<>).MakeGenericType(valueType))!;
+    }
+}
+
+internal sealed class OptionalJsonConverter<T> : JsonConverter<global::Facet.Optional<T>>
+{
+    // A null token must reach Read so it can become a *specified* null; without this,
+    // System.Text.Json would reject null for the non-nullable Optional<T> struct itself.
+    public override bool HandleNull => true;
+
+    public override global::Facet.Optional<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        // An absent property never invokes a converter — the field keeps
+        // default(Optional<T>), i.e. unspecified. Reaching this method means the
+        // property was present, so the result is always specified. Null into a
+        // non-nullable value type throws JsonException here.
+        var value = JsonSerializer.Deserialize<T>(ref reader, options);
+        return new global::Facet.Optional<T>(value!);
+    }
+
+    public override void Write(Utf8JsonWriter writer, global::Facet.Optional<T> value, JsonSerializerOptions options)
+    {
+        // Unspecified values are normally skipped via [JsonIgnore(WhenWritingDefault)]
+        // on the generated properties; if one is serialized directly anyway, null is
+        // the closest wire representation.
+        if (!value.HasValue)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        JsonSerializer.Serialize(writer, value.Value, options);
+    }
+}
+""";
+
+    /// <summary>
+    /// Generated Newtonsoft.Json support for <c>Facet.Optional&lt;T&gt;</c> — the Json.NET
+    /// counterpart of <see cref="OptionalJsonSupportSource"/>, for apps whose MVC pipeline
+    /// binds bodies through Json.NET (AddNewtonsoftJson). Json.NET honors per-property
+    /// [JsonConverter] attributes, so no serializer registration is needed.
+    /// </summary>
+    private const string OptionalNewtonsoftJsonSupportSource = """
+// <auto-generated>
+//     This code was generated by the Facet GenerateDtos source generator.
+//     Changes to this file may cause incorrect behavior and will be lost if
+//     the code is regenerated.
+// </auto-generated>
+
+#nullable enable
+
+using System;
+using Newtonsoft.Json;
+
+namespace Facet.Generated;
+
+/// <summary>
+/// Gives <see cref="global::Facet.Optional{T}"/> JSON Merge Patch (RFC 7396) semantics
+/// under Newtonsoft.Json: an absent property never invokes a converter (the field keeps
+/// default(Optional&lt;T&gt;), i.e. unspecified); an explicit null becomes a specified null,
+/// or a JsonSerializationException — surfaced by ASP.NET Core as HTTP 400 — for
+/// non-nullable value types.
+/// </summary>
+internal sealed class OptionalNewtonsoftJsonConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+        => objectType.IsGenericType
+           && objectType.GetGenericTypeDefinition() == typeof(global::Facet.Optional<>);
+
+    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        var valueType = objectType.GetGenericArguments()[0];
+
+        if (reader.TokenType == JsonToken.Null
+            && valueType.IsValueType
+            && Nullable.GetUnderlyingType(valueType) == null)
+        {
+            throw new JsonSerializationException(
+                $"Cannot convert null to non-nullable {valueType.Name}. Omit the property to leave the value unchanged.");
+        }
+
+        var value = reader.TokenType == JsonToken.Null ? null : serializer.Deserialize(reader, valueType);
+        return Activator.CreateInstance(objectType, value)!;
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        // Unspecified values are normally skipped via [JsonProperty(DefaultValueHandling =
+        // Ignore)] on the generated properties; if one is serialized directly anyway, null
+        // is the closest wire representation.
+        var hasValue = value is not null
+            && (bool)value.GetType().GetProperty("HasValue")!.GetValue(value)!;
+        if (!hasValue)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        serializer.Serialize(writer, value!.GetType().GetProperty("Value")!.GetValue(value));
+    }
+}
+""";
 
     /// <summary>
     /// Splits a [Flags] <see cref="OutputType"/> value into its individual output kinds,

--- a/test/Facet.Tests/Facet.Tests.csproj
+++ b/test/Facet.Tests/Facet.Tests.csproj
@@ -21,6 +21,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>

--- a/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPatchNewtonsoftWireFormatTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPatchNewtonsoftWireFormatTests.cs
@@ -1,0 +1,64 @@
+using Facet.Tests.TestModels;
+using Newtonsoft.Json;
+
+namespace Facet.Tests.UnitTests.Core.GenerateDtos;
+
+/// <summary>
+/// The Json.NET counterpart of <see cref="GenerateDtosPatchWireFormatTests"/>: apps using
+/// ASP.NET Core's AddNewtonsoftJson bind request bodies through Json.NET, so Patch DTOs
+/// carry Newtonsoft attributes too. All calls here use plain JsonConvert with NO settings —
+/// the per-property attributes are the whole registration story.
+/// </summary>
+public class GenerateDtosPatchNewtonsoftWireFormatTests
+{
+    [Fact]
+    public void AbsentProperties_DeserializeAsUnspecified()
+    {
+        var patch = JsonConvert.DeserializeObject<PatchTestEntityPatch>("{}")!;
+
+        patch.Name.HasValue.Should().BeFalse();
+        patch.Email.HasValue.Should().BeFalse();
+        patch.IsActive.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExplicitNull_OnNullableProperty_IsASpecifiedNull()
+    {
+        var patch = JsonConvert.DeserializeObject<PatchTestEntityPatch>("""{"Email":null}""")!;
+
+        patch.Email.HasValue.Should().BeTrue();
+        patch.Email.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExplicitNull_OnNonNullableValueType_Throws()
+    {
+        var act = () => JsonConvert.DeserializeObject<PatchTestEntityPatch>("""{"IsActive":null}""");
+
+        act.Should().Throw<JsonSerializationException>();
+    }
+
+    [Fact]
+    public void PresentValue_IsSpecified()
+    {
+        var patch = JsonConvert.DeserializeObject<PatchTestEntityPatch>("""{"Name":"renamed"}""")!;
+
+        patch.Name.HasValue.Should().BeTrue();
+        patch.Name.Value.Should().Be("renamed");
+        patch.Email.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Serialization_SkipsUnspecifiedProperties()
+    {
+        var patch = new PatchTestEntityPatch
+        {
+            Name = new Optional<string>("renamed"),
+        };
+
+        var json = JsonConvert.SerializeObject(patch);
+
+        json.Should().Be("""{"Name":"renamed"}""",
+            "unspecified properties must not appear on the wire, or a round-trip would clobber them");
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPatchWireFormatTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosPatchWireFormatTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using Facet.Tests.TestModels;
+
+namespace Facet.Tests.UnitTests.Core.GenerateDtos;
+
+/// <summary>
+/// Tests for the generated System.Text.Json wire format of Patch DTOs: RFC 7396
+/// (JSON Merge Patch) semantics via <see cref="Optional{T}"/> — an absent property is
+/// unspecified ("don't touch"), an explicit null is a specified null ("set to null",
+/// rejected for non-nullable value types), and a value is a specified value.
+/// </summary>
+public class GenerateDtosPatchWireFormatTests
+{
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void AbsentProperties_DeserializeAsUnspecified_AndApplyToTouchesNothing()
+    {
+        var patch = JsonSerializer.Deserialize<PatchTestEntityPatch>("{}", Web)!;
+
+        patch.Name.HasValue.Should().BeFalse();
+        patch.Email.HasValue.Should().BeFalse();
+        patch.IsActive.HasValue.Should().BeFalse();
+
+        var entity = new PatchTestEntity { Id = 1, Name = "original", Email = "a@b.c", IsActive = true, Price = 9.99m };
+        patch.ApplyTo(entity);
+
+        entity.Name.Should().Be("original");
+        entity.Email.Should().Be("a@b.c");
+        entity.IsActive.Should().BeTrue();
+        entity.Price.Should().Be(9.99m);
+    }
+
+    [Fact]
+    public void ExplicitNull_OnNullableProperty_IsASpecifiedNull()
+    {
+        var patch = JsonSerializer.Deserialize<PatchTestEntityPatch>("""{"email":null}""", Web)!;
+
+        patch.Email.HasValue.Should().BeTrue("null was explicitly sent — that is 'set to null', not 'don't touch'");
+        patch.Email.Value.Should().BeNull();
+
+        var entity = new PatchTestEntity { Email = "a@b.c" };
+        patch.ApplyTo(entity);
+        entity.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExplicitNull_OnNonNullableValueType_ThrowsJsonException()
+    {
+        // ASP.NET Core surfaces this as an HTTP 400 — "null into a non-nullable
+        // property errors" instead of being silently reinterpreted.
+        var act = () => JsonSerializer.Deserialize<PatchTestEntityPatch>("""{"isActive":null}""", Web);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void PresentValue_IsSpecified_AndApplyToSetsOnlyThat()
+    {
+        var patch = JsonSerializer.Deserialize<PatchTestEntityPatch>("""{"name":"renamed"}""", Web)!;
+
+        patch.Name.HasValue.Should().BeTrue();
+        patch.Name.Value.Should().Be("renamed");
+
+        var entity = new PatchTestEntity { Name = "original", Email = "keep@me.com", IsActive = true };
+        patch.ApplyTo(entity);
+
+        entity.Name.Should().Be("renamed");
+        entity.Email.Should().Be("keep@me.com");
+        entity.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Serialization_SkipsUnspecifiedProperties()
+    {
+        var patch = new PatchTestEntityPatch
+        {
+            Name = new Optional<string>("renamed"),
+        };
+
+        var json = JsonSerializer.Serialize(patch, Web);
+
+        json.Should().Be("""{"name":"renamed"}""",
+            "unspecified properties must not appear on the wire, or a round-trip would clobber them");
+    }
+
+    [Fact]
+    public void Serialization_WritesSpecifiedNull()
+    {
+        var patch = new PatchTestEntityPatch
+        {
+            Email = new Optional<string?>(null),
+        };
+
+        var json = JsonSerializer.Serialize(patch, Web);
+
+        json.Should().Be("""{"email":null}""");
+    }
+}


### PR DESCRIPTION
## Problem

`DtoTypes.Patch` already models tri-state updates in the object model — `Optional<T>` distinguishes *unspecified* / *specified null* / *specified value*, and `ApplyTo` only writes specified properties. But there was no wire story: JSON serializers bind an **absent** property and an **explicit null** identically, so the tri-state died at the HTTP boundary and consumers had to hand-roll "null means don't touch" conventions — which conflate *omit this field* with *clear this field* and make real NULL unrepresentable.

## Solution

Give Patch DTOs **JSON Merge Patch (RFC 7396)** semantics automatically:

| JSON payload | `Optional<T>` state | Effect of `ApplyTo` |
|---|---|---|
| property absent | Unspecified | not touched |
| `"email": null` (nullable target) | Specified null | set to `null` |
| `"isActive": null` (non-nullable value type) | — | deserialization error → HTTP 400 in ASP.NET Core |
| `"name": "x"` | Specified value | set to `"x"` |

The mechanics ride on a guarantee both serializers share: **a converter is never invoked for an absent property** — the field keeps `default(Optional<T>)`, i.e. unspecified. A present property always routes through the converter and becomes specified. Serialization skips unspecified properties, so round-trips never clobber unmentioned fields.

## Both JSON stacks, no registration

Per-property converter attributes are honored by System.Text.Json **and** Newtonsoft.Json, so the generated DTOs are fully self-describing — no serializer options, no MVC startup wiring:

- **System.Text.Json**: `[JsonConverter]` + `[JsonIgnore(WhenWritingDefault)]` per property, plus a generated internal converter factory.
- **Newtonsoft.Json**: `[JsonConverter]` + `[JsonProperty(DefaultValueHandling = Ignore)]` per property, plus a generated internal Json.NET converter. This matters in practice: ASP.NET Core apps using `AddNewtonsoftJson` bind MVC request bodies through Json.NET, where STJ attributes are invisible — validated against a large real-world consumer codebase that binds exactly this way.

Each stack is gated on the consuming compilation actually referencing it, and the converters are **generated into the consuming assembly** (the approach strongly-typed-ID libraries use) — `Facet.Attributes` takes no package dependency on either JSON library, and projects referencing neither still compile.

## Typed clients

In TypeScript, `undefined` is the natural "don't touch" value — `JSON.stringify` omits `undefined`-valued keys entirely — so a client type of `email?: string | null` expresses all three states with no sentinels.

## Known limitation (documented)

Nullable-reference annotations are erased at runtime, so an explicit null into `Optional<string>` (non-nullable reference) deserializes as a specified null rather than failing — only non-nullable *value types* get the automatic 400. Validate reference-type nulls server-side where it matters.

## Tests

11 new runtime facts: all four wire states, `ApplyTo` interaction, and serialization skipping/emitting — under System.Text.Json (6) and plain no-settings `JsonConvert` (5, proving the attributes are the whole registration story). Full suite: 919/919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
