### PR TITLE
feat: assembly-level [GenerateDtosFor] for cross-assembly DTO generation

### DIFF
--- a/docs/09_GenerateDtosAttribute.md
+++ b/docs/09_GenerateDtosAttribute.md
@@ -311,36 +311,53 @@ If you don't need extensibility, prefer `OutputType.Class` — it also emits `Pr
 
 ## Assembly-level generation: `[GenerateDtosFor]`
 
-A source generator can only emit code into the compilation it runs in, so `[GenerateDtos]` on an entity pins the generated DTOs to the **entity's assembly** — even when the `Namespace` option names a downstream layer, the types physically live upstream and the namespace is a cross-assembly fiction. When your architecture wants contract types genuinely **downstream** of the domain — a web-contracts project referencing the domain, with the domain kept free of generated request/response types — use the assembly-level counterpart in the project where the DTOs should live:
+A source generator can only emit code into the compilation it runs in, so `[GenerateDtos]` on an entity pins the generated DTOs to the **entity's assembly** — even when the `Namespace` option names a downstream layer, the types physically live upstream and the namespace is a cross-assembly fiction. The assembly-level counterpart puts the Request/Response types where most solutions actually want them: **in the Web project, next to the controllers that bind them** — where a Request can hydrate itself from the `DbContext`, and a Response can be enriched with in-memory application state that was never persisted to the database.
+
+A typical layered solution, with references flowing toward the domain:
+
+```text
+MyApp.Domain          Schedule, Order — plain entity classes.
+                      References nothing below. No Facet attributes needed here.
+
+MyApp.Persistence     AppDbContext + migrations.
+                      References: MyApp.Domain
+
+MyApp.Web             Controllers + the request/response DTOs.
+                      References: MyApp.Persistence (and therefore MyApp.Domain)
+                      → [assembly: GenerateDtosFor(...)] is declared HERE,
+                        and the DTOs are generated HERE.
+```
+
+(Substitute a dedicated contracts project for `MyApp.Web` if you keep wire types separate — the rule is simply: declare the attribute in the project where the DTOs should live.)
 
 ```csharp
-// In MyApp.Contracts (which references MyApp.Domain):
+// In MyApp.Web:
 [assembly: GenerateDtosFor(typeof(Schedule),
     Types = DtoTypes.Create | DtoTypes.Update,
     OutputType = OutputType.Interface | OutputType.Record | OutputType.Partial,
-    Namespace = "MyApp.Contracts.V1.Requests")]
+    Namespace = "MyApp.Web.Contracts.V1.Requests")]
 ```
 
 The source entity is read as metadata from the referenced assembly and needs no attribute of its own. All `[GenerateDtos]` options apply, including flags-combined `OutputType`, the `Partial` modifier, and FAC101/FAC102 validation. Declare one `[assembly: GenerateDtosFor(...)]` per entity; interface/concrete sibling pairing links outputs **per source entity** — two entities registered in the same assembly never cross-pair.
 
 ### What moving the declaration downstream changes
 
-- **The dependency arrow points the right way.** The contracts project references the domain, and the domain knows nothing about contracts: no `[GenerateDtos]` attributes on entity classes, no downstream namespace strings in domain files. If no other Facet attributes remain there, the domain project can drop the generator reference entirely — generation then runs in the (typically much smaller) contracts compilation instead of your largest project.
+- **The dependency arrow points the right way.** The Web project references the domain, and entity classes stay plain C#: no `[GenerateDtos]` attributes, no downstream namespace strings. If no other Facet attributes remain in the domain project, it can drop the generator reference entirely — generation then runs in the (typically much smaller) Web compilation instead of your largest project.
 - **Types land in the assembly that owns their namespace.** Anything that discovers types by *assembly* — OpenAPI generators, TypeScript exporters, reflection-based registration, `InternalsVisibleTo` — sees the generated DTOs exactly where hand-written ones would have been. Replacing a hand-written contract with a generated one becomes a true drop-in: same assembly, same namespace, same name.
-- **Each layer declares its own shapes.** Several downstream assemblies can independently register DTOs for the same entity (a web project's request bodies, an application layer's command payloads) without the entity accumulating one attribute per consumer.
+- **Each layer declares its own shapes.** Several downstream assemblies can independently register DTOs for the same entity (the Web project's request bodies, an application layer's command payloads) without the entity accumulating one attribute per consumer.
 
 ### Partial halves gain the downstream dependency graph
 
-This is the quiet superpower of combining `GenerateDtosFor` with the `Partial` modifier. A `partial` type must be completed within a single assembly, so a hand-written half is forced into whichever assembly the generated half lives in. With the class-level attribute that means the **entity's** assembly — which, in a layered application, cannot reference your `DbContext`, repositories, or service interfaces (the persistence layer references the domain, never the reverse). Members that need those types simply cannot be written there.
+This is the quiet superpower of combining `GenerateDtosFor` with the `Partial` modifier. A `partial` type must be completed within a single assembly, so a hand-written half lives in whichever assembly the generated half lives in. With the class-level attribute that means the **entity's** assembly — which, in the hierarchy above, cannot reference `AppDbContext`, repositories, or Web services (references flow toward the domain, never away from it). Members that need those types simply cannot be written there.
 
-Declared downstream, the generated half compiles into the contracts project — and the hand-written half beside it can use everything that project references:
+Declared in the Web project, the generated half compiles there — and the hand-written half beside it can use everything the Web project references, in both directions of hydration:
 
 ```csharp
-// MyApp.Contracts — same assembly as the generated partial half
+// MyApp.Web — same assembly as the generated partial halves
+
 public partial record UpdateScheduleRequest : IValidatableObject
 {
-    // Hydration against the real database — impossible in the domain assembly,
-    // which cannot reference AppDbContext:
+    // Request → entity: hydrate from the real database.
     public async Task<Schedule> ApplyAsync(AppDbContext db, CancellationToken ct)
     {
         var schedule = await db.Schedules.FirstAsync(s => s.Id == Id, ct);
@@ -355,9 +372,19 @@ public partial record UpdateScheduleRequest : IValidatableObject
             yield return new ValidationResult("Start must precede end.", [nameof(StartAt)]);
     }
 }
+
+public partial record GetScheduleResponse
+{
+    // Response ← runtime: enrich with in-memory state that is not persisted in
+    // the database — a running-job tracker, a cache, a hub connection count.
+    public bool IsRunningNow { get; private set; }
+
+    public void Hydrate(IScheduleRunner runner)
+        => IsRunningNow = runner.IsRunning(Id);
+}
 ```
 
-Extension methods in a downstream layer were always possible; what same-assembly partials add is members **on the type itself** — instance methods and async factories that take a `DbContext` or services as parameters, computed properties over downstream types, interface implementations (`IValidatableObject` and friends, which extension methods can never provide), and attributes applied to the type through the partial half.
+Extension methods in a downstream layer were always possible; what same-assembly partials add is members **on the type itself** — instance methods and async factories that take a `DbContext` or services as parameters, extra properties fed from runtime state, interface implementations (`IValidatableObject` and friends, which extension methods can never provide), and attributes applied to the type through the partial half.
 
 ## Excluding Audit Fields
 

--- a/docs/09_GenerateDtosAttribute.md
+++ b/docs/09_GenerateDtosAttribute.md
@@ -311,19 +311,53 @@ If you don't need extensibility, prefer `OutputType.Class` — it also emits `Pr
 
 ## Assembly-level generation: `[GenerateDtosFor]`
 
-`[GenerateDtos]` sits on the entity, so the DTOs compile into the entity's assembly. When your architecture wants contract types **downstream** of the domain — a web-contracts project referencing the domain, with the domain kept free of generated request/response types — use the assembly-level counterpart in the project where the DTOs should live:
+A source generator can only emit code into the compilation it runs in, so `[GenerateDtos]` on an entity pins the generated DTOs to the **entity's assembly** — even when the `Namespace` option names a downstream layer, the types physically live upstream and the namespace is a cross-assembly fiction. When your architecture wants contract types genuinely **downstream** of the domain — a web-contracts project referencing the domain, with the domain kept free of generated request/response types — use the assembly-level counterpart in the project where the DTOs should live:
 
 ```csharp
-// In the contracts project (references the domain project):
+// In MyApp.Contracts (which references MyApp.Domain):
 [assembly: GenerateDtosFor(typeof(Schedule),
     Types = DtoTypes.Create | DtoTypes.Update,
     OutputType = OutputType.Interface | OutputType.Record | OutputType.Partial,
-    Namespace = "My.Contracts.V1.Requests")]
+    Namespace = "MyApp.Contracts.V1.Requests")]
 ```
 
 The source entity is read as metadata from the referenced assembly and needs no attribute of its own. All `[GenerateDtos]` options apply, including flags-combined `OutputType`, the `Partial` modifier, and FAC101/FAC102 validation. Declare one `[assembly: GenerateDtosFor(...)]` per entity; interface/concrete sibling pairing links outputs **per source entity** — two entities registered in the same assembly never cross-pair.
 
-This also composes with source generators' single-compilation rule: because generation happens in the declaring (downstream) project, the domain assembly stays dependency-free of contract concerns.
+### What moving the declaration downstream changes
+
+- **The dependency arrow points the right way.** The contracts project references the domain, and the domain knows nothing about contracts: no `[GenerateDtos]` attributes on entity classes, no downstream namespace strings in domain files. If no other Facet attributes remain there, the domain project can drop the generator reference entirely — generation then runs in the (typically much smaller) contracts compilation instead of your largest project.
+- **Types land in the assembly that owns their namespace.** Anything that discovers types by *assembly* — OpenAPI generators, TypeScript exporters, reflection-based registration, `InternalsVisibleTo` — sees the generated DTOs exactly where hand-written ones would have been. Replacing a hand-written contract with a generated one becomes a true drop-in: same assembly, same namespace, same name.
+- **Each layer declares its own shapes.** Several downstream assemblies can independently register DTOs for the same entity (a web project's request bodies, an application layer's command payloads) without the entity accumulating one attribute per consumer.
+
+### Partial halves gain the downstream dependency graph
+
+This is the quiet superpower of combining `GenerateDtosFor` with the `Partial` modifier. A `partial` type must be completed within a single assembly, so a hand-written half is forced into whichever assembly the generated half lives in. With the class-level attribute that means the **entity's** assembly — which, in a layered application, cannot reference your `DbContext`, repositories, or service interfaces (the persistence layer references the domain, never the reverse). Members that need those types simply cannot be written there.
+
+Declared downstream, the generated half compiles into the contracts project — and the hand-written half beside it can use everything that project references:
+
+```csharp
+// MyApp.Contracts — same assembly as the generated partial half
+public partial record UpdateScheduleRequest : IValidatableObject
+{
+    // Hydration against the real database — impossible in the domain assembly,
+    // which cannot reference AppDbContext:
+    public async Task<Schedule> ApplyAsync(AppDbContext db, CancellationToken ct)
+    {
+        var schedule = await db.Schedules.FirstAsync(s => s.Id == Id, ct);
+        // ... map members onto the tracked entity ...
+        return schedule;
+    }
+
+    // Framework-specific validation, using types the domain shouldn't know:
+    public IEnumerable<ValidationResult> Validate(ValidationContext context)
+    {
+        if (StartAt >= EndAt)
+            yield return new ValidationResult("Start must precede end.", [nameof(StartAt)]);
+    }
+}
+```
+
+Extension methods in a downstream layer were always possible; what same-assembly partials add is members **on the type itself** — instance methods and async factories that take a `DbContext` or services as parameters, computed properties over downstream types, interface implementations (`IValidatableObject` and friends, which extension methods can never provide), and attributes applied to the type through the partial half.
 
 ## Excluding Audit Fields
 

--- a/docs/09_GenerateDtosAttribute.md
+++ b/docs/09_GenerateDtosAttribute.md
@@ -309,6 +309,22 @@ Pick `OutputType.PartialClass` when:
 
 If you don't need extensibility, prefer `OutputType.Class` — it also emits `Projection`, `ToSource`, and `BackTo` for full round-tripping.
 
+## Assembly-level generation: `[GenerateDtosFor]`
+
+`[GenerateDtos]` sits on the entity, so the DTOs compile into the entity's assembly. When your architecture wants contract types **downstream** of the domain — a web-contracts project referencing the domain, with the domain kept free of generated request/response types — use the assembly-level counterpart in the project where the DTOs should live:
+
+```csharp
+// In the contracts project (references the domain project):
+[assembly: GenerateDtosFor(typeof(Schedule),
+    Types = DtoTypes.Create | DtoTypes.Update,
+    OutputType = OutputType.Interface | OutputType.Record | OutputType.Partial,
+    Namespace = "My.Contracts.V1.Requests")]
+```
+
+The source entity is read as metadata from the referenced assembly and needs no attribute of its own. All `[GenerateDtos]` options apply, including flags-combined `OutputType`, the `Partial` modifier, and FAC101/FAC102 validation. Declare one `[assembly: GenerateDtosFor(...)]` per entity; interface/concrete sibling pairing links outputs **per source entity** — two entities registered in the same assembly never cross-pair.
+
+This also composes with source generators' single-compilation rule: because generation happens in the declaring (downstream) project, the domain assembly stays dependency-free of contract concerns.
+
 ## Excluding Audit Fields
 
 Use the `ExcludeAuditFields` property to automatically exclude common audit/tracking fields from the generated DTOs.

--- a/src/Facet.Attributes/GenerateDtosAttribute.cs
+++ b/src/Facet.Attributes/GenerateDtosAttribute.cs
@@ -155,6 +155,32 @@ public class GenerateDtosAttribute : Attribute
 }
 
 /// <summary>
+/// Assembly-level counterpart of <see cref="GenerateDtosAttribute"/>: generates DTOs for
+/// <see cref="SourceType"/> into the assembly that DECLARES this attribute rather than the
+/// assembly that declares the entity. Place it in the project where the DTOs should live
+/// (e.g. a web-contracts layer referencing the domain), keeping the domain assembly free of
+/// generated contract types:
+/// <code>
+/// [assembly: GenerateDtosFor(typeof(Schedule),
+///     Types = DtoTypes.Create | DtoTypes.Update,
+///     OutputType = OutputType.Interface | OutputType.Record | OutputType.Partial)]
+/// </code>
+/// All options of <see cref="GenerateDtosAttribute"/> apply. Interface/concrete sibling
+/// pairing links outputs for the same <see cref="SourceType"/> only.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public sealed class GenerateDtosForAttribute : GenerateDtosAttribute
+{
+    /// <summary>The entity type (typically from a referenced assembly) to generate DTOs for.</summary>
+    public Type SourceType { get; }
+
+    public GenerateDtosForAttribute(Type sourceType)
+    {
+        SourceType = sourceType;
+    }
+}
+
+/// <summary>
 /// Obsolete. Use <see cref="GenerateDtosAttribute"/> with <c>ExcludeAuditFields = true</c> instead.
 /// </summary>
 /// <remarks>

--- a/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
@@ -18,6 +18,8 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
     
     private const string GenerateAuditableDtosAttributeName = "Facet.GenerateAuditableDtosAttribute";
 
+    private const string GenerateDtosForAttributeName = "Facet.GenerateDtosForAttribute";
+
     private static readonly DiagnosticDescriptor GeneratorErrorRule = new DiagnosticDescriptor(
         "FAC100",
         "GenerateDtos generator encountered an error",
@@ -74,9 +76,18 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             .Where(static m => m is not null)
             .SelectMany(static (models, _) => models!);
 
+        var generateDtosForTargets = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                GenerateDtosForAttributeName,
+                predicate: static (node, _) => node is CompilationUnitSyntax,
+                transform: static (ctx, token) => GetGenerateDtosForModels(ctx, token))
+            .Where(static m => m is not null)
+            .SelectMany(static (models, _) => models!);
+
         var allTargets = generateDtosTargets.Collect()
             .Combine(generateAuditableDtosTargets.Collect())
-            .Select(static (combined, _) => combined.Left.Concat(combined.Right));
+            .Combine(generateDtosForTargets.Collect())
+            .Select(static (combined, _) => combined.Left.Left.Concat(combined.Left.Right).Concat(combined.Right));
 
         context.RegisterSourceOutput(allTargets, (spc, models) =>
         {
@@ -118,15 +129,47 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
     {
         token.ThrowIfCancellationRequested();
         if (context.TargetSymbol is not INamedTypeSymbol sourceSymbol) return null;
-        if (context.Attributes.Length == 0) return null;
+
+        return BuildModels(context.Attributes, _ => sourceSymbol, forceExcludeAuditFields, token);
+    }
+
+    /// <summary>
+    /// Assembly-level entry point: <c>[assembly: GenerateDtosFor(typeof(Entity), ...)]</c>
+    /// generates into the DECLARING assembly, with the source entity resolved from the
+    /// attribute's constructor argument — typically a type from a referenced assembly, so
+    /// contract DTOs can live downstream of the domain project.
+    /// </summary>
+    private static IEnumerable<GenerateDtosTargetModel>? GetGenerateDtosForModels(GeneratorAttributeSyntaxContext context, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        if (context.TargetSymbol is not IAssemblySymbol) return null;
+
+        return BuildModels(
+            context.Attributes,
+            static attr => attr.ConstructorArguments.Length == 1
+                ? attr.ConstructorArguments[0].Value as INamedTypeSymbol
+                : null,
+            forceExcludeAuditFields: false,
+            token);
+    }
+
+    private static IEnumerable<GenerateDtosTargetModel>? BuildModels(
+        ImmutableArray<AttributeData> attributes,
+        Func<AttributeData, INamedTypeSymbol?> sourceSelector,
+        bool forceExcludeAuditFields,
+        CancellationToken token)
+    {
+        if (attributes.Length == 0) return null;
 
         var models = new List<GenerateDtosTargetModel>();
 
-        foreach (var attribute in context.Attributes)
+        foreach (var attribute in attributes)
         {
             token.ThrowIfCancellationRequested();
 
-            var model = GetDtosModel(context, attribute, sourceSymbol, forceExcludeAuditFields, token);
+            if (sourceSelector(attribute) is not INamedTypeSymbol sourceSymbol) continue;
+
+            var model = GetDtosModel(attribute, sourceSymbol, forceExcludeAuditFields, token);
             if (model == null) continue;
 
             // OutputType is a [Flags] value: kind bits (Class/Record/Struct/RecordStruct/
@@ -183,6 +226,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
             DtoTypes siblingMask = DtoTypes.None;
             foreach (var iface in interfaceModels)
             {
+                if (iface.SourceTypeName != model.SourceTypeName) continue;
                 if (iface.Prefix != model.Prefix) continue;
                 if (iface.Suffix != model.Suffix) continue;
                 if (iface.TargetNamespace != model.TargetNamespace) continue;
@@ -213,7 +257,7 @@ public sealed class GenerateDtosGenerator : IIncrementalGenerator
         return models;
     }
 
-    private static GenerateDtosTargetModel? GetDtosModel(GeneratorAttributeSyntaxContext context, AttributeData attribute, INamedTypeSymbol sourceSymbol, bool forceExcludeAuditFields, CancellationToken token)
+    private static GenerateDtosTargetModel? GetDtosModel(AttributeData attribute, INamedTypeSymbol sourceSymbol, bool forceExcludeAuditFields, CancellationToken token)
     {
         token.ThrowIfCancellationRequested();
 

--- a/test/Facet.Tests.ExternalLib/ExternalSource.cs
+++ b/test/Facet.Tests.ExternalLib/ExternalSource.cs
@@ -20,3 +20,16 @@ public class ExternalSource
     /// </summary>
     public string Description { get; set; } = string.Empty;
 }
+
+/// <summary>
+/// Entity deliberately WITHOUT any [GenerateDtos] attribute: DTOs for it are generated
+/// cross-assembly by [assembly: GenerateDtosFor(typeof(ExternalDomainEntity), ...)] in
+/// Facet.Tests — proving contract generation can live downstream of the domain project.
+/// </summary>
+public class ExternalDomainEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/test/Facet.Tests/TestModels/AssemblyLevelDtoRegistrations.cs
+++ b/test/Facet.Tests/TestModels/AssemblyLevelDtoRegistrations.cs
@@ -1,0 +1,40 @@
+using Facet;
+using Facet.Tests.ExternalLib;
+using Facet.Tests.TestModels;
+
+// Assembly-level DTO generation: the DTOs compile into THIS assembly (Facet.Tests),
+// while the source entities live wherever they naturally belong — including a
+// different, referenced assembly (ExternalDomainEntity in Facet.Tests.ExternalLib).
+
+// True cross-assembly generation: entity in ExternalLib, DTOs generated here.
+[assembly: GenerateDtosFor(typeof(ExternalDomainEntity),
+    Types = DtoTypes.Create | DtoTypes.Update,
+    OutputType = OutputType.Interface | OutputType.Record,
+    Namespace = "Facet.Tests.AssemblyGenerated")]
+
+// Two GenerateDtosFor attributes for DIFFERENT entities in one assembly: sibling
+// interface pairing must link each concrete output to its OWN entity's interface,
+// never across entities.
+[assembly: GenerateDtosFor(typeof(TestAssemblyPairFirstEntity),
+    Types = DtoTypes.Update,
+    OutputType = OutputType.Interface | OutputType.PartialClass,
+    Namespace = "Facet.Tests.AssemblyGenerated")]
+[assembly: GenerateDtosFor(typeof(TestAssemblyPairSecondEntity),
+    Types = DtoTypes.Update,
+    OutputType = OutputType.Interface | OutputType.Record,
+    Namespace = "Facet.Tests.AssemblyGenerated")]
+
+namespace Facet.Tests.TestModels
+{
+    public class TestAssemblyPairFirstEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class TestAssemblyPairSecondEntity
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+    }
+}

--- a/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosForAssemblyTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosForAssemblyTests.cs
@@ -1,0 +1,74 @@
+using Facet.Tests.ExternalLib;
+using System.Reflection;
+
+namespace Facet.Tests.UnitTests.Core.GenerateDtos;
+
+/// <summary>
+/// Tests for assembly-level generation via <c>[assembly: GenerateDtosFor(typeof(...), ...)]</c>
+/// (declared in TestModels/AssemblyLevelDtoRegistrations.cs): DTOs compile into the
+/// DECLARING assembly, sourced from entities that may live in referenced assemblies.
+/// </summary>
+public class GenerateDtosForAssemblyTests
+{
+    private static readonly Assembly TestAssembly = typeof(GenerateDtosForAssemblyTests).Assembly;
+
+    [Fact]
+    public void CrossAssemblyEntity_GeneratesDtosInDeclaringAssembly()
+    {
+        // The entity lives in Facet.Tests.ExternalLib and carries no attribute at all;
+        // the DTOs must exist HERE, in the assembly declaring GenerateDtosFor.
+        typeof(ExternalDomainEntity).Assembly.Should().NotBeSameAs(TestAssembly,
+            "the point of the test is cross-assembly generation");
+
+        var createRecord = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.CreateExternalDomainEntityRequest");
+        var updateRecord = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.UpdateExternalDomainEntityRequest");
+        var createInterface = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.ICreateExternalDomainEntityRequest");
+
+        createRecord.Should().NotBeNull("Create DTO should be generated into the declaring assembly");
+        updateRecord.Should().NotBeNull();
+        createInterface.Should().NotBeNull();
+        createRecord!.GetMethod("<Clone>$").Should().NotBeNull("OutputType.Record should emit a record");
+        createInterface!.IsAssignableFrom(createRecord).Should().BeTrue(
+            "the record should implement its sibling interface");
+
+        createRecord.GetProperty("Id").Should().BeNull("Create DTOs exclude Id");
+        updateRecord!.GetProperty("Id").Should().NotBeNull();
+        updateRecord.GetProperty("Name").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CrossAssemblyDto_SourceCopyConstructorAndToSource_Work()
+    {
+        var updateRecord = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.UpdateExternalDomainEntityRequest")!;
+
+        var entity = new ExternalDomainEntity { Id = 7, Name = "ext", Description = "d", IsActive = true };
+        var dto = Activator.CreateInstance(updateRecord, entity)!;
+
+        updateRecord.GetProperty("Name")!.GetValue(dto).Should().Be("ext");
+
+        var back = (ExternalDomainEntity)updateRecord.GetMethod("ToSource")!.Invoke(dto, null)!;
+        back.Name.Should().Be("ext");
+        back.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MultipleEntitiesInOneAssembly_PairOnlyWithTheirOwnInterface()
+    {
+        var firstInterface = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.IUpdateTestAssemblyPairFirstEntityRequest");
+        var firstConcrete = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.UpdateTestAssemblyPairFirstEntityRequest");
+        var secondInterface = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.IUpdateTestAssemblyPairSecondEntityRequest");
+        var secondConcrete = TestAssembly.GetType("Facet.Tests.AssemblyGenerated.UpdateTestAssemblyPairSecondEntityRequest");
+
+        firstInterface.Should().NotBeNull();
+        firstConcrete.Should().NotBeNull();
+        secondInterface.Should().NotBeNull();
+        secondConcrete.Should().NotBeNull();
+
+        firstInterface!.IsAssignableFrom(firstConcrete!).Should().BeTrue();
+        secondInterface!.IsAssignableFrom(secondConcrete!).Should().BeTrue();
+
+        firstInterface.IsAssignableFrom(secondConcrete).Should().BeFalse(
+            "pairing must never cross-link outputs of different source entities");
+        secondInterface.IsAssignableFrom(firstConcrete).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Follow-up to #396. `[GenerateDtos]` sits on the entity class, which means the generated DTOs always compile into the entity's assembly — fine for co-located contracts, but most layered solutions want the Request/Response types **in the Web project, next to the controllers that bind them** — where a Request can hydrate itself from the `DbContext` and a Response can be enriched with in-memory state that was never persisted. That arrangement had no one-attribute option; the fallback was per-DTO `[Facet]` stub classes.

## Solution

The assembly-level counterpart, declared **in the project where the DTOs should live**:

```csharp
// In the contracts project (references the domain):
[assembly: GenerateDtosFor(typeof(Schedule),
    Types = DtoTypes.Create | DtoTypes.Update,
    OutputType = OutputType.Interface | OutputType.Record | OutputType.Partial,
    Namespace = "My.Contracts.V1.Requests")]
```

The source entity is resolved from the constructor argument as metadata from the referenced assembly — it needs no attribute of its own. `GenerateDtosForAttribute` derives from `GenerateDtosAttribute`, so every option applies unchanged: flags-combined `OutputType`, the `Partial` modifier, exclusions, and FAC101/FAC102 validation.

Beyond layering hygiene, declaring downstream has a concrete payoff for the `Partial` modifier: partial types must be completed **within one assembly**, so with the class-level attribute the hand-written half is stranded in the entity's assembly, where a `DbContext` or application services can't be referenced (persistence references domain, never the reverse). Declared here, the hand-written half lives beside the generated one in the contracts project and can put hydration methods (`ApplyAsync(AppDbContext db, …)`), service-taking factories, `IValidatableObject` implementations, and framework attributes **on the DTO type itself** — things extension methods can never provide. The docs section now covers this with a worked example, plus the drop-in property: generated types land in the assembly that owns their namespace, so assembly-scanning tooling (OpenAPI, TypeScript exporters, reflection registration) sees them exactly where hand-written contracts used to be.

## Implementation

- The class-target and assembly-target pipelines share one model builder (`BuildModels` with a source-selector); `GetDtosModel` needed no `GeneratorAttributeSyntaxContext`, so it now takes only what it uses.
- `ForAttributeWithMetadataName` matches the `CompilationUnitSyntax` carrying `[assembly: ...]` with `IAssemblySymbol` as the target — no custom syntax walking.
- One correctness fix that falls out: sibling interface pairing now also matches on the **source type**. A class-level context only ever holds one source, but an assembly can register many — without the check, entity A's record could have paired with entity B's interface given matching prefix/suffix/namespace.

## Tests

3 new facts, including a **true cross-assembly case**: an attribute-free entity in `Facet.Tests.ExternalLib` whose Interface + Record pair generates into `Facet.Tests`, with the record implementing its sibling interface and `ToSource` round-tripping; plus pairing-isolation coverage proving two entities registered in one assembly never cross-link. Full suite: 911/911.

Note: independent of #397 content-wise, but both touch `Initialize`/`GetDtosModel` — whichever lands second I'll rebase (trivial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
