### PR TITLE
feat: add AdditionalAttributes to GenerateDtosFor attribute

### DIFF
--- a/src/Facet.Attributes/GenerateDtosAttribute.cs
+++ b/src/Facet.Attributes/GenerateDtosAttribute.cs
@@ -251,11 +251,12 @@ public class GenerateDtosAttribute : Attribute
     public DtoPreset Preset { get; set; } = DtoPreset.None;
 
     /// <summary>
-    /// When set, emits a <c>[TsInterface(Name = "...")]</c> attribute on the generated
-    /// DTO class for Reinforced.Typings. This controls the TypeScript interface name
-    /// without requiring a hand-written attribute in the partial class.
+    /// Raw attribute strings to emit on each generated DTO class/record/struct (not interfaces).
+    /// Each string is written verbatim before the type declaration, e.g.
+    /// <c>AdditionalAttributes = new[] { "[TsInterface(Name = \"IUserDto\")]" }</c>.
+    /// This avoids coupling Facet to any specific downstream code generator.
     /// </summary>
-    public string? TsInterfaceName { get; set; }
+    public string[] AdditionalAttributes { get; set; } = Array.Empty<string>();
 }
 
 /// <summary>
@@ -366,4 +367,11 @@ public class GenerateAuditableDtosAttribute : Attribute
     /// to avoid collisions. Default is false (shorter file names).
     /// </summary>
     public bool UseFullName { get; set; } = false;
+
+    /// <summary>
+    /// Raw attribute strings to emit on each generated DTO class/record/struct (not interfaces).
+    /// Each string is written verbatim before the type declaration, e.g.
+    /// <c>AdditionalAttributes = new[] { "[TsInterface(Name = \"IUserDto\")]" }</c>.
+    /// </summary>
+    public string[] AdditionalAttributes { get; set; } = Array.Empty<string>();
 }

--- a/src/Facet/GenerateDtosTargetModel.cs
+++ b/src/Facet/GenerateDtosTargetModel.cs
@@ -31,8 +31,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
     public bool GenerateProjections { get; }
     public bool GenerateReadOnlyProperties { get; }
     public string? PropertySuffix { get; }
-    public string? TsInterfaceName { get; }
     public string? ConvertEnumsTo { get; }
+    public ImmutableArray<string> AdditionalAttributes { get; }
     public ImmutableArray<string> ExcludeProperties { get; }
     public ImmutableArray<FacetMember> Members { get; }
     public bool UseFullName { get; }
@@ -107,8 +107,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
         bool generateProjections,
         bool generateReadOnlyProperties,
         string? propertySuffix,
-        string? tsInterfaceName,
         string? convertEnumsTo,
+        ImmutableArray<string> additionalAttributes,
         ImmutableArray<string> excludeProperties,
         ImmutableArray<FacetMember> members,
         bool useFullName,
@@ -133,8 +133,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
         GenerateProjections = generateProjections;
         GenerateReadOnlyProperties = generateReadOnlyProperties;
         PropertySuffix = propertySuffix;
-        TsInterfaceName = tsInterfaceName;
         ConvertEnumsTo = convertEnumsTo;
+        AdditionalAttributes = additionalAttributes;
         ExcludeProperties = excludeProperties;
         Members = members;
         UseFullName = useFullName;
@@ -167,8 +167,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             GenerateProjections,
             GenerateReadOnlyProperties,
             PropertySuffix,
-            TsInterfaceName,
             ConvertEnumsTo,
+            AdditionalAttributes,
             ExcludeProperties,
             Members,
             UseFullName,
@@ -202,8 +202,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             GenerateProjections,
             GenerateReadOnlyProperties,
             PropertySuffix,
-            TsInterfaceName,
             ConvertEnumsTo,
+            AdditionalAttributes,
             ExcludeProperties,
             members,
             UseFullName,
@@ -236,8 +236,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             GenerateProjections,
             GenerateReadOnlyProperties,
             PropertySuffix,
-            TsInterfaceName,
             ConvertEnumsTo,
+            AdditionalAttributes,
             ExcludeProperties,
             Members,
             UseFullName,
@@ -268,8 +268,8 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             && GenerateProjections == other.GenerateProjections
             && GenerateReadOnlyProperties == other.GenerateReadOnlyProperties
             && PropertySuffix == other.PropertySuffix
-    && TsInterfaceName == other.TsInterfaceName
             && ConvertEnumsTo == other.ConvertEnumsTo
+            && AdditionalAttributes.SequenceEqual(other.AdditionalAttributes)
             && ExcludeProperties.SequenceEqual(other.ExcludeProperties)
             && Members.SequenceEqual(other.Members)
             && UseFullName == other.UseFullName
@@ -302,8 +302,9 @@ internal sealed class GenerateDtosTargetModel : IEquatable<GenerateDtosTargetMod
             hash = hash * 31 + GenerateProjections.GetHashCode();
             hash = hash * 31 + GenerateReadOnlyProperties.GetHashCode();
             hash = hash * 31 + (PropertySuffix?.GetHashCode() ?? 0);
-    hash = hash * 31 + (TsInterfaceName?.GetHashCode() ?? 0);
             hash = hash * 31 + (ConvertEnumsTo?.GetHashCode() ?? 0);
+            foreach (var attr in AdditionalAttributes)
+                hash = hash * 31 + (attr?.GetHashCode() ?? 0);
             hash = hash * 31 + UseFullName.GetHashCode();
             hash = hash * 31 + ExcludeNavigationProperties.GetHashCode();
             hash = hash * 31 + SiblingInterfaceTypes.GetHashCode();

--- a/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
+++ b/src/Facet/Generators/FacetGenerators/GenerateDtosGenerator.cs
@@ -400,8 +400,8 @@ public sealed class GenerateDtosGenerator : IncrementalGenerator
                 model.GenerateProjections,
                 model.GenerateReadOnlyProperties,
                 model.PropertySuffix,
-                model.TsInterfaceName,
                 model.ConvertEnumsTo,
+                model.AdditionalAttributes,
                 model.ExcludeProperties,
                 model.Members,
                 model.UseFullName,
@@ -434,10 +434,18 @@ public sealed class GenerateDtosGenerator : IncrementalGenerator
             var generateProjections = GetNamedArg(attribute.NamedArguments, "GenerateProjections", true);
             var generateReadOnlyProperties = GetNamedArg(attribute.NamedArguments, "GenerateReadOnlyProperties", false);
             var propertySuffix = GetNamedArg<string?>(attribute.NamedArguments, "PropertySuffix", null);
-            var tsInterfaceName = GetNamedArg<string?>(attribute.NamedArguments, "TsInterfaceName", null);
             var useFullName = GetNamedArg(attribute.NamedArguments, "UseFullName", false);
             var convertEnumsTo = ExtractConvertEnumsTo(attribute.NamedArguments);
             var preset = GetNamedArg(attribute.NamedArguments, "Preset", DtoPreset.None);
+            var additionalAttributes = ImmutableArray<string>.Empty;
+            var additionalAttrsArg = attribute.NamedArguments.FirstOrDefault(kvp => kvp.Key == "AdditionalAttributes");
+            if (additionalAttrsArg.Value.Kind == TypedConstantKind.Array && !additionalAttrsArg.Value.IsNull)
+            {
+                additionalAttributes = additionalAttrsArg.Value.Values
+                    .Select(v => v.Value?.ToString() ?? string.Empty)
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToImmutableArray();
+            }
             var excludeAuditFields = forceExcludeAuditFields || GetNamedArg(attribute.NamedArguments, "ExcludeAuditFields", false);
 
             // Track which properties were explicitly set so presets don't override them.
@@ -638,8 +646,8 @@ public sealed class GenerateDtosGenerator : IncrementalGenerator
                 generateProjections,
                 generateReadOnlyProperties,
                 propertySuffix,
-                tsInterfaceName,
                 convertEnumsTo,
+                additionalAttributes,
                 excludeProperties.ToImmutableArray(),
                 members.ToImmutableArray(),
                 useFullName,
@@ -884,10 +892,14 @@ public sealed class GenerateDtosGenerator : IncrementalGenerator
         sb.AppendLine($"/// Generated {purpose} DTO contract for {sourceTypeName}.");
         sb.AppendLine($"/// </summary>");
 
-        // Emit [TsInterface] attribute for Reinforced.Typings when TsInterfaceName is set.
-        if (!string.IsNullOrEmpty(model.TsInterfaceName) && GetKind(model.OutputType) != OutputType.Interface)
+        // Emit user-supplied additional attributes verbatim (not on interfaces).
+        if (GetKind(model.OutputType) != OutputType.Interface)
         {
-            sb.AppendLine($"[Reinforced.Typings.Attributes.TsInterface(Name = \"{model.TsInterfaceName}\")]");
+            foreach (var attr in model.AdditionalAttributes)
+            {
+                if (!string.IsNullOrWhiteSpace(attr))
+                    sb.AppendLine(attr);
+            }
         }
 
         if (GetKind(model.OutputType) != OutputType.Interface)

--- a/test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs
+++ b/test/Facet.Tests/TestModels/GenerateDtosTestEntities.cs
@@ -250,3 +250,40 @@ public partial interface IUpdateModTestPartialStructInterfaceEntityRequest
 // manifest AdditionalFile for this test project — such an entity would be a FAC105 error).
 // Its behavior is covered by the driver-based GenerateDtosManifestNavigationTests /
 // GenerateDtosManifestDiagnosticsTests, which supply an in-memory manifest.
+
+// ── AdditionalAttributes ─────────────────────────────────────────────────────
+
+[GenerateDtos(Types = DtoTypes.Response, OutputType = OutputType.Class,
+    AdditionalAttributes = new[] { "[System.Serializable]" })]
+public class TestAdditionalAttributesEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// Multiple attributes should all be emitted verbatim.
+[GenerateDtos(Types = DtoTypes.Response, OutputType = OutputType.Record,
+    AdditionalAttributes = new[] { "[System.Serializable]", "[System.ComponentModel.DefaultProperty(\"Name\")]" })]
+public class TestAdditionalAttributesMultiEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// AdditionalAttributes should NOT be emitted on Interface outputs.
+[GenerateDtos(Types = DtoTypes.Response, OutputType = OutputType.Interface | OutputType.Class,
+    AdditionalAttributes = new[] { "[System.Serializable]" })]
+public class TestAdditionalAttributesInterfaceEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// Empty AdditionalAttributes should produce no attributes (no crash).
+[GenerateDtos(Types = DtoTypes.Response, OutputType = OutputType.Class,
+    AdditionalAttributes = new string[0])]
+public class TestAdditionalAttributesEmptyEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosAdditionalAttributesTests.cs
+++ b/test/Facet.Tests/UnitTests/Core/GenerateDtos/GenerateDtosAdditionalAttributesTests.cs
@@ -1,0 +1,90 @@
+using Facet.Tests.TestModels;
+using System.Reflection;
+
+namespace Facet.Tests.UnitTests.Core.GenerateDtos;
+
+/// <summary>
+/// Tests for the AdditionalAttributes property on [GenerateDtos].
+/// Verifies that raw attribute strings are emitted verbatim on generated
+/// DTO classes/records but not on interfaces.
+/// </summary>
+public class GenerateDtosAdditionalAttributesTests
+{
+    private static readonly Assembly TestAssembly = Assembly.GetAssembly(typeof(TestAdditionalAttributesEntity))!;
+
+    [Fact]
+    public void AdditionalAttributes_EmitsAttributeOnGeneratedClass()
+    {
+        var dto = TestAssembly.GetType("Facet.Tests.TestModels.TestAdditionalAttributesEntityResponse");
+
+        dto.Should().NotBeNull();
+        dto!.IsClass.Should().BeTrue();
+
+        var attr = dto.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "System.SerializableAttribute");
+
+        attr.Should().NotBeNull("AdditionalAttributes should emit the Serializable attribute verbatim");
+    }
+
+    [Fact]
+    public void AdditionalAttributes_EmitsMultipleAttributesOnGeneratedRecord()
+    {
+        var dto = TestAssembly.GetType("Facet.Tests.TestModels.TestAdditionalAttributesMultiEntityResponse");
+
+        dto.Should().NotBeNull();
+        dto!.IsClass.Should().BeTrue("records are reference types");
+
+        var attrs = dto.GetCustomAttributesData();
+        attrs.Should().Contain(a => a.AttributeType.FullName == "System.SerializableAttribute",
+            "the Serializable attribute should be emitted verbatim");
+        attrs.Should().Contain(a => a.AttributeType.FullName == "System.ComponentModel.DefaultPropertyAttribute",
+            "the DefaultProperty attribute should be emitted verbatim");
+    }
+
+    [Fact]
+    public void AdditionalAttributes_DoesNotEmitOnInterfaceOutput()
+    {
+        var iface = TestAssembly.GetType("Facet.Tests.TestModels.ITestAdditionalAttributesInterfaceEntityResponse");
+        var cls = TestAssembly.GetType("Facet.Tests.TestModels.TestAdditionalAttributesInterfaceEntityResponse");
+
+        iface.Should().NotBeNull("Interface | Class should produce both outputs");
+        cls.Should().NotBeNull();
+
+        // Interface should NOT have the Serializable attribute
+        var ifaceAttr = iface!.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "System.SerializableAttribute");
+        ifaceAttr.Should().BeNull("AdditionalAttributes should not be emitted on interface outputs");
+
+        // Class SHOULD have the Serializable attribute
+        var classAttr = cls!.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "System.SerializableAttribute");
+        classAttr.Should().NotBeNull("AdditionalAttributes should be emitted on class outputs even when paired with an interface");
+    }
+
+    [Fact]
+    public void AdditionalAttributes_EmptyArray_ProducesNoExtraAttributes()
+    {
+        var dto = TestAssembly.GetType("Facet.Tests.TestModels.TestAdditionalAttributesEmptyEntityResponse");
+
+        dto.Should().NotBeNull();
+        dto!.IsClass.Should().BeTrue();
+
+        // Should still have the [Facet] attribute but no Serializable attribute
+        var attr = dto.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "System.SerializableAttribute");
+        attr.Should().BeNull("empty AdditionalAttributes should not emit any extra attributes");
+    }
+
+    [Fact]
+    public void AdditionalAttributes_PreservesFacetAttribute()
+    {
+        var dto = TestAssembly.GetType("Facet.Tests.TestModels.TestAdditionalAttributesEntityResponse");
+
+        dto.Should().NotBeNull();
+
+        var facetAttr = dto!.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName?.StartsWith("Facet.FacetAttribute") == true
+                              || a.AttributeType.Name == "FacetAttribute");
+        facetAttr.Should().NotBeNull("the [Facet] attribute should still be emitted alongside AdditionalAttributes");
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `AdditionalAttributes` property to `GenerateDtosAttribute` and `GenerateDtosForAttribute`. When set, the generator emits each string verbatim as an attribute on the generated DTO class/record/struct (not interfaces).

## Usage

```csharp
[GenerateDtosFor(typeof(Order), AdditionalAttributes = new[] { "[TsInterface(Name = \"IOrderDto\")]" })]
```

## Why not TsInterfaceName?

The original `TsInterfaceName` property (merged in #408) hardcoded `[Reinforced.Typings.Attributes.TsInterface(...)]` in the source generator, coupling Facet to one obscure package. `AdditionalAttributes` is fully generic — the generator has zero knowledge of any specific downstream tool.

## Tests

5 tests covering single attribute on class, multiple attributes on record, suppression on interface outputs, empty array, and `[Facet]` preservation.

🤖 Generated with [Copilot](https://github.com/features/copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>