### PR TITLE
ci: skip preview publishing on fork and dependabot PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,15 @@ defaults:
 jobs:
   publish-preview:
     runs-on: ubuntu-latest
+    # Fork PRs (and dependabot PRs, which use a separate restricted secret store)
+    # run without repository secrets or a writable token, so NuGet login fails on
+    # the empty NUGET_USER and the PR comment couldn't be posted either. Skip the
+    # job instead of failing it — external contributions otherwise always show a
+    # red X they cannot fix. Build/test coverage for those PRs comes from the
+    # build and test workflows, which need no secrets.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Every PR opened from a fork currently gets a guaranteed red X from the **Publish Preview** workflow: fork PRs run without repository secrets or a writable token, so `NuGet/login@v1` fails immediately on the empty `NUGET_USER` input —

```
##[error]Input required and not supplied: user
```

(example: [this run](https://github.com/Tim-Maes/Facet/actions/runs/29021381835) on #399) — and even if login succeeded, the `id-token: write` / `pull-requests: write` permissions and the PR-comment step aren't available to a fork PR's read-only token. Dependabot PRs fail the same way through their separate restricted secret store (their runs show the identical error).

## Fix

One job-level `if:` guard that skips the job — instead of failing it — when the PR head repo isn't this repo, or when the actor is dependabot:

```yaml
if: >-
  github.event.pull_request.head.repo.full_name == github.repository &&
  github.actor != 'dependabot[bot]'
```

A skipped job shows as neutral, so external contributions get true green when build + test pass (those workflows need no secrets and already cover fork PRs). Same-repo PRs keep publishing preview packages exactly as today.

If you ever want previews for a trusted fork PR, the usual pattern is a maintainer-applied label + `pull_request_target` — but that has real security trade-offs and doesn't seem worth it here; skipping is the safe default.

Once this lands on master, existing fork PRs (#397, #399, #400) pick the guard up automatically on their next push/rebase, since `pull_request` workflows run from the merge commit with the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
